### PR TITLE
fix compile error

### DIFF
--- a/apiwallet/src/lib.rs
+++ b/apiwallet/src/lib.rs
@@ -34,5 +34,5 @@ extern crate failure_derive;
 extern crate log;
 
 pub mod api;
-pub use api::{APIForeign, APIOwner};
+pub use crate::api::{APIForeign, APIOwner};
 


### PR DESCRIPTION
```
error[E0658]: imports can only refer to extern crate names passed with `--extern` on stable channel (see issue #53130)   
  --> apiwallet/src/lib.rs:37:9                                                                                          
   |                                                                                                                     
36 | pub mod api;                                                                                                        
   | ------------ not an extern crate passed with `--extern`                                                             
37 | pub use api::{APIForeign, APIOwner};                                                                                
   |         ^^^                                                                                                         
   |                                                                                                                     
note: this import refers to the module defined here                                                                      
  --> apiwallet/src/lib.rs:36:1                                                                                          
   |                                                                                                                     
36 | pub mod api;                                                                                                        
   | ^^^^^^^^^^^^                                                                                                        
                                                                                                                         
error: aborting due to previous error                                                                                    
                                                                                                                         
For more information about this error, try `rustc --explain E0658`.                                                      
error: Could not compile `grin_apiwallet`.   
```