### PR TITLE
api v2

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -400,10 +400,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
 name = "easy-jsonrpc"
-version = "0.2.0"
+version = "0.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "easy-jsonrpc-proc-macro 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "easy-jsonrpc-proc-macro 0.4.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "jsonrpc-core 10.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "rand 0.6.5 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde 1.0.89 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -412,7 +412,7 @@ dependencies = [
 
 [[package]]
 name = "easy-jsonrpc-proc-macro"
-version = "0.2.0"
+version = "0.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "heck 0.3.1 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -586,7 +586,7 @@ dependencies = [
 name = "grin_apiwallet"
 version = "1.1.0"
 dependencies = [
- "easy-jsonrpc 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "easy-jsonrpc 0.4.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "failure 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)",
  "failure_derive 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)",
  "grin_api 1.1.0 (git+https://github.com/bddap/grin?branch=milestone/1.1.0)",
@@ -2695,8 +2695,8 @@ dependencies = [
 "checksum digest 0.7.6 (registry+https://github.com/rust-lang/crates.io-index)" = "03b072242a8cbaf9c145665af9d250c59af3b958f83ed6824e13533cf76d5b90"
 "checksum dirs 1.0.5 (registry+https://github.com/rust-lang/crates.io-index)" = "3fd78930633bd1c6e35c4b42b1df7b0cbc6bc191146e512bb3bedf243fcc3901"
 "checksum dtoa 0.4.3 (registry+https://github.com/rust-lang/crates.io-index)" = "6d301140eb411af13d3115f9a562c85cc6b541ade9dfa314132244aaee7489dd"
-"checksum easy-jsonrpc 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)" = "4e0cb740db04464d020c02930fc080c057480b611bb4a96871caaab1615b7e42"
-"checksum easy-jsonrpc-proc-macro 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)" = "ff88c7d11b38c5ada21b07e95d468bcdd4f0bb9f771d93463b1a7afd797e5c97"
+"checksum easy-jsonrpc 0.4.1 (registry+https://github.com/rust-lang/crates.io-index)" = "2f0d8eaadf5a9ed73697761ad586140c40aa0837fb5b141a2b04ee9c07eacbfe"
+"checksum easy-jsonrpc-proc-macro 0.4.1 (registry+https://github.com/rust-lang/crates.io-index)" = "b50f53cc7025979b06da8fde906f948f0fa4665bf840043f4de1e25acee53c97"
 "checksum encode_unicode 0.3.5 (registry+https://github.com/rust-lang/crates.io-index)" = "90b2c9496c001e8cb61827acdefad780795c42264c137744cae6f7d9e3450abd"
 "checksum enum_primitive 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)" = "be4551092f4d519593039259a9ed8daedf0da12e5109c5280338073eaeb81180"
 "checksum env_logger 0.5.13 (registry+https://github.com/rust-lang/crates.io-index)" = "15b0a4d2e39f8420210be8b27eeda28029729e2fd4291019455016c348240c38"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -553,17 +553,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 [[package]]
 name = "grin_api"
 version = "1.1.0"
-source = "git+https://github.com/bddap/grin?branch=milestone/1.1.0#020fd778ea2fa45d351c566151b10e6f95da1f08"
+source = "git+https://github.com/mimblewimble/grin?branch=milestone/1.1.0#1b3eaba3025f92770ba468de9e77ebd1e4a660cd"
 dependencies = [
  "failure 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)",
  "failure_derive 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)",
  "futures 0.1.25 (registry+https://github.com/rust-lang/crates.io-index)",
- "grin_chain 1.1.0 (git+https://github.com/bddap/grin?branch=milestone/1.1.0)",
- "grin_core 1.1.0 (git+https://github.com/bddap/grin?branch=milestone/1.1.0)",
- "grin_p2p 1.1.0 (git+https://github.com/bddap/grin?branch=milestone/1.1.0)",
- "grin_pool 1.1.0 (git+https://github.com/bddap/grin?branch=milestone/1.1.0)",
- "grin_store 1.1.0 (git+https://github.com/bddap/grin?branch=milestone/1.1.0)",
- "grin_util 1.1.0 (git+https://github.com/bddap/grin?branch=milestone/1.1.0)",
+ "grin_chain 1.1.0 (git+https://github.com/mimblewimble/grin?branch=milestone/1.1.0)",
+ "grin_core 1.1.0 (git+https://github.com/mimblewimble/grin?branch=milestone/1.1.0)",
+ "grin_p2p 1.1.0 (git+https://github.com/mimblewimble/grin?branch=milestone/1.1.0)",
+ "grin_pool 1.1.0 (git+https://github.com/mimblewimble/grin?branch=milestone/1.1.0)",
+ "grin_store 1.1.0 (git+https://github.com/mimblewimble/grin?branch=milestone/1.1.0)",
+ "grin_util 1.1.0 (git+https://github.com/mimblewimble/grin?branch=milestone/1.1.0)",
  "http 0.1.16 (registry+https://github.com/rust-lang/crates.io-index)",
  "hyper 0.12.19 (registry+https://github.com/rust-lang/crates.io-index)",
  "hyper-rustls 0.14.0 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -589,14 +589,14 @@ dependencies = [
  "easy-jsonrpc 0.4.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "failure 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)",
  "failure_derive 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)",
- "grin_api 1.1.0 (git+https://github.com/bddap/grin?branch=milestone/1.1.0)",
- "grin_chain 1.1.0 (git+https://github.com/bddap/grin?branch=milestone/1.1.0)",
- "grin_core 1.1.0 (git+https://github.com/bddap/grin?branch=milestone/1.1.0)",
- "grin_keychain 1.1.0 (git+https://github.com/bddap/grin?branch=milestone/1.1.0)",
+ "grin_api 1.1.0 (git+https://github.com/mimblewimble/grin?branch=milestone/1.1.0)",
+ "grin_chain 1.1.0 (git+https://github.com/mimblewimble/grin?branch=milestone/1.1.0)",
+ "grin_core 1.1.0 (git+https://github.com/mimblewimble/grin?branch=milestone/1.1.0)",
+ "grin_keychain 1.1.0 (git+https://github.com/mimblewimble/grin?branch=milestone/1.1.0)",
  "grin_libwallet 1.1.0",
  "grin_refwallet 1.1.0",
- "grin_store 1.1.0 (git+https://github.com/bddap/grin?branch=milestone/1.1.0)",
- "grin_util 1.1.0 (git+https://github.com/bddap/grin?branch=milestone/1.1.0)",
+ "grin_store 1.1.0 (git+https://github.com/mimblewimble/grin?branch=milestone/1.1.0)",
+ "grin_util 1.1.0 (git+https://github.com/mimblewimble/grin?branch=milestone/1.1.0)",
  "grin_wallet_config 1.1.0",
  "log 0.4.6 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde_json 1.0.39 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -607,7 +607,7 @@ dependencies = [
 [[package]]
 name = "grin_chain"
 version = "1.1.0"
-source = "git+https://github.com/bddap/grin?branch=milestone/1.1.0#020fd778ea2fa45d351c566151b10e6f95da1f08"
+source = "git+https://github.com/mimblewimble/grin?branch=milestone/1.1.0#1b3eaba3025f92770ba468de9e77ebd1e4a660cd"
 dependencies = [
  "bitflags 1.0.4 (registry+https://github.com/rust-lang/crates.io-index)",
  "byteorder 1.3.1 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -615,10 +615,10 @@ dependencies = [
  "croaring 0.3.8 (registry+https://github.com/rust-lang/crates.io-index)",
  "failure 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)",
  "failure_derive 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)",
- "grin_core 1.1.0 (git+https://github.com/bddap/grin?branch=milestone/1.1.0)",
- "grin_keychain 1.1.0 (git+https://github.com/bddap/grin?branch=milestone/1.1.0)",
- "grin_store 1.1.0 (git+https://github.com/bddap/grin?branch=milestone/1.1.0)",
- "grin_util 1.1.0 (git+https://github.com/bddap/grin?branch=milestone/1.1.0)",
+ "grin_core 1.1.0 (git+https://github.com/mimblewimble/grin?branch=milestone/1.1.0)",
+ "grin_keychain 1.1.0 (git+https://github.com/mimblewimble/grin?branch=milestone/1.1.0)",
+ "grin_store 1.1.0 (git+https://github.com/mimblewimble/grin?branch=milestone/1.1.0)",
+ "grin_util 1.1.0 (git+https://github.com/mimblewimble/grin?branch=milestone/1.1.0)",
  "lazy_static 1.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "log 0.4.6 (registry+https://github.com/rust-lang/crates.io-index)",
  "lru-cache 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -630,7 +630,7 @@ dependencies = [
 [[package]]
 name = "grin_core"
 version = "1.1.0"
-source = "git+https://github.com/bddap/grin?branch=milestone/1.1.0#020fd778ea2fa45d351c566151b10e6f95da1f08"
+source = "git+https://github.com/mimblewimble/grin?branch=milestone/1.1.0#1b3eaba3025f92770ba468de9e77ebd1e4a660cd"
 dependencies = [
  "blake2-rfc 0.2.18 (registry+https://github.com/rust-lang/crates.io-index)",
  "byteorder 1.3.1 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -639,8 +639,8 @@ dependencies = [
  "enum_primitive 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "failure 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)",
  "failure_derive 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)",
- "grin_keychain 1.1.0 (git+https://github.com/bddap/grin?branch=milestone/1.1.0)",
- "grin_util 1.1.0 (git+https://github.com/bddap/grin?branch=milestone/1.1.0)",
+ "grin_keychain 1.1.0 (git+https://github.com/mimblewimble/grin?branch=milestone/1.1.0)",
+ "grin_util 1.1.0 (git+https://github.com/mimblewimble/grin?branch=milestone/1.1.0)",
  "lazy_static 1.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "log 0.4.6 (registry+https://github.com/rust-lang/crates.io-index)",
  "lru-cache 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -656,12 +656,12 @@ dependencies = [
 [[package]]
 name = "grin_keychain"
 version = "1.1.0"
-source = "git+https://github.com/bddap/grin?branch=milestone/1.1.0#020fd778ea2fa45d351c566151b10e6f95da1f08"
+source = "git+https://github.com/mimblewimble/grin?branch=milestone/1.1.0#1b3eaba3025f92770ba468de9e77ebd1e4a660cd"
 dependencies = [
  "blake2-rfc 0.2.18 (registry+https://github.com/rust-lang/crates.io-index)",
  "byteorder 1.3.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "digest 0.7.6 (registry+https://github.com/rust-lang/crates.io-index)",
- "grin_util 1.1.0 (git+https://github.com/bddap/grin?branch=milestone/1.1.0)",
+ "grin_util 1.1.0 (git+https://github.com/mimblewimble/grin?branch=milestone/1.1.0)",
  "hmac 0.6.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "lazy_static 1.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "log 0.4.6 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -683,10 +683,10 @@ dependencies = [
  "chrono 0.4.6 (registry+https://github.com/rust-lang/crates.io-index)",
  "failure 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)",
  "failure_derive 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)",
- "grin_core 1.1.0 (git+https://github.com/bddap/grin?branch=milestone/1.1.0)",
- "grin_keychain 1.1.0 (git+https://github.com/bddap/grin?branch=milestone/1.1.0)",
- "grin_store 1.1.0 (git+https://github.com/bddap/grin?branch=milestone/1.1.0)",
- "grin_util 1.1.0 (git+https://github.com/bddap/grin?branch=milestone/1.1.0)",
+ "grin_core 1.1.0 (git+https://github.com/mimblewimble/grin?branch=milestone/1.1.0)",
+ "grin_keychain 1.1.0 (git+https://github.com/mimblewimble/grin?branch=milestone/1.1.0)",
+ "grin_store 1.1.0 (git+https://github.com/mimblewimble/grin?branch=milestone/1.1.0)",
+ "grin_util 1.1.0 (git+https://github.com/mimblewimble/grin?branch=milestone/1.1.0)",
  "grin_wallet_config 1.1.0",
  "log 0.4.6 (registry+https://github.com/rust-lang/crates.io-index)",
  "rand 0.5.6 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -699,15 +699,15 @@ dependencies = [
 [[package]]
 name = "grin_p2p"
 version = "1.1.0"
-source = "git+https://github.com/bddap/grin?branch=milestone/1.1.0#020fd778ea2fa45d351c566151b10e6f95da1f08"
+source = "git+https://github.com/mimblewimble/grin?branch=milestone/1.1.0#1b3eaba3025f92770ba468de9e77ebd1e4a660cd"
 dependencies = [
  "bitflags 1.0.4 (registry+https://github.com/rust-lang/crates.io-index)",
  "bytes 0.4.12 (registry+https://github.com/rust-lang/crates.io-index)",
  "chrono 0.4.6 (registry+https://github.com/rust-lang/crates.io-index)",
  "enum_primitive 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "grin_core 1.1.0 (git+https://github.com/bddap/grin?branch=milestone/1.1.0)",
- "grin_store 1.1.0 (git+https://github.com/bddap/grin?branch=milestone/1.1.0)",
- "grin_util 1.1.0 (git+https://github.com/bddap/grin?branch=milestone/1.1.0)",
+ "grin_core 1.1.0 (git+https://github.com/mimblewimble/grin?branch=milestone/1.1.0)",
+ "grin_store 1.1.0 (git+https://github.com/mimblewimble/grin?branch=milestone/1.1.0)",
+ "grin_util 1.1.0 (git+https://github.com/mimblewimble/grin?branch=milestone/1.1.0)",
  "log 0.4.6 (registry+https://github.com/rust-lang/crates.io-index)",
  "net2 0.2.33 (registry+https://github.com/rust-lang/crates.io-index)",
  "num 0.1.42 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -719,16 +719,16 @@ dependencies = [
 [[package]]
 name = "grin_pool"
 version = "1.1.0"
-source = "git+https://github.com/bddap/grin?branch=milestone/1.1.0#020fd778ea2fa45d351c566151b10e6f95da1f08"
+source = "git+https://github.com/mimblewimble/grin?branch=milestone/1.1.0#1b3eaba3025f92770ba468de9e77ebd1e4a660cd"
 dependencies = [
  "blake2-rfc 0.2.18 (registry+https://github.com/rust-lang/crates.io-index)",
  "chrono 0.4.6 (registry+https://github.com/rust-lang/crates.io-index)",
  "failure 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)",
  "failure_derive 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)",
- "grin_core 1.1.0 (git+https://github.com/bddap/grin?branch=milestone/1.1.0)",
- "grin_keychain 1.1.0 (git+https://github.com/bddap/grin?branch=milestone/1.1.0)",
- "grin_store 1.1.0 (git+https://github.com/bddap/grin?branch=milestone/1.1.0)",
- "grin_util 1.1.0 (git+https://github.com/bddap/grin?branch=milestone/1.1.0)",
+ "grin_core 1.1.0 (git+https://github.com/mimblewimble/grin?branch=milestone/1.1.0)",
+ "grin_keychain 1.1.0 (git+https://github.com/mimblewimble/grin?branch=milestone/1.1.0)",
+ "grin_store 1.1.0 (git+https://github.com/mimblewimble/grin?branch=milestone/1.1.0)",
+ "grin_util 1.1.0 (git+https://github.com/mimblewimble/grin?branch=milestone/1.1.0)",
  "log 0.4.6 (registry+https://github.com/rust-lang/crates.io-index)",
  "rand 0.5.6 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde 1.0.89 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -744,14 +744,14 @@ dependencies = [
  "failure 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)",
  "failure_derive 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)",
  "futures 0.1.25 (registry+https://github.com/rust-lang/crates.io-index)",
- "grin_api 1.1.0 (git+https://github.com/bddap/grin?branch=milestone/1.1.0)",
+ "grin_api 1.1.0 (git+https://github.com/mimblewimble/grin?branch=milestone/1.1.0)",
  "grin_apiwallet 1.1.0",
- "grin_chain 1.1.0 (git+https://github.com/bddap/grin?branch=milestone/1.1.0)",
- "grin_core 1.1.0 (git+https://github.com/bddap/grin?branch=milestone/1.1.0)",
- "grin_keychain 1.1.0 (git+https://github.com/bddap/grin?branch=milestone/1.1.0)",
+ "grin_chain 1.1.0 (git+https://github.com/mimblewimble/grin?branch=milestone/1.1.0)",
+ "grin_core 1.1.0 (git+https://github.com/mimblewimble/grin?branch=milestone/1.1.0)",
+ "grin_keychain 1.1.0 (git+https://github.com/mimblewimble/grin?branch=milestone/1.1.0)",
  "grin_libwallet 1.1.0",
- "grin_store 1.1.0 (git+https://github.com/bddap/grin?branch=milestone/1.1.0)",
- "grin_util 1.1.0 (git+https://github.com/bddap/grin?branch=milestone/1.1.0)",
+ "grin_store 1.1.0 (git+https://github.com/mimblewimble/grin?branch=milestone/1.1.0)",
+ "grin_util 1.1.0 (git+https://github.com/mimblewimble/grin?branch=milestone/1.1.0)",
  "grin_wallet_config 1.1.0",
  "hyper 0.12.19 (registry+https://github.com/rust-lang/crates.io-index)",
  "log 0.4.6 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -786,15 +786,15 @@ dependencies = [
 [[package]]
 name = "grin_store"
 version = "1.1.0"
-source = "git+https://github.com/bddap/grin?branch=milestone/1.1.0#020fd778ea2fa45d351c566151b10e6f95da1f08"
+source = "git+https://github.com/mimblewimble/grin?branch=milestone/1.1.0#1b3eaba3025f92770ba468de9e77ebd1e4a660cd"
 dependencies = [
  "byteorder 1.3.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "croaring 0.3.8 (registry+https://github.com/rust-lang/crates.io-index)",
  "env_logger 0.5.13 (registry+https://github.com/rust-lang/crates.io-index)",
  "failure 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)",
  "failure_derive 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)",
- "grin_core 1.1.0 (git+https://github.com/bddap/grin?branch=milestone/1.1.0)",
- "grin_util 1.1.0 (git+https://github.com/bddap/grin?branch=milestone/1.1.0)",
+ "grin_core 1.1.0 (git+https://github.com/mimblewimble/grin?branch=milestone/1.1.0)",
+ "grin_util 1.1.0 (git+https://github.com/mimblewimble/grin?branch=milestone/1.1.0)",
  "libc 0.2.50 (registry+https://github.com/rust-lang/crates.io-index)",
  "lmdb-zero 0.4.4 (registry+https://github.com/rust-lang/crates.io-index)",
  "log 0.4.6 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -806,7 +806,7 @@ dependencies = [
 [[package]]
 name = "grin_util"
 version = "1.1.0"
-source = "git+https://github.com/bddap/grin?branch=milestone/1.1.0#020fd778ea2fa45d351c566151b10e6f95da1f08"
+source = "git+https://github.com/mimblewimble/grin?branch=milestone/1.1.0#1b3eaba3025f92770ba468de9e77ebd1e4a660cd"
 dependencies = [
  "backtrace 0.3.14 (registry+https://github.com/rust-lang/crates.io-index)",
  "base64 0.9.3 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -833,15 +833,15 @@ dependencies = [
  "ctrlc 3.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "failure 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)",
  "failure_derive 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)",
- "grin_api 1.1.0 (git+https://github.com/bddap/grin?branch=milestone/1.1.0)",
+ "grin_api 1.1.0 (git+https://github.com/mimblewimble/grin?branch=milestone/1.1.0)",
  "grin_apiwallet 1.1.0",
- "grin_chain 1.1.0 (git+https://github.com/bddap/grin?branch=milestone/1.1.0)",
- "grin_core 1.1.0 (git+https://github.com/bddap/grin?branch=milestone/1.1.0)",
- "grin_keychain 1.1.0 (git+https://github.com/bddap/grin?branch=milestone/1.1.0)",
+ "grin_chain 1.1.0 (git+https://github.com/mimblewimble/grin?branch=milestone/1.1.0)",
+ "grin_core 1.1.0 (git+https://github.com/mimblewimble/grin?branch=milestone/1.1.0)",
+ "grin_keychain 1.1.0 (git+https://github.com/mimblewimble/grin?branch=milestone/1.1.0)",
  "grin_libwallet 1.1.0",
  "grin_refwallet 1.1.0",
- "grin_store 1.1.0 (git+https://github.com/bddap/grin?branch=milestone/1.1.0)",
- "grin_util 1.1.0 (git+https://github.com/bddap/grin?branch=milestone/1.1.0)",
+ "grin_store 1.1.0 (git+https://github.com/mimblewimble/grin?branch=milestone/1.1.0)",
+ "grin_util 1.1.0 (git+https://github.com/mimblewimble/grin?branch=milestone/1.1.0)",
  "grin_wallet_config 1.1.0",
  "linefeed 0.5.4 (registry+https://github.com/rust-lang/crates.io-index)",
  "log 0.4.6 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -854,8 +854,8 @@ name = "grin_wallet_config"
 version = "1.1.0"
 dependencies = [
  "dirs 1.0.5 (registry+https://github.com/rust-lang/crates.io-index)",
- "grin_core 1.1.0 (git+https://github.com/bddap/grin?branch=milestone/1.1.0)",
- "grin_util 1.1.0 (git+https://github.com/bddap/grin?branch=milestone/1.1.0)",
+ "grin_core 1.1.0 (git+https://github.com/mimblewimble/grin?branch=milestone/1.1.0)",
+ "grin_util 1.1.0 (git+https://github.com/mimblewimble/grin?branch=milestone/1.1.0)",
  "pretty_assertions 0.5.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "rand 0.5.6 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde 1.0.89 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -2714,15 +2714,15 @@ dependencies = [
 "checksum generic-array 0.9.0 (registry+https://github.com/rust-lang/crates.io-index)" = "ef25c5683767570c2bbd7deba372926a55eaae9982d7726ee2a1050239d45b9d"
 "checksum git2 0.7.5 (registry+https://github.com/rust-lang/crates.io-index)" = "591f8be1674b421644b6c030969520bc3fa12114d2eb467471982ed3e9584e71"
 "checksum glob 0.2.11 (registry+https://github.com/rust-lang/crates.io-index)" = "8be18de09a56b60ed0edf84bc9df007e30040691af7acd1c41874faac5895bfb"
-"checksum grin_api 1.1.0 (git+https://github.com/bddap/grin?branch=milestone/1.1.0)" = "<none>"
-"checksum grin_chain 1.1.0 (git+https://github.com/bddap/grin?branch=milestone/1.1.0)" = "<none>"
-"checksum grin_core 1.1.0 (git+https://github.com/bddap/grin?branch=milestone/1.1.0)" = "<none>"
-"checksum grin_keychain 1.1.0 (git+https://github.com/bddap/grin?branch=milestone/1.1.0)" = "<none>"
-"checksum grin_p2p 1.1.0 (git+https://github.com/bddap/grin?branch=milestone/1.1.0)" = "<none>"
-"checksum grin_pool 1.1.0 (git+https://github.com/bddap/grin?branch=milestone/1.1.0)" = "<none>"
+"checksum grin_api 1.1.0 (git+https://github.com/mimblewimble/grin?branch=milestone/1.1.0)" = "<none>"
+"checksum grin_chain 1.1.0 (git+https://github.com/mimblewimble/grin?branch=milestone/1.1.0)" = "<none>"
+"checksum grin_core 1.1.0 (git+https://github.com/mimblewimble/grin?branch=milestone/1.1.0)" = "<none>"
+"checksum grin_keychain 1.1.0 (git+https://github.com/mimblewimble/grin?branch=milestone/1.1.0)" = "<none>"
+"checksum grin_p2p 1.1.0 (git+https://github.com/mimblewimble/grin?branch=milestone/1.1.0)" = "<none>"
+"checksum grin_pool 1.1.0 (git+https://github.com/mimblewimble/grin?branch=milestone/1.1.0)" = "<none>"
 "checksum grin_secp256k1zkp 0.7.5 (registry+https://github.com/rust-lang/crates.io-index)" = "75e9a265f3eeea4c204470f7262e2c6fe18f3d8ddf5fb24340cb550ac4f909c5"
-"checksum grin_store 1.1.0 (git+https://github.com/bddap/grin?branch=milestone/1.1.0)" = "<none>"
-"checksum grin_util 1.1.0 (git+https://github.com/bddap/grin?branch=milestone/1.1.0)" = "<none>"
+"checksum grin_store 1.1.0 (git+https://github.com/mimblewimble/grin?branch=milestone/1.1.0)" = "<none>"
+"checksum grin_util 1.1.0 (git+https://github.com/mimblewimble/grin?branch=milestone/1.1.0)" = "<none>"
 "checksum h2 0.1.16 (registry+https://github.com/rust-lang/crates.io-index)" = "ddb2b25a33e231484694267af28fec74ac63b5ccf51ee2065a5e313b834d836e"
 "checksum heck 0.3.1 (registry+https://github.com/rust-lang/crates.io-index)" = "20564e78d53d2bb135c343b3f47714a56af2061f1c928fdb541dc7b9fdd94205"
 "checksum hmac 0.6.3 (registry+https://github.com/rust-lang/crates.io-index)" = "733e1b3ac906631ca01ebb577e9bb0f5e37a454032b9036b5eaea4013ed6f99a"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -415,6 +415,27 @@ version = "0.4.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
+name = "easy-jsonrpc"
+version = "0.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "easy-jsonrpc-proc-macro 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "jsonrpc-core 10.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "serde 1.0.88 (registry+https://github.com/rust-lang/crates.io-index)",
+ "serde_json 1.0.38 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "easy-jsonrpc-proc-macro"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "proc-macro2 0.4.27 (registry+https://github.com/rust-lang/crates.io-index)",
+ "quote 0.6.11 (registry+https://github.com/rust-lang/crates.io-index)",
+ "syn 0.15.26 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
 name = "encode_unicode"
 version = "0.3.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -546,17 +567,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 [[package]]
 name = "grin_api"
 version = "1.1.0"
-source = "git+https://github.com/mimblewimble/grin?branch=milestone/1.1.0#a080284563e0bbb1153b51636b3cc77f4ff989db"
+source = "git+https://github.com/bddap/grin?branch=milestone/1.1.0#d25f84532a23e3be52e8202224c36f391be3575d"
 dependencies = [
  "failure 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)",
  "failure_derive 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)",
  "futures 0.1.25 (registry+https://github.com/rust-lang/crates.io-index)",
- "grin_chain 1.1.0 (git+https://github.com/mimblewimble/grin?branch=milestone/1.1.0)",
- "grin_core 1.1.0 (git+https://github.com/mimblewimble/grin?branch=milestone/1.1.0)",
- "grin_p2p 1.1.0 (git+https://github.com/mimblewimble/grin?branch=milestone/1.1.0)",
- "grin_pool 1.1.0 (git+https://github.com/mimblewimble/grin?branch=milestone/1.1.0)",
- "grin_store 1.1.0 (git+https://github.com/mimblewimble/grin?branch=milestone/1.1.0)",
- "grin_util 1.1.0 (git+https://github.com/mimblewimble/grin?branch=milestone/1.1.0)",
+ "grin_chain 1.1.0 (git+https://github.com/bddap/grin?branch=milestone/1.1.0)",
+ "grin_core 1.1.0 (git+https://github.com/bddap/grin?branch=milestone/1.1.0)",
+ "grin_p2p 1.1.0 (git+https://github.com/bddap/grin?branch=milestone/1.1.0)",
+ "grin_pool 1.1.0 (git+https://github.com/bddap/grin?branch=milestone/1.1.0)",
+ "grin_store 1.1.0 (git+https://github.com/bddap/grin?branch=milestone/1.1.0)",
+ "grin_util 1.1.0 (git+https://github.com/bddap/grin?branch=milestone/1.1.0)",
  "http 0.1.16 (registry+https://github.com/rust-lang/crates.io-index)",
  "hyper 0.12.19 (registry+https://github.com/rust-lang/crates.io-index)",
  "hyper-rustls 0.14.0 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -579,24 +600,27 @@ dependencies = [
 name = "grin_apiwallet"
 version = "1.1.0"
 dependencies = [
+ "easy-jsonrpc 0.1.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "failure 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)",
  "failure_derive 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)",
- "grin_api 1.1.0 (git+https://github.com/mimblewimble/grin?branch=milestone/1.1.0)",
- "grin_chain 1.1.0 (git+https://github.com/mimblewimble/grin?branch=milestone/1.1.0)",
- "grin_core 1.1.0 (git+https://github.com/mimblewimble/grin?branch=milestone/1.1.0)",
- "grin_keychain 1.1.0 (git+https://github.com/mimblewimble/grin?branch=milestone/1.1.0)",
+ "grin_api 1.1.0 (git+https://github.com/bddap/grin?branch=milestone/1.1.0)",
+ "grin_chain 1.1.0 (git+https://github.com/bddap/grin?branch=milestone/1.1.0)",
+ "grin_core 1.1.0 (git+https://github.com/bddap/grin?branch=milestone/1.1.0)",
+ "grin_keychain 1.1.0 (git+https://github.com/bddap/grin?branch=milestone/1.1.0)",
  "grin_libwallet 1.1.0",
- "grin_store 1.1.0 (git+https://github.com/mimblewimble/grin?branch=milestone/1.1.0)",
- "grin_util 1.1.0 (git+https://github.com/mimblewimble/grin?branch=milestone/1.1.0)",
+ "grin_refwallet 1.1.0",
+ "grin_store 1.1.0 (git+https://github.com/bddap/grin?branch=milestone/1.1.0)",
+ "grin_util 1.1.0 (git+https://github.com/bddap/grin?branch=milestone/1.1.0)",
  "grin_wallet_config 1.1.0",
  "log 0.4.6 (registry+https://github.com/rust-lang/crates.io-index)",
+ "serde_json 1.0.38 (registry+https://github.com/rust-lang/crates.io-index)",
  "uuid 0.6.5 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
 name = "grin_chain"
 version = "1.1.0"
-source = "git+https://github.com/mimblewimble/grin?branch=milestone/1.1.0#a080284563e0bbb1153b51636b3cc77f4ff989db"
+source = "git+https://github.com/bddap/grin?branch=milestone/1.1.0#d25f84532a23e3be52e8202224c36f391be3575d"
 dependencies = [
  "bitflags 1.0.4 (registry+https://github.com/rust-lang/crates.io-index)",
  "byteorder 1.3.1 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -604,10 +628,10 @@ dependencies = [
  "croaring 0.3.8 (registry+https://github.com/rust-lang/crates.io-index)",
  "failure 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)",
  "failure_derive 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)",
- "grin_core 1.1.0 (git+https://github.com/mimblewimble/grin?branch=milestone/1.1.0)",
- "grin_keychain 1.1.0 (git+https://github.com/mimblewimble/grin?branch=milestone/1.1.0)",
- "grin_store 1.1.0 (git+https://github.com/mimblewimble/grin?branch=milestone/1.1.0)",
- "grin_util 1.1.0 (git+https://github.com/mimblewimble/grin?branch=milestone/1.1.0)",
+ "grin_core 1.1.0 (git+https://github.com/bddap/grin?branch=milestone/1.1.0)",
+ "grin_keychain 1.1.0 (git+https://github.com/bddap/grin?branch=milestone/1.1.0)",
+ "grin_store 1.1.0 (git+https://github.com/bddap/grin?branch=milestone/1.1.0)",
+ "grin_util 1.1.0 (git+https://github.com/bddap/grin?branch=milestone/1.1.0)",
  "lazy_static 1.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "log 0.4.6 (registry+https://github.com/rust-lang/crates.io-index)",
  "lru-cache 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -619,7 +643,7 @@ dependencies = [
 [[package]]
 name = "grin_core"
 version = "1.1.0"
-source = "git+https://github.com/mimblewimble/grin?branch=milestone/1.1.0#a080284563e0bbb1153b51636b3cc77f4ff989db"
+source = "git+https://github.com/bddap/grin?branch=milestone/1.1.0#d25f84532a23e3be52e8202224c36f391be3575d"
 dependencies = [
  "blake2-rfc 0.2.18 (registry+https://github.com/rust-lang/crates.io-index)",
  "byteorder 1.3.1 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -628,8 +652,8 @@ dependencies = [
  "enum_primitive 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "failure 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)",
  "failure_derive 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)",
- "grin_keychain 1.1.0 (git+https://github.com/mimblewimble/grin?branch=milestone/1.1.0)",
- "grin_util 1.1.0 (git+https://github.com/mimblewimble/grin?branch=milestone/1.1.0)",
+ "grin_keychain 1.1.0 (git+https://github.com/bddap/grin?branch=milestone/1.1.0)",
+ "grin_util 1.1.0 (git+https://github.com/bddap/grin?branch=milestone/1.1.0)",
  "lazy_static 1.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "log 0.4.6 (registry+https://github.com/rust-lang/crates.io-index)",
  "lru-cache 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -645,12 +669,12 @@ dependencies = [
 [[package]]
 name = "grin_keychain"
 version = "1.1.0"
-source = "git+https://github.com/mimblewimble/grin?branch=milestone/1.1.0#a080284563e0bbb1153b51636b3cc77f4ff989db"
+source = "git+https://github.com/bddap/grin?branch=milestone/1.1.0#d25f84532a23e3be52e8202224c36f391be3575d"
 dependencies = [
  "blake2-rfc 0.2.18 (registry+https://github.com/rust-lang/crates.io-index)",
  "byteorder 1.3.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "digest 0.7.6 (registry+https://github.com/rust-lang/crates.io-index)",
- "grin_util 1.1.0 (git+https://github.com/mimblewimble/grin?branch=milestone/1.1.0)",
+ "grin_util 1.1.0 (git+https://github.com/bddap/grin?branch=milestone/1.1.0)",
  "hmac 0.6.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "lazy_static 1.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "log 0.4.6 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -672,10 +696,10 @@ dependencies = [
  "chrono 0.4.6 (registry+https://github.com/rust-lang/crates.io-index)",
  "failure 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)",
  "failure_derive 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)",
- "grin_core 1.1.0 (git+https://github.com/mimblewimble/grin?branch=milestone/1.1.0)",
- "grin_keychain 1.1.0 (git+https://github.com/mimblewimble/grin?branch=milestone/1.1.0)",
- "grin_store 1.1.0 (git+https://github.com/mimblewimble/grin?branch=milestone/1.1.0)",
- "grin_util 1.1.0 (git+https://github.com/mimblewimble/grin?branch=milestone/1.1.0)",
+ "grin_core 1.1.0 (git+https://github.com/bddap/grin?branch=milestone/1.1.0)",
+ "grin_keychain 1.1.0 (git+https://github.com/bddap/grin?branch=milestone/1.1.0)",
+ "grin_store 1.1.0 (git+https://github.com/bddap/grin?branch=milestone/1.1.0)",
+ "grin_util 1.1.0 (git+https://github.com/bddap/grin?branch=milestone/1.1.0)",
  "grin_wallet_config 1.1.0",
  "log 0.4.6 (registry+https://github.com/rust-lang/crates.io-index)",
  "rand 0.5.6 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -688,15 +712,15 @@ dependencies = [
 [[package]]
 name = "grin_p2p"
 version = "1.1.0"
-source = "git+https://github.com/mimblewimble/grin?branch=milestone/1.1.0#a080284563e0bbb1153b51636b3cc77f4ff989db"
+source = "git+https://github.com/bddap/grin?branch=milestone/1.1.0#d25f84532a23e3be52e8202224c36f391be3575d"
 dependencies = [
  "bitflags 1.0.4 (registry+https://github.com/rust-lang/crates.io-index)",
  "bytes 0.4.11 (registry+https://github.com/rust-lang/crates.io-index)",
  "chrono 0.4.6 (registry+https://github.com/rust-lang/crates.io-index)",
  "enum_primitive 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "grin_core 1.1.0 (git+https://github.com/mimblewimble/grin?branch=milestone/1.1.0)",
- "grin_store 1.1.0 (git+https://github.com/mimblewimble/grin?branch=milestone/1.1.0)",
- "grin_util 1.1.0 (git+https://github.com/mimblewimble/grin?branch=milestone/1.1.0)",
+ "grin_core 1.1.0 (git+https://github.com/bddap/grin?branch=milestone/1.1.0)",
+ "grin_store 1.1.0 (git+https://github.com/bddap/grin?branch=milestone/1.1.0)",
+ "grin_util 1.1.0 (git+https://github.com/bddap/grin?branch=milestone/1.1.0)",
  "log 0.4.6 (registry+https://github.com/rust-lang/crates.io-index)",
  "net2 0.2.33 (registry+https://github.com/rust-lang/crates.io-index)",
  "num 0.1.42 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -708,16 +732,16 @@ dependencies = [
 [[package]]
 name = "grin_pool"
 version = "1.1.0"
-source = "git+https://github.com/mimblewimble/grin?branch=milestone/1.1.0#a080284563e0bbb1153b51636b3cc77f4ff989db"
+source = "git+https://github.com/bddap/grin?branch=milestone/1.1.0#d25f84532a23e3be52e8202224c36f391be3575d"
 dependencies = [
  "blake2-rfc 0.2.18 (registry+https://github.com/rust-lang/crates.io-index)",
  "chrono 0.4.6 (registry+https://github.com/rust-lang/crates.io-index)",
  "failure 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)",
  "failure_derive 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)",
- "grin_core 1.1.0 (git+https://github.com/mimblewimble/grin?branch=milestone/1.1.0)",
- "grin_keychain 1.1.0 (git+https://github.com/mimblewimble/grin?branch=milestone/1.1.0)",
- "grin_store 1.1.0 (git+https://github.com/mimblewimble/grin?branch=milestone/1.1.0)",
- "grin_util 1.1.0 (git+https://github.com/mimblewimble/grin?branch=milestone/1.1.0)",
+ "grin_core 1.1.0 (git+https://github.com/bddap/grin?branch=milestone/1.1.0)",
+ "grin_keychain 1.1.0 (git+https://github.com/bddap/grin?branch=milestone/1.1.0)",
+ "grin_store 1.1.0 (git+https://github.com/bddap/grin?branch=milestone/1.1.0)",
+ "grin_util 1.1.0 (git+https://github.com/bddap/grin?branch=milestone/1.1.0)",
  "log 0.4.6 (registry+https://github.com/rust-lang/crates.io-index)",
  "rand 0.5.6 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde 1.0.88 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -733,14 +757,14 @@ dependencies = [
  "failure 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)",
  "failure_derive 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)",
  "futures 0.1.25 (registry+https://github.com/rust-lang/crates.io-index)",
- "grin_api 1.1.0 (git+https://github.com/mimblewimble/grin?branch=milestone/1.1.0)",
+ "grin_api 1.1.0 (git+https://github.com/bddap/grin?branch=milestone/1.1.0)",
  "grin_apiwallet 1.1.0",
- "grin_chain 1.1.0 (git+https://github.com/mimblewimble/grin?branch=milestone/1.1.0)",
- "grin_core 1.1.0 (git+https://github.com/mimblewimble/grin?branch=milestone/1.1.0)",
- "grin_keychain 1.1.0 (git+https://github.com/mimblewimble/grin?branch=milestone/1.1.0)",
+ "grin_chain 1.1.0 (git+https://github.com/bddap/grin?branch=milestone/1.1.0)",
+ "grin_core 1.1.0 (git+https://github.com/bddap/grin?branch=milestone/1.1.0)",
+ "grin_keychain 1.1.0 (git+https://github.com/bddap/grin?branch=milestone/1.1.0)",
  "grin_libwallet 1.1.0",
- "grin_store 1.1.0 (git+https://github.com/mimblewimble/grin?branch=milestone/1.1.0)",
- "grin_util 1.1.0 (git+https://github.com/mimblewimble/grin?branch=milestone/1.1.0)",
+ "grin_store 1.1.0 (git+https://github.com/bddap/grin?branch=milestone/1.1.0)",
+ "grin_util 1.1.0 (git+https://github.com/bddap/grin?branch=milestone/1.1.0)",
  "grin_wallet_config 1.1.0",
  "hyper 0.12.19 (registry+https://github.com/rust-lang/crates.io-index)",
  "log 0.4.6 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -761,7 +785,7 @@ dependencies = [
 [[package]]
 name = "grin_secp256k1zkp"
 version = "0.7.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
+source = "git+https://github.com/mimblewimble/rust-secp256k1-zkp?rev=a7a523da4fe72ddda6c13034be99b04d19854d3f#a7a523da4fe72ddda6c13034be99b04d19854d3f"
 dependencies = [
  "arrayvec 0.3.25 (registry+https://github.com/rust-lang/crates.io-index)",
  "gcc 0.3.55 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -775,15 +799,15 @@ dependencies = [
 [[package]]
 name = "grin_store"
 version = "1.1.0"
-source = "git+https://github.com/mimblewimble/grin?branch=milestone/1.1.0#a080284563e0bbb1153b51636b3cc77f4ff989db"
+source = "git+https://github.com/bddap/grin?branch=milestone/1.1.0#d25f84532a23e3be52e8202224c36f391be3575d"
 dependencies = [
  "byteorder 1.3.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "croaring 0.3.8 (registry+https://github.com/rust-lang/crates.io-index)",
  "env_logger 0.5.13 (registry+https://github.com/rust-lang/crates.io-index)",
  "failure 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)",
  "failure_derive 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)",
- "grin_core 1.1.0 (git+https://github.com/mimblewimble/grin?branch=milestone/1.1.0)",
- "grin_util 1.1.0 (git+https://github.com/mimblewimble/grin?branch=milestone/1.1.0)",
+ "grin_core 1.1.0 (git+https://github.com/bddap/grin?branch=milestone/1.1.0)",
+ "grin_util 1.1.0 (git+https://github.com/bddap/grin?branch=milestone/1.1.0)",
  "libc 0.2.49 (registry+https://github.com/rust-lang/crates.io-index)",
  "lmdb-zero 0.4.4 (registry+https://github.com/rust-lang/crates.io-index)",
  "log 0.4.6 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -795,12 +819,12 @@ dependencies = [
 [[package]]
 name = "grin_util"
 version = "1.1.0"
-source = "git+https://github.com/mimblewimble/grin?branch=milestone/1.1.0#a080284563e0bbb1153b51636b3cc77f4ff989db"
+source = "git+https://github.com/bddap/grin?branch=milestone/1.1.0#d25f84532a23e3be52e8202224c36f391be3575d"
 dependencies = [
  "backtrace 0.3.14 (registry+https://github.com/rust-lang/crates.io-index)",
  "base64 0.9.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "byteorder 1.3.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "grin_secp256k1zkp 0.7.4 (registry+https://github.com/rust-lang/crates.io-index)",
+ "grin_secp256k1zkp 0.7.4 (git+https://github.com/mimblewimble/rust-secp256k1-zkp?rev=a7a523da4fe72ddda6c13034be99b04d19854d3f)",
  "lazy_static 1.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "log 0.4.6 (registry+https://github.com/rust-lang/crates.io-index)",
  "log4rs 0.8.1 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -822,15 +846,15 @@ dependencies = [
  "ctrlc 3.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "failure 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)",
  "failure_derive 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)",
- "grin_api 1.1.0 (git+https://github.com/mimblewimble/grin?branch=milestone/1.1.0)",
+ "grin_api 1.1.0 (git+https://github.com/bddap/grin?branch=milestone/1.1.0)",
  "grin_apiwallet 1.1.0",
- "grin_chain 1.1.0 (git+https://github.com/mimblewimble/grin?branch=milestone/1.1.0)",
- "grin_core 1.1.0 (git+https://github.com/mimblewimble/grin?branch=milestone/1.1.0)",
- "grin_keychain 1.1.0 (git+https://github.com/mimblewimble/grin?branch=milestone/1.1.0)",
+ "grin_chain 1.1.0 (git+https://github.com/bddap/grin?branch=milestone/1.1.0)",
+ "grin_core 1.1.0 (git+https://github.com/bddap/grin?branch=milestone/1.1.0)",
+ "grin_keychain 1.1.0 (git+https://github.com/bddap/grin?branch=milestone/1.1.0)",
  "grin_libwallet 1.1.0",
  "grin_refwallet 1.1.0",
- "grin_store 1.1.0 (git+https://github.com/mimblewimble/grin?branch=milestone/1.1.0)",
- "grin_util 1.1.0 (git+https://github.com/mimblewimble/grin?branch=milestone/1.1.0)",
+ "grin_store 1.1.0 (git+https://github.com/bddap/grin?branch=milestone/1.1.0)",
+ "grin_util 1.1.0 (git+https://github.com/bddap/grin?branch=milestone/1.1.0)",
  "grin_wallet_config 1.1.0",
  "linefeed 0.5.4 (registry+https://github.com/rust-lang/crates.io-index)",
  "log 0.4.6 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -843,8 +867,8 @@ name = "grin_wallet_config"
 version = "1.1.0"
 dependencies = [
  "dirs 1.0.5 (registry+https://github.com/rust-lang/crates.io-index)",
- "grin_core 1.1.0 (git+https://github.com/mimblewimble/grin?branch=milestone/1.1.0)",
- "grin_util 1.1.0 (git+https://github.com/mimblewimble/grin?branch=milestone/1.1.0)",
+ "grin_core 1.1.0 (git+https://github.com/bddap/grin?branch=milestone/1.1.0)",
+ "grin_util 1.1.0 (git+https://github.com/bddap/grin?branch=milestone/1.1.0)",
  "pretty_assertions 0.5.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "rand 0.5.6 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde 1.0.88 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -973,6 +997,18 @@ dependencies = [
 name = "itoa"
 version = "0.4.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
+
+[[package]]
+name = "jsonrpc-core"
+version = "10.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "futures 0.1.25 (registry+https://github.com/rust-lang/crates.io-index)",
+ "log 0.4.6 (registry+https://github.com/rust-lang/crates.io-index)",
+ "serde 1.0.88 (registry+https://github.com/rust-lang/crates.io-index)",
+ "serde_derive 1.0.88 (registry+https://github.com/rust-lang/crates.io-index)",
+ "serde_json 1.0.38 (registry+https://github.com/rust-lang/crates.io-index)",
+]
 
 [[package]]
 name = "kernel32-sys"
@@ -1932,6 +1968,9 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 name = "serde"
 version = "1.0.88"
 source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "serde_derive 1.0.88 (registry+https://github.com/rust-lang/crates.io-index)",
+]
 
 [[package]]
 name = "serde-value"
@@ -2627,6 +2666,8 @@ dependencies = [
 "checksum digest 0.7.6 (registry+https://github.com/rust-lang/crates.io-index)" = "03b072242a8cbaf9c145665af9d250c59af3b958f83ed6824e13533cf76d5b90"
 "checksum dirs 1.0.5 (registry+https://github.com/rust-lang/crates.io-index)" = "3fd78930633bd1c6e35c4b42b1df7b0cbc6bc191146e512bb3bedf243fcc3901"
 "checksum dtoa 0.4.3 (registry+https://github.com/rust-lang/crates.io-index)" = "6d301140eb411af13d3115f9a562c85cc6b541ade9dfa314132244aaee7489dd"
+"checksum easy-jsonrpc 0.1.3 (registry+https://github.com/rust-lang/crates.io-index)" = "7d785a8646bdfa33102e5f78204bcf25d79948f750d70d436d9c5101220ccedf"
+"checksum easy-jsonrpc-proc-macro 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)" = "48a7c76b05a6a1c018d36e41804e889476809afa79eb8d9aa5eb354270b5379d"
 "checksum encode_unicode 0.3.5 (registry+https://github.com/rust-lang/crates.io-index)" = "90b2c9496c001e8cb61827acdefad780795c42264c137744cae6f7d9e3450abd"
 "checksum enum_primitive 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)" = "be4551092f4d519593039259a9ed8daedf0da12e5109c5280338073eaeb81180"
 "checksum env_logger 0.5.13 (registry+https://github.com/rust-lang/crates.io-index)" = "15b0a4d2e39f8420210be8b27eeda28029729e2fd4291019455016c348240c38"
@@ -2644,15 +2685,15 @@ dependencies = [
 "checksum generic-array 0.9.0 (registry+https://github.com/rust-lang/crates.io-index)" = "ef25c5683767570c2bbd7deba372926a55eaae9982d7726ee2a1050239d45b9d"
 "checksum git2 0.7.5 (registry+https://github.com/rust-lang/crates.io-index)" = "591f8be1674b421644b6c030969520bc3fa12114d2eb467471982ed3e9584e71"
 "checksum glob 0.2.11 (registry+https://github.com/rust-lang/crates.io-index)" = "8be18de09a56b60ed0edf84bc9df007e30040691af7acd1c41874faac5895bfb"
-"checksum grin_api 1.1.0 (git+https://github.com/mimblewimble/grin?branch=milestone/1.1.0)" = "<none>"
-"checksum grin_chain 1.1.0 (git+https://github.com/mimblewimble/grin?branch=milestone/1.1.0)" = "<none>"
-"checksum grin_core 1.1.0 (git+https://github.com/mimblewimble/grin?branch=milestone/1.1.0)" = "<none>"
-"checksum grin_keychain 1.1.0 (git+https://github.com/mimblewimble/grin?branch=milestone/1.1.0)" = "<none>"
-"checksum grin_p2p 1.1.0 (git+https://github.com/mimblewimble/grin?branch=milestone/1.1.0)" = "<none>"
-"checksum grin_pool 1.1.0 (git+https://github.com/mimblewimble/grin?branch=milestone/1.1.0)" = "<none>"
-"checksum grin_secp256k1zkp 0.7.4 (registry+https://github.com/rust-lang/crates.io-index)" = "223095ed6108a42855ab2ce368d2056cfd384705f81c494f6d88ab3383161562"
-"checksum grin_store 1.1.0 (git+https://github.com/mimblewimble/grin?branch=milestone/1.1.0)" = "<none>"
-"checksum grin_util 1.1.0 (git+https://github.com/mimblewimble/grin?branch=milestone/1.1.0)" = "<none>"
+"checksum grin_api 1.1.0 (git+https://github.com/bddap/grin?branch=milestone/1.1.0)" = "<none>"
+"checksum grin_chain 1.1.0 (git+https://github.com/bddap/grin?branch=milestone/1.1.0)" = "<none>"
+"checksum grin_core 1.1.0 (git+https://github.com/bddap/grin?branch=milestone/1.1.0)" = "<none>"
+"checksum grin_keychain 1.1.0 (git+https://github.com/bddap/grin?branch=milestone/1.1.0)" = "<none>"
+"checksum grin_p2p 1.1.0 (git+https://github.com/bddap/grin?branch=milestone/1.1.0)" = "<none>"
+"checksum grin_pool 1.1.0 (git+https://github.com/bddap/grin?branch=milestone/1.1.0)" = "<none>"
+"checksum grin_secp256k1zkp 0.7.4 (git+https://github.com/mimblewimble/rust-secp256k1-zkp?rev=a7a523da4fe72ddda6c13034be99b04d19854d3f)" = "<none>"
+"checksum grin_store 1.1.0 (git+https://github.com/bddap/grin?branch=milestone/1.1.0)" = "<none>"
+"checksum grin_util 1.1.0 (git+https://github.com/bddap/grin?branch=milestone/1.1.0)" = "<none>"
 "checksum h2 0.1.16 (registry+https://github.com/rust-lang/crates.io-index)" = "ddb2b25a33e231484694267af28fec74ac63b5ccf51ee2065a5e313b834d836e"
 "checksum hmac 0.6.3 (registry+https://github.com/rust-lang/crates.io-index)" = "733e1b3ac906631ca01ebb577e9bb0f5e37a454032b9036b5eaea4013ed6f99a"
 "checksum http 0.1.16 (registry+https://github.com/rust-lang/crates.io-index)" = "fe67e3678f2827030e89cc4b9e7ecd16d52f132c0b940ab5005f88e821500f6a"
@@ -2664,6 +2705,7 @@ dependencies = [
 "checksum indexmap 1.0.2 (registry+https://github.com/rust-lang/crates.io-index)" = "7e81a7c05f79578dbc15793d8b619db9ba32b4577003ef3af1a91c416798c58d"
 "checksum iovec 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)" = "dbe6e417e7d0975db6512b90796e8ce223145ac4e33c377e4a42882a0e88bb08"
 "checksum itoa 0.4.3 (registry+https://github.com/rust-lang/crates.io-index)" = "1306f3464951f30e30d12373d31c79fbd52d236e5e896fd92f96ec7babbbe60b"
+"checksum jsonrpc-core 10.1.0 (registry+https://github.com/rust-lang/crates.io-index)" = "dc15eef5f8b6bef5ac5f7440a957ff95d036e2f98706947741bfc93d1976db4c"
 "checksum kernel32-sys 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)" = "7507624b29483431c0ba2d82aece8ca6cdba9382bff4ddd0f7490560c056098d"
 "checksum lazy_static 1.3.0 (registry+https://github.com/rust-lang/crates.io-index)" = "bc5729f27f159ddd61f4df6228e827e86643d4d3e7c32183cb30a1c08f604a14"
 "checksum lazycell 1.2.1 (registry+https://github.com/rust-lang/crates.io-index)" = "b294d6fa9ee409a054354afc4352b0b9ef7ca222c69b8812cbea9e7d2bf3783f"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -416,20 +416,22 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
 name = "easy-jsonrpc"
-version = "0.1.3"
+version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "easy-jsonrpc-proc-macro 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "easy-jsonrpc-proc-macro 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "jsonrpc-core 10.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "rand 0.6.5 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde 1.0.88 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde_json 1.0.38 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
 name = "easy-jsonrpc-proc-macro"
-version = "0.1.1"
+version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
+ "heck 0.3.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "proc-macro2 0.4.27 (registry+https://github.com/rust-lang/crates.io-index)",
  "quote 0.6.11 (registry+https://github.com/rust-lang/crates.io-index)",
  "syn 0.15.26 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -600,7 +602,7 @@ dependencies = [
 name = "grin_apiwallet"
 version = "1.1.0"
 dependencies = [
- "easy-jsonrpc 0.1.3 (registry+https://github.com/rust-lang/crates.io-index)",
+ "easy-jsonrpc 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "failure 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)",
  "failure_derive 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)",
  "grin_api 1.1.0 (git+https://github.com/bddap/grin?branch=milestone/1.1.0)",
@@ -614,6 +616,7 @@ dependencies = [
  "grin_wallet_config 1.1.0",
  "log 0.4.6 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde_json 1.0.38 (registry+https://github.com/rust-lang/crates.io-index)",
+ "tempfile 3.0.7 (registry+https://github.com/rust-lang/crates.io-index)",
  "uuid 0.6.5 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
@@ -891,6 +894,14 @@ dependencies = [
  "slab 0.4.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "string 0.1.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "tokio-io 0.1.11 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "heck"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "unicode-segmentation 1.2.1 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -1835,6 +1846,14 @@ dependencies = [
 ]
 
 [[package]]
+name = "remove_dir_all"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "winapi 0.3.6 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
 name = "ring"
 version = "0.13.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2085,6 +2104,19 @@ dependencies = [
  "quote 0.6.11 (registry+https://github.com/rust-lang/crates.io-index)",
  "syn 0.15.26 (registry+https://github.com/rust-lang/crates.io-index)",
  "unicode-xid 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "tempfile"
+version = "3.0.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "cfg-if 0.1.6 (registry+https://github.com/rust-lang/crates.io-index)",
+ "libc 0.2.49 (registry+https://github.com/rust-lang/crates.io-index)",
+ "rand 0.6.5 (registry+https://github.com/rust-lang/crates.io-index)",
+ "redox_syscall 0.1.51 (registry+https://github.com/rust-lang/crates.io-index)",
+ "remove_dir_all 0.5.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "winapi 0.3.6 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -2419,6 +2451,11 @@ dependencies = [
 ]
 
 [[package]]
+name = "unicode-segmentation"
+version = "1.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+
+[[package]]
 name = "unicode-width"
 version = "0.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2666,8 +2703,8 @@ dependencies = [
 "checksum digest 0.7.6 (registry+https://github.com/rust-lang/crates.io-index)" = "03b072242a8cbaf9c145665af9d250c59af3b958f83ed6824e13533cf76d5b90"
 "checksum dirs 1.0.5 (registry+https://github.com/rust-lang/crates.io-index)" = "3fd78930633bd1c6e35c4b42b1df7b0cbc6bc191146e512bb3bedf243fcc3901"
 "checksum dtoa 0.4.3 (registry+https://github.com/rust-lang/crates.io-index)" = "6d301140eb411af13d3115f9a562c85cc6b541ade9dfa314132244aaee7489dd"
-"checksum easy-jsonrpc 0.1.3 (registry+https://github.com/rust-lang/crates.io-index)" = "7d785a8646bdfa33102e5f78204bcf25d79948f750d70d436d9c5101220ccedf"
-"checksum easy-jsonrpc-proc-macro 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)" = "48a7c76b05a6a1c018d36e41804e889476809afa79eb8d9aa5eb354270b5379d"
+"checksum easy-jsonrpc 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)" = "4e0cb740db04464d020c02930fc080c057480b611bb4a96871caaab1615b7e42"
+"checksum easy-jsonrpc-proc-macro 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)" = "ff88c7d11b38c5ada21b07e95d468bcdd4f0bb9f771d93463b1a7afd797e5c97"
 "checksum encode_unicode 0.3.5 (registry+https://github.com/rust-lang/crates.io-index)" = "90b2c9496c001e8cb61827acdefad780795c42264c137744cae6f7d9e3450abd"
 "checksum enum_primitive 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)" = "be4551092f4d519593039259a9ed8daedf0da12e5109c5280338073eaeb81180"
 "checksum env_logger 0.5.13 (registry+https://github.com/rust-lang/crates.io-index)" = "15b0a4d2e39f8420210be8b27eeda28029729e2fd4291019455016c348240c38"
@@ -2695,6 +2732,7 @@ dependencies = [
 "checksum grin_store 1.1.0 (git+https://github.com/bddap/grin?branch=milestone/1.1.0)" = "<none>"
 "checksum grin_util 1.1.0 (git+https://github.com/bddap/grin?branch=milestone/1.1.0)" = "<none>"
 "checksum h2 0.1.16 (registry+https://github.com/rust-lang/crates.io-index)" = "ddb2b25a33e231484694267af28fec74ac63b5ccf51ee2065a5e313b834d836e"
+"checksum heck 0.3.1 (registry+https://github.com/rust-lang/crates.io-index)" = "20564e78d53d2bb135c343b3f47714a56af2061f1c928fdb541dc7b9fdd94205"
 "checksum hmac 0.6.3 (registry+https://github.com/rust-lang/crates.io-index)" = "733e1b3ac906631ca01ebb577e9bb0f5e37a454032b9036b5eaea4013ed6f99a"
 "checksum http 0.1.16 (registry+https://github.com/rust-lang/crates.io-index)" = "fe67e3678f2827030e89cc4b9e7ecd16d52f132c0b940ab5005f88e821500f6a"
 "checksum httparse 1.3.3 (registry+https://github.com/rust-lang/crates.io-index)" = "e8734b0cfd3bc3e101ec59100e101c2eecd19282202e87808b3037b442777a83"
@@ -2797,6 +2835,7 @@ dependencies = [
 "checksum redox_users 0.3.0 (registry+https://github.com/rust-lang/crates.io-index)" = "3fe5204c3a17e97dde73f285d49be585df59ed84b50a872baf416e73b62c3828"
 "checksum regex 1.1.0 (registry+https://github.com/rust-lang/crates.io-index)" = "37e7cbbd370869ce2e8dff25c7018702d10b21a20ef7135316f8daecd6c25b7f"
 "checksum regex-syntax 0.6.5 (registry+https://github.com/rust-lang/crates.io-index)" = "8c2f35eedad5295fdf00a63d7d4b238135723f92b434ec06774dad15c7ab0861"
+"checksum remove_dir_all 0.5.1 (registry+https://github.com/rust-lang/crates.io-index)" = "3488ba1b9a2084d38645c4c08276a1752dcbf2c7130d74f1569681ad5d2799c5"
 "checksum ring 0.13.5 (registry+https://github.com/rust-lang/crates.io-index)" = "2c4db68a2e35f3497146b7e4563df7d4773a2433230c5e4b448328e31740458a"
 "checksum ripemd160 0.7.0 (registry+https://github.com/rust-lang/crates.io-index)" = "482aa56cc68aaeccdaaff1cc5a72c247da8bbad3beb174ca5741f274c22883fb"
 "checksum rpassword 2.1.0 (registry+https://github.com/rust-lang/crates.io-index)" = "d37473170aedbe66ffa3ad3726939ba677d83c646ad4fd99e5b4bc38712f45ec"
@@ -2831,6 +2870,7 @@ dependencies = [
 "checksum supercow 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)" = "171758edb47aa306a78dfa4ab9aeb5167405bd4e3dc2b64e88f6a84bbe98bd63"
 "checksum syn 0.15.26 (registry+https://github.com/rust-lang/crates.io-index)" = "f92e629aa1d9c827b2bb8297046c1ccffc57c99b947a680d3ccff1f136a3bee9"
 "checksum synstructure 0.10.1 (registry+https://github.com/rust-lang/crates.io-index)" = "73687139bf99285483c96ac0add482c3776528beac1d97d444f6e91f203a2015"
+"checksum tempfile 3.0.7 (registry+https://github.com/rust-lang/crates.io-index)" = "b86c784c88d98c801132806dadd3819ed29d8600836c4088e855cdf3e178ed8a"
 "checksum term 0.5.1 (registry+https://github.com/rust-lang/crates.io-index)" = "5e6b677dd1e8214ea1ef4297f85dbcbed8e8cdddb561040cc998ca2551c37561"
 "checksum termcolor 1.0.4 (registry+https://github.com/rust-lang/crates.io-index)" = "4096add70612622289f2fdcdbd5086dc81c1e2675e6ae58d6c4f62a16c6d7f2f"
 "checksum terminfo 0.6.1 (registry+https://github.com/rust-lang/crates.io-index)" = "8e51065bafd2abe106b6036483b69d1741f4a1ec56ce8a2378de341637de689e"
@@ -2863,6 +2903,7 @@ dependencies = [
 "checksum ucd-util 0.1.3 (registry+https://github.com/rust-lang/crates.io-index)" = "535c204ee4d8434478593480b8f86ab45ec9aae0e83c568ca81abf0fd0e88f86"
 "checksum unicode-bidi 0.3.4 (registry+https://github.com/rust-lang/crates.io-index)" = "49f2bd0c6468a8230e1db229cff8029217cf623c767ea5d60bfbd42729ea54d5"
 "checksum unicode-normalization 0.1.8 (registry+https://github.com/rust-lang/crates.io-index)" = "141339a08b982d942be2ca06ff8b076563cbe223d1befd5450716790d44e2426"
+"checksum unicode-segmentation 1.2.1 (registry+https://github.com/rust-lang/crates.io-index)" = "aa6024fc12ddfd1c6dbc14a80fa2324d4568849869b779f6bd37e5e4c03344d1"
 "checksum unicode-width 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)" = "882386231c45df4700b275c7ff55b6f3698780a650026380e72dabe76fa46526"
 "checksum unicode-xid 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)" = "fc72304796d0818e357ead4e000d19c9c174ab23dc11093ac919054d20a6a7fc"
 "checksum unsafe-any 0.4.2 (registry+https://github.com/rust-lang/crates.io-index)" = "f30360d7979f5e9c6e6cea48af192ea8fab4afb3cf72597154b8f08935bc9c7f"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -41,5 +41,13 @@ grin_util = { git = "https://github.com/mimblewimble/grin", branch = "milestone/
 grin_api = { git = "https://github.com/mimblewimble/grin", branch = "milestone/1.1.0" }
 grin_store = { git = "https://github.com/mimblewimble/grin", branch = "milestone/1.1.0" }
 
+[patch.'https://github.com/mimblewimble/grin']
+grin_core = { git = "https://github.com/bddap/grin", branch = "milestone/1.1.0" }
+grin_keychain = { git = "https://github.com/bddap/grin", branch = "milestone/1.1.0" }
+grin_chain = { git = "https://github.com/bddap/grin", branch = "milestone/1.1.0" }
+grin_util = { git = "https://github.com/bddap/grin", branch = "milestone/1.1.0" }
+grin_api = { git = "https://github.com/bddap/grin", branch = "milestone/1.1.0" }
+grin_store = { git = "https://github.com/bddap/grin", branch = "milestone/1.1.0" }
+
 [build-dependencies]
 built = "0.3"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -41,13 +41,5 @@ grin_util = { git = "https://github.com/mimblewimble/grin", branch = "milestone/
 grin_api = { git = "https://github.com/mimblewimble/grin", branch = "milestone/1.1.0" }
 grin_store = { git = "https://github.com/mimblewimble/grin", branch = "milestone/1.1.0" }
 
-[patch.'https://github.com/mimblewimble/grin']
-grin_core = { git = "https://github.com/bddap/grin", branch = "milestone/1.1.0" }
-grin_keychain = { git = "https://github.com/bddap/grin", branch = "milestone/1.1.0" }
-grin_chain = { git = "https://github.com/bddap/grin", branch = "milestone/1.1.0" }
-grin_util = { git = "https://github.com/bddap/grin", branch = "milestone/1.1.0" }
-grin_api = { git = "https://github.com/bddap/grin", branch = "milestone/1.1.0" }
-grin_store = { git = "https://github.com/bddap/grin", branch = "milestone/1.1.0" }
-
 [build-dependencies]
 built = "0.3"

--- a/apiwallet/Cargo.toml
+++ b/apiwallet/Cargo.toml
@@ -15,7 +15,7 @@ failure = "0.1"
 failure_derive = "0.1"
 log = "0.4"
 uuid = { version = "0.6", features = ["serde", "v4"] }
-easy-jsonrpc = "0.1.1"
+easy-jsonrpc = "0.2.0"
 
 grin_libwallet = { path = "../libwallet", version = "1.1.0" }
 grin_wallet_config = { path = "../config", version = "1.1.0" }
@@ -30,3 +30,4 @@ grin_store = { git = "https://github.com/mimblewimble/grin", branch = "milestone
 [dev-dependencies]
 grin_refwallet = { path = "../refwallet", version = "1.1.0" }
 serde_json = "1"
+tempfile = "3.0.7"

--- a/apiwallet/Cargo.toml
+++ b/apiwallet/Cargo.toml
@@ -15,7 +15,7 @@ failure = "0.1"
 failure_derive = "0.1"
 log = "0.4"
 uuid = { version = "0.6", features = ["serde", "v4"] }
-easy-jsonrpc = "0.2.0"
+easy-jsonrpc = "0.4.1"
 
 grin_libwallet = { path = "../libwallet", version = "1.1.0" }
 grin_wallet_config = { path = "../config", version = "1.1.0" }

--- a/apiwallet/Cargo.toml
+++ b/apiwallet/Cargo.toml
@@ -15,6 +15,7 @@ failure = "0.1"
 failure_derive = "0.1"
 log = "0.4"
 uuid = { version = "0.6", features = ["serde", "v4"] }
+easy-jsonrpc = "0.1.1"
 
 grin_libwallet = { path = "../libwallet", version = "1.1.0" }
 grin_wallet_config = { path = "../config", version = "1.1.0" }
@@ -25,3 +26,7 @@ grin_chain = { git = "https://github.com/mimblewimble/grin", branch = "milestone
 grin_util = { git = "https://github.com/mimblewimble/grin", branch = "milestone/1.1.0" }
 grin_api = { git = "https://github.com/mimblewimble/grin", branch = "milestone/1.1.0" }
 grin_store = { git = "https://github.com/mimblewimble/grin", branch = "milestone/1.1.0" }
+
+[dev-dependencies]
+grin_refwallet = { path = "../refwallet", version = "1.1.0" }
+serde_json = "1"

--- a/apiwallet/src/api.rs
+++ b/apiwallet/src/api.rs
@@ -55,90 +55,18 @@ const USER_MESSAGE_MAX_LEN: usize = 256;
 /// Public definition used to generate jsonrpc api.
 pub trait OwnerAPI {
 	/**
-	Returns a list of accounts stored in the wallet (i.e. mappings between
-	user-specified labels and BIP32 derivation paths.
-
-	# Returns
-	* Result Containing:
-	* A Vector of [`AcctPathMapping`](../types/struct.AcctPathMapping.html) data
-	* or [`libwallet::Error`](../struct.Error.html) if an error is encountered.
-
-	# Remarks
-
-	* A wallet should always have the path with the label 'default' path defined,
-	with path m/0/0
-	* This method does not need to use the wallet seed or keychain.
-
-	# Example
-	Set up as in [`new`](struct.APIOwner.html#method.new) method above.
-
-	``` ignore
-	# extern crate grin_wallet_config as config;
-	# extern crate grin_refwallet as wallet;
-	# extern crate grin_keychain as keychain;
-	# extern crate grin_util as util;
-	# use std::sync::Arc;
-	# use util::Mutex;
-	# use keychain::ExtKeychain;
-	# use wallet::libwallet::api::APIOwner;
-	# use wallet::{LMDBBackend, HTTPNodeClient, WalletBackend};
-	# use config::WalletConfig;
-	# let mut wallet_config = WalletConfig::default();
-	# wallet_config.data_file_dir = "test_output/doc/wallet1".to_owned();
-	# let node_client = HTTPNodeClient::new(&wallet_config.check_node_api_http_addr, None);
-	# let mut wallet:Arc<Mutex<WalletBackend<HTTPNodeClient, ExtKeychain>>> =
-	# Arc::new(Mutex::new(
-	# 	LMDBBackend::new(wallet_config.clone(), "", node_client).unwrap()
-	# ));
-	let api_owner = APIOwner::new(wallet.clone());
-
-	let result = api_owner.accounts();
-
-	if let Ok(accts) = result {
-		//...
-	}
-	```
+	Networked version of [APIOwner::accounts](struct.APIOwner.html#method.accounts).
 
 	# Json rpc example
 
 	```
-	# fn json_rpc_owner_doctest(request: serde_json::Value, expected_response: serde_json::Value) {
-	#   use easy_jsonrpc::JSONRPCServer;
-	# 	use grin_apiwallet::api::{APIOwner, OwnerAPI};
-	# 	use grin_keychain::ExtKeychain;
-	# 	use grin_refwallet::{HTTPNodeClient, LMDBBackend, WalletBackend};
-	# 	use grin_util::Mutex;
-	# 	use grin_wallet_config::WalletConfig;
-	# 	use serde_json;
-	# 	use std::sync::Arc;
-	#
-	# 	let mut wallet_config = WalletConfig::default();
-	# 	wallet_config.data_file_dir = "test_output/doc/wallet1".to_owned();
-	# 	let node_client = HTTPNodeClient::new(&wallet_config.check_node_api_http_addr, None);
-	# 	let wallet: Arc<Mutex<WalletBackend<HTTPNodeClient, ExtKeychain>>> = Arc::new(Mutex::new(
-	# 		LMDBBackend::new(wallet_config.clone(), "", node_client).unwrap(),
-	# 	));
-	# 	let api_owner = APIOwner::new(wallet);
-	# 	let owner_api = &api_owner as &dyn OwnerAPI;
-	#
-	# 	assert_eq!(
-	# 		owner_api
-	# 			.handle_parsed(serde_json::from_value(request).unwrap())
-	# 			.unwrap(),
-	# 		serde_json::from_value(expected_response).unwrap(),
-	# 	);
-	# }
-	#
-	# use serde_json::json;
-	# json_rpc_owner_doctest(json!(
+	# grin_apiwallet::doctest_helper_json_rpc_owner_assert_response!(
 	{
 		"jsonrpc": "2.0",
 		"method": "accounts",
 		"params": [],
 		"id": 1
-	}
-	# ),
-	# json!(
+	},
 	{
 		"jsonrpc": "2.0",
 		"result": {
@@ -151,24 +79,85 @@ pub trait OwnerAPI {
 		},
 		"id": 1
 	}
-	# ));
+	# );
 	```
 	 */
 	fn accounts(&self) -> Result<Vec<AcctPathMapping>, ErrorKind>;
 
-	/// ``` ignore
-	/// panic!("doctest not written")
-	/// ```
+	/**
+	Networked version of [APIOwner::create_account_path](struct.APIOwner.html#method.create_account_path).
+
+	# Json rpc example
+
+	```
+	# grin_apiwallet::doctest_helper_json_rpc_owner_assert_response!(
+	{
+		"jsonrpc": "2.0",
+		"method": "create_account_path",
+		"params": ["account1"],
+		"id": 1
+	},
+	{
+		"jsonrpc": "2.0",
+		"result": {
+			"Ok": "0200000001000000000000000000000000"
+		},
+		"id": 1
+	}
+	# );
+	```
+	 */
 	fn create_account_path(&self, label: &String) -> Result<Identifier, ErrorKind>;
 
-	/// ``` ignore
-	/// panic!("doctest not written")
-	/// ```
+	/**
+	Networked version of [APIOwner::set_active_account](struct.APIOwner.html#method.set_active_account).
+
+	# Json rpc example
+
+	```
+	# grin_apiwallet::doctest_helper_json_rpc_owner_assert_response!(
+	{
+		"jsonrpc": "2.0",
+		"method": "set_active_account",
+		"params": ["default"],
+		"id": 1
+	},
+	{
+		"jsonrpc": "2.0",
+		"result": {
+			"Ok": null
+		},
+		"id": 1
+	}
+	# );
+	```
+	 */
 	fn set_active_account(&self, label: &String) -> Result<(), ErrorKind>;
 
-	/// ``` ignore
-	/// panic!("doctest not written")
-	/// ```
+	/**
+	Networked version of [APIOwner::retrieve_outputs](struct.APIOwner.html#method.retrieve_outputs).
+
+
+	```
+	# grin_apiwallet::doctest_helper_json_rpc_owner_assert_response!(
+	{
+		"jsonrpc": "2.0",
+		"method": "retrieve_outputs",
+		"params": [false, false, null],
+		"id": 1
+	},
+	{
+		"jsonrpc": "2.0",
+		"result": {
+			"Err": {
+				"CallbackImpl": "Error opening wallet"
+			}
+		},
+		"id": 1
+	}
+	# );
+	```
+	 */
 	fn retrieve_outputs(
 		&self,
 		include_spent: bool,
@@ -176,9 +165,30 @@ pub trait OwnerAPI {
 		tx_id: Option<u32>,
 	) -> Result<(bool, Vec<(OutputData, pedersen::Commitment)>), ErrorKind>;
 
-	/// ``` ignore
-	/// panic!("doctest not written")
-	/// ```
+	/**
+	Networked version of [APIOwner::retrieve_txs](struct.APIOwner.html#method.retrieve_txs).
+
+
+	```
+	# grin_apiwallet::doctest_helper_json_rpc_owner_assert_response!(
+	{
+		"jsonrpc": "2.0",
+		"method": "retrieve_txs",
+		"params": [false, null, null],
+		"id": 1
+	},
+	{
+		"jsonrpc": "2.0",
+		"result": {
+			"Err": {
+				"CallbackImpl": "Error opening wallet"
+			}
+		},
+		"id": 1
+	}
+	# );
+	```
+	 */
 	fn retrieve_txs(
 		&self,
 		refresh_from_node: bool,
@@ -186,18 +196,60 @@ pub trait OwnerAPI {
 		tx_slate_id: Option<Uuid>,
 	) -> Result<(bool, Vec<TxLogEntry>), ErrorKind>;
 
-	/// ``` ignore
-	/// panic!("doctest not written")
-	/// ```
+	/**
+	Networked version of [APIOwner::retrieve_summary_info](struct.APIOwner.html#method.retrieve_summary_info).
+
+
+	```
+	# grin_apiwallet::doctest_helper_json_rpc_owner_assert_response!(
+	{
+		"jsonrpc": "2.0",
+		"method": "retrieve_summary_info",
+		"params": [false, 1],
+		"id": 1
+	},
+	{
+		"jsonrpc": "2.0",
+		"result": {
+			"Err": {
+				"CallbackImpl": "Error opening wallet"
+			}
+		},
+		"id": 1
+	}
+	# );
+	```
+	 */
 	fn retrieve_summary_info(
 		&self,
 		refresh_from_node: bool,
 		minimum_confirmations: u64,
 	) -> Result<(bool, WalletInfo), ErrorKind>;
 
-	/// ``` ignore
-	/// panic!("doctest not written")
-	/// ```
+	/**
+	Networked version of [APIOwner::estimate_initiate_tx](struct.APIOwner.html#method.estimate_initiate_tx).
+
+
+	```
+	# grin_apiwallet::doctest_helper_json_rpc_owner_assert_response!(
+	{
+		"jsonrpc": "2.0",
+		"method": "estimate_initiate_tx",
+		"params": [null, 0, 0, 10, 0, false],
+		"id": 1
+	},
+	{
+		"jsonrpc": "2.0",
+		"result": {
+			"Err": {
+				"CallbackImpl": "Error opening wallet"
+			}
+		},
+		"id": 1
+	}
+	# );
+	```
+	 */
 	fn estimate_initiate_tx(
 		&self,
 		src_acct_name: Option<String>,
@@ -208,44 +260,269 @@ pub trait OwnerAPI {
 		selection_strategy_is_use_all: bool,
 	) -> Result<(/* total */ u64, /* fee */ u64), ErrorKind>;
 
-	/// ``` ignore
-	/// panic!("doctest not written")
-	/// ```
+	/**
+	Networked version of [APIOwner::finalize_tx](struct.APIOwner.html#method.finalize_tx).
+
+
+	```
+	# grin_apiwallet::doctest_helper_json_rpc_owner_assert_response!(
+	{
+		"jsonrpc": "2.0",
+		"method": "finalize_tx",
+		"params": [{
+			"amount": 0,
+			"fee": 0,
+			"height": 0,
+			"id": "414bad48-3386-4fa7-8483-72384c886ba3",
+			"lock_height": 0,
+			"num_participants": 2,
+			"participant_data": [],
+			"tx": {
+				"body": {
+					"inputs": [],
+					"kernels": [],
+					"outputs": []
+				},
+				"offset": "0000000000000000000000000000000000000000000000000000000000000000"
+			},
+			"version": 1
+		}],
+		"id": 1
+	},
+	{
+		"jsonrpc": "2.0",
+		"result": {
+			"Err": {
+				"CallbackImpl": "Error opening wallet"
+			}
+		},
+		"id": 1
+	}
+	# );
+	```
+	 */
 	fn finalize_tx(&self, slate: Slate) -> Result<Slate, ErrorKind>;
 
-	/// ``` ignore
-	/// panic!("doctest not written")
-	/// ```
+	/**
+	Networked version of [APIOwner::cancel_tx](struct.APIOwner.html#method.cancel_tx).
+
+
+	```
+	# grin_apiwallet::doctest_helper_json_rpc_owner_assert_response!(
+	{
+		"jsonrpc": "2.0",
+		"method": "cancel_tx",
+		"params": [null, null],
+		"id": 1
+	},
+	{
+		"jsonrpc": "2.0",
+		"result": {
+			"Err": {
+				"CallbackImpl": "Error opening wallet"
+			}
+		},
+		"id": 1
+	}
+	# );
+	```
+	 */
 	fn cancel_tx(&self, tx_id: Option<u32>, tx_slate_id: Option<Uuid>) -> Result<(), ErrorKind>;
 
-	/// ``` ignore
-	/// panic!("doctest not written")
-	/// ```
+	/**
+	Networked version of [APIOwner::get_stored_tx](struct.APIOwner.html#method.get_stored_tx).
+
+
+	```
+	# grin_apiwallet::doctest_helper_json_rpc_owner_assert_response!(
+	{
+		"jsonrpc": "2.0",
+		"method": "get_stored_tx",
+		"params": [
+			{
+				"amount_credited": 0,
+				"amount_debited": 0,
+				"confirmation_ts": null,
+				"confirmed": false,
+				"creation_ts": "2019-03-05T20:49:59.444095Z",
+				"fee": null,
+				"id": 10,
+				"messages": null,
+				"num_inputs": 0,
+				"num_outputs": 0,
+				"parent_key_id": "0000000000000000000000000000000000",
+				"stored_tx": null,
+				"tx_slate_id": null,
+				"tx_type": "TxReceived"
+			}
+		],
+		"id": 1
+	},
+	{
+		"jsonrpc": "2.0",
+		"result": {
+			"Ok": null
+		},
+		"id": 1
+	}
+	# );
+	```
+	 */
 	fn get_stored_tx(&self, entry: &TxLogEntry) -> Result<Option<Transaction>, ErrorKind>;
 
-	/// ``` ignore
-	/// panic!("doctest not written")
-	/// ```
+	/**
+	Networked version of [APIOwner::post_tx](struct.APIOwner.html#method.post_tx).
+
+
+	```
+	# grin_apiwallet::doctest_helper_json_rpc_owner_assert_response!(
+	{
+		"jsonrpc": "2.0",
+		"method": "post_tx",
+		"params": [
+			{
+				"body": {
+					"inputs": [],
+					"kernels": [],
+					"outputs": []
+				},
+				"offset": "0000000000000000000000000000000000000000000000000000000000000000"
+			},
+			false
+		],
+		"id": 1
+	},
+	{
+		"jsonrpc": "2.0",
+		"result": {
+			"Err": {
+				"ClientCallback": "Posting transaction to node: Request error: Cannot make request: an error occurred trying to connect: Connection refused (os error 61)"
+			}
+		},
+		"id": 1
+	}
+	# );
+	```
+	 */
 	fn post_tx(&self, tx: &Transaction, fluff: bool) -> Result<(), ErrorKind>;
 
-	/// ``` ignore
-	/// panic!("doctest not written")
-	/// ```
+	/**
+	Networked version of [APIOwner::verify_slate_messages](struct.APIOwner.html#method.verify_slate_messages).
+
+
+	```
+	# grin_apiwallet::doctest_helper_json_rpc_owner_assert_response!(
+	{
+		"jsonrpc": "2.0",
+		"method": "verify_slate_messages",
+		"params": [{
+			"amount": 0,
+			"fee": 0,
+			"height": 0,
+			"id": "414bad48-3386-4fa7-8483-72384c886ba3",
+			"lock_height": 0,
+			"num_participants": 2,
+			"participant_data": [],
+			"tx": {
+				"body": {
+					"inputs": [],
+					"kernels": [],
+					"outputs": []
+				},
+				"offset": "0000000000000000000000000000000000000000000000000000000000000000"
+			},
+			"version": 1
+		}],
+		"id": 1
+	},
+	{
+		"jsonrpc": "2.0",
+		"result": {
+			 "Ok": null
+		},
+		"id": 1
+	}
+	# );
+	```
+	 */
 	fn verify_slate_messages(&self, slate: &Slate) -> Result<(), ErrorKind>;
 
-	/// ``` ignore
-	/// panic!("doctest not written")
-	/// ```
+	/**
+	Networked version of [APIOwner::restore](struct.APIOwner.html#method.restore).
+
+
+	```
+	# grin_apiwallet::doctest_helper_json_rpc_owner_assert_response!(
+	{
+		"jsonrpc": "2.0",
+		"method": "restore",
+		"params": [],
+		"id": 1
+	},
+	{
+		"jsonrpc": "2.0",
+		"result": {
+			"Err": {
+				"CallbackImpl": "Error opening wallet"
+			}
+		},
+		"id": 1
+	}
+	# );
+	```
+	 */
 	fn restore(&self) -> Result<(), ErrorKind>;
 
-	/// ``` ignore
-	/// panic!("doctest not written")
-	/// ```
+	/**
+	Networked version of [APIOwner::check_repair](struct.APIOwner.html#method.check_repair).
+
+
+	```
+	# grin_apiwallet::doctest_helper_json_rpc_owner_assert_response!(
+	{
+		"jsonrpc": "2.0",
+		"method": "check_repair",
+		"params": [],
+		"id": 1
+	},
+	{
+		"jsonrpc": "2.0",
+		"result": {
+			"Err": {
+				"CallbackImpl": "Error opening wallet"
+			}
+		},
+		"id": 1
+	}
+	# );
+	```
+	 */
 	fn check_repair(&self) -> Result<(), ErrorKind>;
 
-	/// ``` ignore
-	/// panic!("doctest not written")
-	/// ```
+	/**
+	Networked version of [APIOwner::node_height](struct.APIOwner.html#method.node_height).
+
+
+	```
+	# grin_apiwallet::doctest_helper_json_rpc_owner_assert_response!(
+	{
+		"jsonrpc": "2.0",
+		"method": "node_height",
+		"params": [],
+		"id": 1
+	},
+	{
+		"jsonrpc": "2.0",
+		"result": {
+			"Err": {
+				"CallbackImpl": "Error opening wallet"
+			}
+		},
+		"id": 1
+	}
+	# );
+	```
+	 */
 	fn node_height(&self) -> Result<(u64, bool), ErrorKind>;
 }
 
@@ -1265,4 +1542,60 @@ where
 		w.close()?;
 		Ok(())
 	}
+}
+
+#[doc(hidden)]
+#[macro_export]
+macro_rules! doctest_helper_json_rpc_owner_assert_response {
+	($request:tt, $expected_response:tt) => {
+		// create temporary wallet, run jsonrpc request on owner api of wallet, delete wallet, return
+		// json response.
+		// In order to prevent leaking tempdirs, This function should not panic.
+		fn rpc_owner_result(
+			request: serde_json::Value,
+		) -> Result<Option<serde_json::Value>, String> {
+			use easy_jsonrpc::Handler;
+			use grin_apiwallet::api::{APIOwner, OwnerAPI};
+			use grin_keychain::ExtKeychain;
+			use grin_refwallet::{HTTPNodeClient, LMDBBackend, WalletBackend};
+			use grin_util::Mutex;
+			use grin_wallet_config::WalletConfig;
+			use serde_json;
+			use std::sync::Arc;
+			use tempfile::tempdir;
+
+			let dir = tempdir().map_err(|e| format!("{:#?}", e))?;
+				{
+				let mut wallet_config = WalletConfig::default();
+				wallet_config.data_file_dir = dir
+					.path()
+					.to_str()
+					.ok_or("Failed to convert tmpdir path to string.".to_owned())?
+					.to_owned();
+				let node_client =
+					HTTPNodeClient::new(&wallet_config.check_node_api_http_addr, None);
+				let wallet: Arc<Mutex<WalletBackend<HTTPNodeClient, ExtKeychain>>> =
+					Arc::new(Mutex::new(
+						LMDBBackend::new(wallet_config.clone(), "", node_client)
+							.map_err(|e| format!("{:#?}", e))?,
+					));
+				let api_owner = APIOwner::new(wallet);
+				let owner_api = &api_owner as &dyn OwnerAPI;
+				Ok(owner_api.handle_request(request))
+				}
+			}
+
+		let response = rpc_owner_result(serde_json::json!($request))
+			.unwrap()
+			.unwrap();
+		let expected_response = serde_json::json!($expected_response);
+
+		if response != expected_response {
+			panic!(
+				"(left != right) \nleft: {}\nright: {}",
+				serde_json::to_string_pretty(&response).unwrap(),
+				serde_json::to_string_pretty(&expected_response).unwrap()
+				);
+			}
+	};
 }

--- a/apiwallet/src/api.rs
+++ b/apiwallet/src/api.rs
@@ -51,7 +51,7 @@ use easy_jsonrpc;
 
 const USER_MESSAGE_MAX_LEN: usize = 256;
 
-/// Public definition used to generate jsonrpc api.
+/// Public definition used to generate jsonrpc api for APIOwner.
 #[easy_jsonrpc::rpc]
 pub trait OwnerApi {
 	/**
@@ -373,8 +373,8 @@ pub trait OwnerApi {
 	/**
 	Networked version of [APIOwner::post_tx](struct.APIOwner.html#method.post_tx).
 
-
-	```
+	```no_run
+    # // This test currently fails on travis
 	# grin_apiwallet::doctest_helper_json_rpc_owner_assert_response!(
 	{
 		"jsonrpc": "2.0",
@@ -1454,8 +1454,9 @@ where
 	}
 }
 
+/// Public definition used to generate jsonrpc api for APIForeign.
 #[easy_jsonrpc::rpc]
-trait ForeignApi {
+pub trait ForeignApi {
 	/**
 	Networked version of [APIForeign::build_coinbase](struct.APIForeign.html#method.build_coinbase).
 
@@ -1466,12 +1467,21 @@ trait ForeignApi {
 	{
 		"jsonrpc": "2.0",
 		"method": "build_coinbase",
-		"params": [],
+		"params": [
+            {
+                "fees": 0,
+            	"height": 0,
+                "key_id": null
+            }
+        ],
 		"id": 1
 	},
 	{
 		"jsonrpc": "2.0",
 		"result": {
+            "Err": {
+                "CallbackImpl": "Error opening wallet"
+            }
 		},
 		"id": 1
 	}
@@ -1490,12 +1500,32 @@ trait ForeignApi {
 	{
 		"jsonrpc": "2.0",
 		"method": "verify_slate_messages",
-		"params": [],
+		"params": [
+            {
+    			"amount": 0,
+    			"fee": 0,
+    			"height": 0,
+    			"id": "414bad48-3386-4fa7-8483-72384c886ba3",
+    			"lock_height": 0,
+    			"num_participants": 2,
+    			"participant_data": [],
+    			"tx": {
+    				"body": {
+    					"inputs": [],
+    					"kernels": [],
+    					"outputs": []
+    				},
+    				"offset": "0000000000000000000000000000000000000000000000000000000000000000"
+    			},
+    			"version": 1
+		    }
+        ],
 		"id": 1
 	},
 	{
 		"jsonrpc": "2.0",
 		"result": {
+            "Ok": null
 		},
 		"id": 1
 	}
@@ -1514,12 +1544,36 @@ trait ForeignApi {
 	{
 		"jsonrpc": "2.0",
 		"method": "receive_tx",
-		"params": [],
+		"params": [
+            {
+    			"amount": 0,
+    			"fee": 0,
+    			"height": 0,
+    			"id": "414bad48-3386-4fa7-8483-72384c886ba3",
+    			"lock_height": 0,
+    			"num_participants": 2,
+    			"participant_data": [],
+    			"tx": {
+    				"body": {
+    					"inputs": [],
+    					"kernels": [],
+    					"outputs": []
+    				},
+    				"offset": "0000000000000000000000000000000000000000000000000000000000000000"
+    			},
+    			"version": 1
+		    },
+            null,
+            null
+        ],
 		"id": 1
 	},
 	{
 		"jsonrpc": "2.0",
 		"result": {
+            "Err": {
+                "CallbackImpl": "Error opening wallet"
+            }
 		},
 		"id": 1
 	}
@@ -1722,7 +1776,7 @@ macro_rules! doctest_helper_json_rpc_foreign_assert_response {
 			request: serde_json::Value,
 		) -> Result<Option<serde_json::Value>, String> {
 			use easy_jsonrpc::Handler;
-			use grin_apiwallet::api::{APIOwner, OwnerApi};
+			use grin_apiwallet::api::{APIForeign, ForeignApi};
 			use grin_keychain::ExtKeychain;
 			use grin_refwallet::{HTTPNodeClient, LMDBBackend, WalletBackend};
 			use grin_util::Mutex;
@@ -1746,8 +1800,8 @@ macro_rules! doctest_helper_json_rpc_foreign_assert_response {
 						LMDBBackend::new(wallet_config.clone(), "", node_client)
 							.map_err(|e| format!("{:#?}", e))?,
 					));
-				let api_foreign = APIForeign::new(wallet);
-				let foreign_api = &api_foreign as &dyn OwnerApi;
+				let api_foreign = *APIForeign::new(wallet);
+				let foreign_api = &api_foreign as &dyn ForeignApi;
 				Ok(foreign_api.handle_request(request))
 				}
 			}

--- a/libwallet/src/error.rs
+++ b/libwallet/src/error.rs
@@ -30,7 +30,7 @@ pub struct Error {
 }
 
 /// Wallet errors, mostly wrappers around underlying crypto or I/O errors.
-#[derive(Clone, Eq, PartialEq, Debug, Fail)]
+#[derive(Clone, Eq, PartialEq, Debug, Fail, Serialize, Deserialize)]
 pub enum ErrorKind {
 	/// Not enough funds
 	#[fail(

--- a/refwallet/src/controller.rs
+++ b/refwallet/src/controller.rs
@@ -18,10 +18,10 @@
 use crate::adapters::util::get_versioned_slate;
 use crate::adapters::{FileWalletCommAdapter, HTTPWalletCommAdapter, KeybaseWalletCommAdapter};
 use crate::api::{ApiServer, BasicAuthMiddleware, Handler, ResponseFuture, Router, TLSConfig};
+use crate::apiwallet::api::{APIForeign, APIOwner};
 use crate::core::core;
 use crate::core::core::Transaction;
 use crate::keychain::Keychain;
-use crate::apiwallet::api::{APIForeign, APIOwner};
 use crate::libwallet::slate::{Slate, VersionedSlate};
 use crate::libwallet::types::{
 	CbData, NodeClient, OutputData, SendTXArgs, TxLogEntry, WalletBackend, WalletInfo,
@@ -271,7 +271,7 @@ where
 	pub fn retrieve_summary_info(
 		&self,
 		req: &Request<Body>,
-		mut api: APIOwner<T, C, K>,
+		api: APIOwner<T, C, K>,
 	) -> Result<(bool, WalletInfo), Error> {
 		let mut minimum_confirmations = 1; // TODO - default needed here
 		let params = parse_params(req);
@@ -289,7 +289,7 @@ where
 	pub fn node_height(
 		&self,
 		_req: &Request<Body>,
-		mut api: APIOwner<T, C, K>,
+		api: APIOwner<T, C, K>,
 	) -> Result<(u64, bool), Error> {
 		api.node_height()
 	}
@@ -319,7 +319,7 @@ where
 	pub fn issue_send_tx(
 		&self,
 		req: Request<Body>,
-		mut api: APIOwner<T, C, K>,
+		api: APIOwner<T, C, K>,
 	) -> Box<dyn Future<Item = Slate, Error = Error> + Send> {
 		Box::new(parse_body(req).and_then(move |args: SendTXArgs| {
 			let result = api.initiate_tx(
@@ -382,7 +382,7 @@ where
 	pub fn finalize_tx(
 		&self,
 		req: Request<Body>,
-		mut api: APIOwner<T, C, K>,
+		api: APIOwner<T, C, K>,
 	) -> Box<dyn Future<Item = Slate, Error = Error> + Send> {
 		Box::new(
 			parse_body(req).and_then(move |mut slate| match api.finalize_tx(&mut slate) {
@@ -398,7 +398,7 @@ where
 	pub fn cancel_tx(
 		&self,
 		req: Request<Body>,
-		mut api: APIOwner<T, C, K>,
+		api: APIOwner<T, C, K>,
 	) -> Box<dyn Future<Item = (), Error = Error> + Send> {
 		let params = parse_params(&req);
 		if let Some(id_string) = params.get("id") {
@@ -652,7 +652,7 @@ where
 	fn build_coinbase(
 		&self,
 		req: Request<Body>,
-		mut api: APIForeign<T, C, K>,
+		api: APIForeign<T, C, K>,
 	) -> Box<dyn Future<Item = CbData, Error = Error> + Send> {
 		Box::new(parse_body(req).and_then(move |block_fees| api.build_coinbase(&block_fees)))
 	}
@@ -660,7 +660,7 @@ where
 	fn receive_tx(
 		&self,
 		req: Request<Body>,
-		mut api: APIForeign<T, C, K>,
+		api: APIForeign<T, C, K>,
 	) -> Box<dyn Future<Item = VersionedSlate, Error = Error> + Send> {
 		Box::new(parse_body(req).and_then(
 			//TODO: No way to insert a message from the params


### PR DESCRIPTION
This pr adds the ability to generate jsonrpc handlers for APIOwner and APIForeign via proceedural macro.

Since the handler generator is not specific to grin I've split it into its own crate, easy-jsonrpc. easy-jsonrpc provides a macro, jsonrpc_server, which decorates a trait definition and generates appropriate jsonrpc handlers.

This pr introduces a new trait, OwnerAPI, which the existing struct APIOwner implements. A new trait was added for several reasons:

1. APIOwner contains methods that don't make sense in a jsonrpc context; method signatures needed to be changed.
    - Mutable out parameters don't work in an rpc
    - Functions involving callbacks don't work in an rpc
    - Rpc methods can't return Result<, Error> because Error is not serializable. Result<, ErrorKind> is used instead
    - fn new() never needs to be called from a remote client
2. Adding a new trait is not a breaking change. Changing APIOwner to an rpc compliant trait would require refactoring other parts of grin-wallet.
3. APIOwner can trivially implement OwnerAPI (perhaps WalletBackend could implement it as well)

## TODO

- [x] Add doctests for every OwnerAPI method, OwnerAPI doctests will serve as jsonrpc documentation. See `OwnerAPI::accounts` for an example.
- [x] Add links to docs for APIOwner methods from each OwnerAPI method doc
- [ ] Implement fn initiate_tx(..) -> Result<(Slate, OutputLockFn<W, C, K>), Error> without using a callback
- [ ] Implement fn tx_lock_outputs(.. , mut lock_fn: OutputLockFn<W, C, K>) -> Result<(), Error> without using a callback
- [ ] Implement issue_send_tx like in refwallet/src/controller.rs
- [ ] Either A) Depreciate APIOwner in favor of OwnerAPI, or B) Rename OwnerAPI to be more decriptive e.g. RPCAPIOwner
- [ ] Add ForeignAPI trait
- [x] Add jsonrpc_client macro for typed client generation
- [ ] Possibly automatically generate clients in other languages such as javascript

## Blockers

This pr requires https://github.com/mimblewimble/grin/pull/2596, which implements serde for error types.