### PR TITLE
Store payment outputs in wallet database

### DIFF
--- a/apiwallet/src/api.rs
+++ b/apiwallet/src/api.rs
@@ -37,16 +37,16 @@ use uuid::Uuid;
 use crate::core::core::hash::Hashed;
 use crate::core::core::Transaction;
 use crate::core::ser;
-use crate::libwallet::internal::{keys, tx, updater};
 use crate::keychain::{Identifier, Keychain};
+use crate::libwallet::internal::{keys, tx, updater};
 use crate::libwallet::slate::Slate;
 use crate::libwallet::types::{
-	AcctPathMapping, BlockFees, CbData, NodeClient, OutputData, OutputLockFn, PaymentData, TxLogEntry,
-	TxLogEntryType, TxWrapper, WalletBackend, WalletInfo,
+	AcctPathMapping, BlockFees, CbData, NodeClient, OutputData, OutputLockFn, PaymentData,
+	TxLogEntry, TxLogEntryType, TxWrapper, WalletBackend, WalletInfo,
 };
+use crate::libwallet::{Error, ErrorKind};
 use crate::util;
 use crate::util::secp::{pedersen, ContextFlag, Secp256k1};
-use crate::libwallet::{Error, ErrorKind};
 
 const USER_MESSAGE_MAX_LEN: usize = 256;
 

--- a/apiwallet/src/api.rs
+++ b/apiwallet/src/api.rs
@@ -369,22 +369,20 @@ where
 	/// Returns a list of payment outputs from the active account in the wallet.
 	pub fn retrieve_payments(
 		&self,
-		include_spent: bool,
 		refresh_from_node: bool,
 		tx_id: Option<Uuid>,
 	) -> Result<(bool, Vec<(PaymentData, pedersen::Commitment)>), Error> {
 		let mut w = self.wallet.lock();
 		w.open_with_credentials()?;
 
-		let validated = false;
+		let mut validated = false;
 		if refresh_from_node {
-			//todo: need refresh or not?
-			//validated = self.update_outputs(&mut w, false);
+			validated = self.update_outputs(&mut w, false);
 		}
 
 		let res = Ok((
 			validated,
-			updater::retrieve_payments(&mut *w, include_spent, tx_id)?,
+			updater::retrieve_payments(&mut *w, tx_id)?,
 		));
 
 		w.close()?;

--- a/libwallet/src/internal/restore.rs
+++ b/libwallet/src/internal/restore.rs
@@ -215,6 +215,7 @@ where
 		lock_height: output.lock_height,
 		is_coinbase: output.is_coinbase,
 		tx_log_entry: Some(log_id),
+		slate_id: None,
 	});
 
 	let max_child_index = found_parents.get(&parent_key_id).unwrap().clone();
@@ -283,7 +284,7 @@ where
 
 	// Now, get all outputs owned by this wallet (regardless of account)
 	let wallet_outputs = {
-		let res = updater::retrieve_outputs(&mut *wallet, true, None, None)?;
+		let res = updater::retrieve_outputs(&mut *wallet, true, None, None, None)?;
 		res
 	};
 

--- a/libwallet/src/internal/selection.rs
+++ b/libwallet/src/internal/selection.rs
@@ -64,6 +64,7 @@ where
 	let mut context = Context::new(
 		wallet.keychain().secp(),
 		blinding.secret_key(&keychain.secp()).unwrap(),
+		parent_key_id.clone(),
 	);
 
 	// Store our private identifiers for each input
@@ -134,6 +135,7 @@ where
 						lock_height: 0,
 						is_coinbase: false,
 						tx_log_entry: Some(log_id),
+						slate_id: Some(slate_id.clone()),
 					})?;
 				}
 				batch.save_tx_log_entry(t.clone(), &parent_key_id)?;
@@ -179,6 +181,7 @@ where
 		blinding
 			.secret_key(wallet.keychain().clone().secp())
 			.unwrap(),
+		parent_key_id.clone(),
 	);
 
 	context.add_output(&key_id, &None);
@@ -210,6 +213,7 @@ where
 				lock_height: 0,
 				is_coinbase: false,
 				tx_log_entry: Some(log_id),
+				slate_id: Some(slate_id),
 			})?;
 			batch.save_tx_log_entry(t, &parent_key_id)?;
 			batch.commit()?;

--- a/libwallet/src/internal/selection.rs
+++ b/libwallet/src/internal/selection.rs
@@ -64,7 +64,7 @@ where
 	let mut context = Context::new(
 		wallet.keychain().secp(),
 		blinding.secret_key(&keychain.secp()).unwrap(),
-		parent_key_id.clone(),
+		Some(parent_key_id.clone()),
 	);
 
 	// Store our private identifiers for each input
@@ -181,7 +181,7 @@ where
 		blinding
 			.secret_key(wallet.keychain().clone().secp())
 			.unwrap(),
-		parent_key_id.clone(),
+		Some(parent_key_id.clone()),
 	);
 
 	context.add_output(&key_id, &None);

--- a/libwallet/src/internal/tx.rs
+++ b/libwallet/src/internal/tx.rs
@@ -244,7 +244,7 @@ where
 			slate_id: slate.id,
 		})?;
 	} else {
-		warn!("complete_tx - impossible here! how come a tx is finalized without a payment output?");
+		warn!("complete_tx - no 'payment' output! is this a sending to self for test purpose?");
 	}
 	batch.commit()?;
 	Ok(())

--- a/libwallet/src/internal/tx.rs
+++ b/libwallet/src/internal/tx.rs
@@ -19,9 +19,11 @@ use uuid::Uuid;
 use crate::internal::{selection, updater};
 use crate::keychain::{Identifier, Keychain};
 use crate::slate::Slate;
-use crate::types::{Context, NodeClient, OutputLockFn, OutputStatus, PaymentData, TxLogEntryType, WalletBackend};
-use crate::util::to_hex;
+use crate::types::{
+	Context, NodeClient, OutputLockFn, OutputStatus, PaymentData, TxLogEntryType, WalletBackend,
+};
 use crate::util::secp::pedersen;
+use crate::util::to_hex;
 use crate::{Error, ErrorKind};
 
 /// Creates a new slate for a transaction, can be called by anyone involved in
@@ -200,14 +202,23 @@ where
 	slate.finalize(wallet.keychain())?;
 
 	// Get the change output/s from database
-	let changes = updater::retrieve_outputs(wallet, false, None, Some(slate.id), Some(&context.parent_key_id))?;
-	let change_commits = changes.iter().map(|(_,c)| c.clone()).collect::<Vec<pedersen::Commitment>>();
+	let changes = updater::retrieve_outputs(
+		wallet,
+		false,
+		None,
+		Some(slate.id),
+		Some(&context.parent_key_id),
+	)?;
+	let change_commits = changes
+		.iter()
+		.map(|(_, c)| c.clone())
+		.collect::<Vec<pedersen::Commitment>>();
 
 	// Find the payment output/s
 	let mut outputs = Vec::new();
 	for output in slate.tx.outputs() {
-		if change_commits.contains( &output.commit ) {
-			outputs.insert( 0, output.commit.clone() );
+		if change_commits.contains(&output.commit) {
+			outputs.insert(0, output.commit.clone());
 		}
 	}
 

--- a/libwallet/src/internal/tx.rs
+++ b/libwallet/src/internal/tx.rs
@@ -233,15 +233,19 @@ where
 	)?;
 	// todo: only one payment output at this moment, but in case we have multiple in the future,
 	// 	then we need find a way for multiple PaymentData, especially for "value"
-	let payment_output = to_hex(outputs.first().clone().unwrap().as_ref().to_vec());
-	batch.save_payment(PaymentData {
-		commit: payment_output,
-		value: slate.amount,
-		status: OutputStatus::Unconfirmed,
-		height: slate.height,
-		lock_height: 0,
-		slate_id: slate.id,
-	})?;
+	if outputs.len() > 0 {
+		let payment_output = to_hex(outputs.first().clone().unwrap().as_ref().to_vec());
+		batch.save_payment(PaymentData {
+			commit: payment_output,
+			value: slate.amount,
+			status: OutputStatus::Unconfirmed,
+			height: slate.height,
+			lock_height: 0,
+			slate_id: slate.id,
+		})?;
+	} else {
+		warn!("complete_tx - impossible here! how come a tx is finalized without a payment output?");
+	}
 	batch.commit()?;
 	Ok(())
 }

--- a/libwallet/src/internal/tx.rs
+++ b/libwallet/src/internal/tx.rs
@@ -201,13 +201,15 @@ where
 	// Final transaction can be built by anyone at this stage
 	slate.finalize(wallet.keychain())?;
 
+	let parent_key_id = context.parent_key_id.as_ref().map(|x| x);
+
 	// Get the change output/s from database
 	let changes = updater::retrieve_outputs(
 		wallet,
 		false,
 		None,
 		Some(slate.id),
-		Some(&context.parent_key_id),
+		parent_key_id,
 	)?;
 	let change_commits = changes
 		.iter()

--- a/libwallet/src/internal/tx.rs
+++ b/libwallet/src/internal/tx.rs
@@ -20,7 +20,8 @@ use crate::internal::{selection, updater};
 use crate::keychain::{Identifier, Keychain};
 use crate::slate::Slate;
 use crate::types::{
-	Context, NodeClient, OutputLockFn, OutputStatus, PaymentCommits, PaymentData, TxLogEntryType, WalletBackend,
+	Context, NodeClient, OutputLockFn, OutputStatus, PaymentCommits, PaymentData, TxLogEntryType,
+	WalletBackend,
 };
 use crate::util::secp::pedersen;
 use crate::util::to_hex;
@@ -204,13 +205,7 @@ where
 	let parent_key_id = context.parent_key_id.as_ref().map(|x| x);
 
 	// Get the change output/s from database
-	let changes = updater::retrieve_outputs(
-		wallet,
-		false,
-		None,
-		Some(slate.id),
-		parent_key_id,
-	)?;
+	let changes = updater::retrieve_outputs(wallet, false, None, Some(slate.id), parent_key_id)?;
 	let change_commits = changes
 		.iter()
 		.map(|(_, c)| c.clone())
@@ -226,10 +221,16 @@ where
 
 	// sender save the payment output
 	let mut batch = wallet.batch()?;
-	batch.save_payment_commits(&slate.id, PaymentCommits {
-		commits: outputs.iter().map(|c| to_hex(c.as_ref().to_vec())).collect::<Vec<String>>(),
-		slate_id: slate.id,
-	})?;
+	batch.save_payment_commits(
+		&slate.id,
+		PaymentCommits {
+			commits: outputs
+				.iter()
+				.map(|c| to_hex(c.as_ref().to_vec()))
+				.collect::<Vec<String>>(),
+			slate_id: slate.id,
+		},
+	)?;
 	// todo: only one payment output at this moment, but in case we have multiple in the future,
 	// 	then we need find a way for multiple PaymentData, especially for "value"
 	let payment_output = to_hex(outputs.first().clone().unwrap().as_ref().to_vec());

--- a/libwallet/src/internal/updater.rs
+++ b/libwallet/src/internal/updater.rs
@@ -27,8 +27,8 @@ use crate::error::{Error, ErrorKind};
 use crate::internal::keys;
 use crate::keychain::{Identifier, Keychain};
 use crate::types::{
-	BlockFees, CbData, NodeClient, OutputData, OutputStatus, PaymentData, TxLogEntry, TxLogEntryType,
-	WalletBackend, WalletInfo,
+	BlockFees, CbData, NodeClient, OutputData, OutputStatus, PaymentData, TxLogEntry,
+	TxLogEntryType, WalletBackend, WalletInfo,
 };
 use crate::util;
 use crate::util::secp::pedersen;
@@ -98,10 +98,10 @@ pub fn retrieve_payments<T: ?Sized, C, K>(
 	show_spent: bool,
 	tx_id: Option<Uuid>,
 ) -> Result<Vec<(PaymentData, pedersen::Commitment)>, Error>
-	where
-		T: WalletBackend<C, K>,
-		C: NodeClient,
-		K: Keychain,
+where
+	T: WalletBackend<C, K>,
+	C: NodeClient,
+	K: Keychain,
 {
 	// just read the wallet here, no need for a write lock
 	let mut outputs = wallet
@@ -120,7 +120,8 @@ pub fn retrieve_payments<T: ?Sized, C, K>(
 	let res = outputs
 		.into_iter()
 		.map(|out| {
-			let commit = pedersen::Commitment::from_vec(util::from_hex(out.commit.clone()).unwrap());
+			let commit =
+				pedersen::Commitment::from_vec(util::from_hex(out.commit.clone()).unwrap());
 			(out, commit)
 		})
 		.collect();
@@ -458,7 +459,7 @@ where
 			OutputStatus::Locked => {
 				locked_total += out.value;
 			}
-			OutputStatus::Spent => {},
+			OutputStatus::Spent => {}
 			OutputStatus::Confirmed => {}
 		}
 	}

--- a/libwallet/src/types.rs
+++ b/libwallet/src/types.rs
@@ -492,7 +492,7 @@ impl fmt::Display for OutputStatus {
 /// Holds the context for a single aggsig transaction
 pub struct Context {
 	/// parent_key_id
-	pub parent_key_id: Identifier,
+	pub parent_key_id: Option<Identifier>,
 	/// Secret key (of which public is shared)
 	pub sec_key: SecretKey,
 	/// Secret nonce (of which public is shared)
@@ -508,7 +508,7 @@ pub struct Context {
 
 impl Context {
 	/// Create a new context with defaults
-	pub fn new(secp: &secp::Secp256k1, sec_key: SecretKey, parent_key_id: Identifier) -> Context {
+	pub fn new(secp: &secp::Secp256k1, sec_key: SecretKey, parent_key_id: Option<Identifier>) -> Context {
 		Context {
 			parent_key_id: parent_key_id,
 			sec_key: sec_key,

--- a/libwallet/src/types.rs
+++ b/libwallet/src/types.rs
@@ -508,7 +508,11 @@ pub struct Context {
 
 impl Context {
 	/// Create a new context with defaults
-	pub fn new(secp: &secp::Secp256k1, sec_key: SecretKey, parent_key_id: Option<Identifier>) -> Context {
+	pub fn new(
+		secp: &secp::Secp256k1,
+		sec_key: SecretKey,
+		parent_key_id: Option<Identifier>,
+	) -> Context {
 		Context {
 			parent_key_id: parent_key_id,
 			sec_key: sec_key,

--- a/libwallet/src/types.rs
+++ b/libwallet/src/types.rs
@@ -389,7 +389,6 @@ impl ser::Readable for PaymentData {
 }
 
 impl PaymentData {
-
 	/// How many confirmations has this output received?
 	/// If height == 0 then we are either Unconfirmed or the output was
 	/// cut-through

--- a/libwallet/tests/libwallet.rs
+++ b/libwallet/tests/libwallet.rs
@@ -17,9 +17,9 @@ use self::core::libtx::{aggsig, proof};
 use self::keychain::{BlindSum, BlindingFactor, ExtKeychain, Keychain};
 use self::util::secp;
 use self::util::secp::key::{PublicKey, SecretKey};
-use grin_libwallet::types::Context;
 use grin_core as core;
 use grin_keychain as keychain;
+use grin_libwallet::types::Context;
 use grin_util as util;
 use rand::thread_rng;
 

--- a/libwallet/tests/libwallet.rs
+++ b/libwallet/tests/libwallet.rs
@@ -71,7 +71,7 @@ fn aggsig_sender_receiver_interaction() {
 
 		let blind = blinding_factor.secret_key(&keychain.secp()).unwrap();
 
-		s_cx = Context::new(&keychain.secp(), blind);
+		s_cx = Context::new(&keychain.secp(), blind, None);
 		s_cx.get_public_keys(&keychain.secp())
 	};
 
@@ -85,7 +85,7 @@ fn aggsig_sender_receiver_interaction() {
 		// let blind = blind_sum.secret_key(&keychain.secp())?;
 		let blind = keychain.derive_key(0, &key_id).unwrap();
 
-		rx_cx = Context::new(&keychain.secp(), blind);
+		rx_cx = Context::new(&keychain.secp(), blind, None);
 		let (pub_excess, pub_nonce) = rx_cx.get_public_keys(&keychain.secp());
 		rx_cx.add_output(&key_id, &None);
 
@@ -288,7 +288,7 @@ fn aggsig_sender_receiver_interaction_offset() {
 
 		let blind = blinding_factor.secret_key(&keychain.secp()).unwrap();
 
-		s_cx = Context::new(&keychain.secp(), blind);
+		s_cx = Context::new(&keychain.secp(), blind, None);
 		s_cx.get_public_keys(&keychain.secp())
 	};
 
@@ -301,7 +301,7 @@ fn aggsig_sender_receiver_interaction_offset() {
 
 		let blind = keychain.derive_key(0, &key_id).unwrap();
 
-		rx_cx = Context::new(&keychain.secp(), blind);
+		rx_cx = Context::new(&keychain.secp(), blind, None);
 		let (pub_excess, pub_nonce) = rx_cx.get_public_keys(&keychain.secp());
 		rx_cx.add_output(&key_id, &None);
 

--- a/refwallet/src/command.rs
+++ b/refwallet/src/command.rs
@@ -444,7 +444,8 @@ pub fn txs(
 
 			// should only be one here, but just in case
 			for tx in &txs {
-				let (_, outputs) = api.retrieve_payments(g_args.show_spent, true, tx.tx_slate_id)?;
+				let (_, outputs) =
+					api.retrieve_payments(g_args.show_spent, true, tx.tx_slate_id)?;
 				if outputs.len() > 0 {
 					display::payments(&g_args.account, height, validated, outputs, dark_scheme)?;
 				}

--- a/refwallet/src/command.rs
+++ b/refwallet/src/command.rs
@@ -399,6 +399,20 @@ pub fn outputs(
 	Ok(())
 }
 
+pub fn payments(
+	wallet: Arc<Mutex<WalletInst<impl NodeClient + 'static, keychain::ExtKeychain>>>,
+	g_args: &GlobalArgs,
+	dark_scheme: bool,
+) -> Result<(), Error> {
+	controller::owner_single_use(wallet.clone(), |api| {
+		let (height, _) = api.node_height()?;
+		let (validated, outputs) = api.retrieve_payments(g_args.show_spent, true, None)?;
+		display::payments(&g_args.account, height, validated, outputs, dark_scheme)?;
+		Ok(())
+	})?;
+	Ok(())
+}
+
 /// Txs command args
 pub struct TxsArgs {
 	pub id: Option<u32>,
@@ -427,9 +441,18 @@ pub fn txs(
 		if args.id.is_some() {
 			let (_, outputs) = api.retrieve_outputs(true, false, args.id)?;
 			display::outputs(&g_args.account, height, validated, outputs, dark_scheme)?;
+
 			// should only be one here, but just in case
-			for tx in txs {
-				display::tx_messages(&tx, dark_scheme)?;
+			for tx in &txs {
+				let (_, outputs) = api.retrieve_payments(g_args.show_spent, true, tx.tx_slate_id)?;
+				if outputs.len() > 0 {
+					display::payments(&g_args.account, height, validated, outputs, dark_scheme)?;
+				}
+			}
+
+			// should only be one here, but just in case
+			for tx in &txs {
+				display::tx_messages(tx, dark_scheme)?;
 			}
 		};
 		Ok(())

--- a/refwallet/src/command.rs
+++ b/refwallet/src/command.rs
@@ -406,7 +406,7 @@ pub fn payments(
 ) -> Result<(), Error> {
 	controller::owner_single_use(wallet.clone(), |api| {
 		let (height, _) = api.node_height()?;
-		let (validated, outputs) = api.retrieve_payments(g_args.show_spent, true, None)?;
+		let (validated, outputs) = api.retrieve_payments(true, None)?;
 		display::payments(&g_args.account, height, validated, outputs, dark_scheme)?;
 		Ok(())
 	})?;
@@ -445,7 +445,7 @@ pub fn txs(
 			// should only be one here, but just in case
 			for tx in &txs {
 				let (_, outputs) =
-					api.retrieve_payments(g_args.show_spent, true, tx.tx_slate_id)?;
+					api.retrieve_payments(true, tx.tx_slate_id)?;
 				if outputs.len() > 0 {
 					display::payments(&g_args.account, height, validated, outputs, dark_scheme)?;
 				}

--- a/refwallet/src/display.rs
+++ b/refwallet/src/display.rs
@@ -157,7 +157,11 @@ pub fn payments(
 		let status = format!("{}", out.status);
 
 		let num_confirmations = format!("{}", out.num_confirmations(cur_height));
-		let value = format!("{}", core::amount_to_hr_string(out.value, false));
+		let value = if out.value == 0 {
+			"unknown".to_owned()
+		} else {
+			format!("{}", core::amount_to_hr_string(out.value, false))
+		};
 		let slate_id = format!("{}", out.slate_id);
 
 		if dark_background_color_scheme {

--- a/refwallet/src/display.rs
+++ b/refwallet/src/display.rs
@@ -14,7 +14,7 @@
 
 use crate::core::core::{self, amount_to_hr_string};
 use crate::core::global;
-use crate::libwallet::types::{AcctPathMapping, OutputData, OutputStatus, TxLogEntry, WalletInfo};
+use crate::libwallet::types::{AcctPathMapping, OutputData, OutputStatus, PaymentData, TxLogEntry, WalletInfo};
 use crate::libwallet::Error;
 use crate::util;
 use crate::util::secp::pedersen;
@@ -100,6 +100,83 @@ pub fn outputs(
 				bFB->num_confirmations,
 				bFG->value,
 				bFD->tx,
+			]);
+		}
+	}
+
+	table.set_format(*prettytable::format::consts::FORMAT_NO_COLSEP);
+	table.printstd();
+	println!();
+
+	if !validated {
+		println!(
+			"\nWARNING: Wallet failed to verify data. \
+			 The above is from local cache and possibly invalid! \
+			 (is your `grin server` offline or broken?)"
+		);
+	}
+	Ok(())
+}
+
+/// Display payments in a pretty way
+pub fn payments(
+	account: &str,
+	cur_height: u64,
+	validated: bool,
+	outputs: Vec<(PaymentData, pedersen::Commitment)>,
+	dark_background_color_scheme: bool,
+) -> Result<(), Error> {
+	let title = format!(
+		"Wallet Payments - Account '{}' - Block Height: {}",
+		account, cur_height
+	);
+	println!();
+	let mut t = term::stdout().unwrap();
+	t.fg(term::color::MAGENTA).unwrap();
+	writeln!(t, "{}", title).unwrap();
+	t.reset().unwrap();
+
+	let mut table = table!();
+
+	table.set_titles(row![
+		bMG->"Output Commitment",
+		bMG->"Block Height",
+		bMG->"Locked Until",
+		bMG->"Status",
+		bMG->"# Confirms",
+		bMG->"Value",
+		bMG->"Shared Transaction Id"
+	]);
+
+	for (out, commit) in outputs {
+		let commit = format!("{}", util::to_hex(commit.as_ref().to_vec()));
+		let height = format!("{}", out.height);
+		let lock_height = format!("{}", out.lock_height);
+		let status = format!("{}", out.status);
+
+		let num_confirmations = format!("{}", out.num_confirmations(cur_height));
+		let value = format!("{}", core::amount_to_hr_string(out.value, false));
+		let slate_id = format!("{}", out.slate_id);
+
+		if dark_background_color_scheme {
+			table.add_row(row![
+				bFC->commit,
+				bFB->height,
+				bFB->lock_height,
+				bFR->status,
+				bFB->num_confirmations,
+				bFG->value,
+				bFC->slate_id,
+			]);
+		} else {
+			table.add_row(row![
+				bFD->commit,
+				bFB->height,
+				bFB->lock_height,
+				bFR->status,
+				bFB->num_confirmations,
+				bFG->value,
+				bFD->slate_id,
 			]);
 		}
 	}

--- a/refwallet/src/display.rs
+++ b/refwallet/src/display.rs
@@ -14,7 +14,9 @@
 
 use crate::core::core::{self, amount_to_hr_string};
 use crate::core::global;
-use crate::libwallet::types::{AcctPathMapping, OutputData, OutputStatus, PaymentData, TxLogEntry, WalletInfo};
+use crate::libwallet::types::{
+	AcctPathMapping, OutputData, OutputStatus, PaymentData, TxLogEntry, WalletInfo,
+};
 use crate::libwallet::Error;
 use crate::util;
 use crate::util::secp::pedersen;

--- a/refwallet/src/lmdb_wallet.rs
+++ b/refwallet/src/lmdb_wallet.rs
@@ -42,6 +42,7 @@ pub const DB_DIR: &'static str = "db";
 pub const TX_SAVE_DIR: &'static str = "saved_txs";
 
 const OUTPUT_PREFIX: u8 = 'o' as u8;
+const PAYMENT_PREFIX: u8 = 'P' as u8;
 const DERIV_PREFIX: u8 = 'd' as u8;
 const CONFIRMED_HEIGHT_PREFIX: u8 = 'c' as u8;
 const PRIVATE_TX_CONTEXT_PREFIX: u8 = 'p' as u8;
@@ -238,6 +239,10 @@ where
 		Box::new(self.db.iter(&[OUTPUT_PREFIX]).unwrap())
 	}
 
+	fn payment_log_iter<'a>(&'a self) -> Box<dyn Iterator<Item = PaymentData> + 'a> {
+		Box::new(self.db.iter(&[PAYMENT_PREFIX]).unwrap())
+	}
+
 	fn get_tx_log_entry(&self, u: &Uuid) -> Result<Option<TxLogEntry>, Error> {
 		let key = to_key(TX_LOG_ENTRY_PREFIX, &mut u.as_bytes().to_vec());
 		self.db.get_ser(&key).map_err(|e| e.into())
@@ -380,12 +385,23 @@ where
 	}
 
 	fn save(&mut self, out: OutputData) -> Result<(), Error> {
-		// Save the output data to the db.
+		// Save the self output data to the db.
 		{
 			let key = match out.mmr_index {
 				Some(i) => to_key_u64(OUTPUT_PREFIX, &mut out.key_id.to_bytes().to_vec(), i),
 				None => to_key(OUTPUT_PREFIX, &mut out.key_id.to_bytes().to_vec()),
 			};
+			self.db.borrow().as_ref().unwrap().put_ser(&key, &out)?;
+		}
+
+		Ok(())
+	}
+
+	fn save_payment(&mut self, out: PaymentData) -> Result<(), Error> {
+		// Save the payment output data to the db.
+		{
+			let commit = out.commit.clone();
+			let key = to_key(PAYMENT_PREFIX, &mut commit.as_bytes().to_vec());
 			self.db.borrow().as_ref().unwrap().put_ser(&key, &out)?;
 		}
 

--- a/refwallet/src/lmdb_wallet.rs
+++ b/refwallet/src/lmdb_wallet.rs
@@ -43,6 +43,7 @@ pub const TX_SAVE_DIR: &'static str = "saved_txs";
 
 const OUTPUT_PREFIX: u8 = 'o' as u8;
 const PAYMENT_PREFIX: u8 = 'P' as u8;
+const PAYMENT_COMMITS_PREFIX: u8 = 'Q' as u8;
 const DERIV_PREFIX: u8 = 'd' as u8;
 const CONFIRMED_HEIGHT_PREFIX: u8 = 'c' as u8;
 const PRIVATE_TX_CONTEXT_PREFIX: u8 = 'p' as u8;
@@ -239,6 +240,16 @@ where
 		Box::new(self.db.iter(&[OUTPUT_PREFIX]).unwrap())
 	}
 
+	fn get_payment_log_commits(&self, u: &Uuid) -> Result<Option<PaymentCommits>, Error> {
+		let key = to_key(PAYMENT_COMMITS_PREFIX, &mut u.as_bytes().to_vec());
+		self.db.get_ser(&key).map_err(|e| e.into())
+	}
+
+	fn get_payment_log_entry(&self, commit: String) -> Result<Option<PaymentData>, Error> {
+		let key = to_key(PAYMENT_PREFIX, &mut commit.as_bytes().to_vec());
+		self.db.get_ser(&key).map_err(|e| e.into())
+	}
+
 	fn payment_log_iter<'a>(&'a self) -> Box<dyn Iterator<Item = PaymentData> + 'a> {
 		Box::new(self.db.iter(&[PAYMENT_PREFIX]).unwrap())
 	}
@@ -397,6 +408,16 @@ where
 		Ok(())
 	}
 
+	fn save_payment_commits(&mut self, u: &Uuid, commits: PaymentCommits) -> Result<(), Error> {
+		// Save the payment commits list data to the db.
+		{
+			let key = to_key(PAYMENT_COMMITS_PREFIX, &mut u.as_bytes().to_vec());
+			self.db.borrow().as_ref().unwrap().put_ser(&key, &commits)?;
+		}
+
+		Ok(())
+	}
+
 	fn save_payment(&mut self, out: PaymentData) -> Result<(), Error> {
 		// Save the payment output data to the db.
 		{
@@ -416,6 +437,24 @@ where
 		option_to_not_found(
 			self.db.borrow().as_ref().unwrap().get_ser(&key),
 			&format!("Key ID: {}", id),
+		)
+		.map_err(|e| e.into())
+	}
+
+	fn get_payment_commits(&self, u: &Uuid) -> Result<PaymentCommits, Error> {
+		let key = to_key(PAYMENT_COMMITS_PREFIX, &mut u.as_bytes().to_vec());
+		option_to_not_found(
+			self.db.borrow().as_ref().unwrap().get_ser(&key),
+			&format!("slate_id: {}", u.to_string()),
+		)
+		.map_err(|e| e.into())
+	}
+
+	fn get_payment_log_entry(&self, commit: String) -> Result<PaymentData, Error> {
+		let key = to_key(PAYMENT_PREFIX, &mut commit.as_bytes().to_vec());
+		option_to_not_found(
+			self.db.borrow().as_ref().unwrap().get_ser(&key),
+			&format!("key: {:?}", commit),
 		)
 		.map_err(|e| e.into())
 	}

--- a/refwallet/tests/transaction.rs
+++ b/refwallet/tests/transaction.rs
@@ -397,6 +397,16 @@ fn tx_rollback(test_dir: &str) -> Result<(), libwallet::Error> {
 		assert_eq!(outputs.len(), 3);
 		assert_eq!(locked_count, 2);
 		assert_eq!(unconfirmed_count, 1);
+		// check the payments are as expected
+		unconfirmed_count = 0;
+		let (_, payments) = api.retrieve_payments(false, tx.unwrap().tx_slate_id)?;
+		for (p, _) in &payments {
+			if p.status == OutputStatus::Unconfirmed {
+				unconfirmed_count = unconfirmed_count + 1;
+			}
+		}
+		assert_eq!(payments.len(), 1);
+		assert_eq!(unconfirmed_count, 1);
 
 		Ok(())
 	})?;
@@ -417,6 +427,16 @@ fn tx_rollback(test_dir: &str) -> Result<(), libwallet::Error> {
 		}
 		assert_eq!(outputs.len(), 1);
 		assert_eq!(unconfirmed_count, 1);
+		// check the payments are as expected: receiver don't have this.
+		unconfirmed_count = 0;
+		let (_, payments) = api.retrieve_payments(false, tx.unwrap().tx_slate_id)?;
+		for (p, _) in &payments {
+			if p.status == OutputStatus::Unconfirmed {
+				unconfirmed_count = unconfirmed_count + 1;
+			}
+		}
+		assert_eq!(payments.len(), 0);
+		assert_eq!(unconfirmed_count, 0);
 		let (refreshed, wallet2_info) = api.retrieve_summary_info(true, 1)?;
 		assert!(refreshed);
 		assert_eq!(wallet2_info.amount_currently_spendable, 0,);

--- a/src/bin/cmd/wallet_args.rs
+++ b/src/bin/cmd/wallet_args.rs
@@ -603,6 +603,14 @@ pub fn wallet_command(
 			&global_wallet_args,
 			wallet_config.dark_background_color_scheme.unwrap_or(true),
 		),
+		("payments", Some(_)) => {
+			info!("payments command received");
+			command::payments(
+			inst_wallet(),
+			&global_wallet_args,
+			wallet_config.dark_background_color_scheme.unwrap_or(true),
+			)
+		}
 		("txs", Some(args)) => {
 			let a = arg_parse!(parse_txs_args(&args));
 			command::txs(

--- a/src/bin/cmd/wallet_args.rs
+++ b/src/bin/cmd/wallet_args.rs
@@ -606,9 +606,9 @@ pub fn wallet_command(
 		("payments", Some(_)) => {
 			info!("payments command received");
 			command::payments(
-			inst_wallet(),
-			&global_wallet_args,
-			wallet_config.dark_background_color_scheme.unwrap_or(true),
+				inst_wallet(),
+				&global_wallet_args,
+				wallet_config.dark_background_color_scheme.unwrap_or(true),
 			)
 		}
 		("txs", Some(args)) => {

--- a/src/bin/cmd/wallet_tests.rs
+++ b/src/bin/cmd/wallet_tests.rs
@@ -498,6 +498,12 @@ mod wallet_tests {
 		];
 		execute_command(&app, test_dir, "wallet1", &client1, arg_vec)?;
 
+        // payments
+        let arg_vec = vec![
+            "grin-wallet", "-p", "password", "-a", "mining", "payments",
+        ];
+        execute_command(&app, test_dir, "wallet1", &client1, arg_vec)?;
+
 		// let logging finish
 		thread::sleep(Duration::from_millis(200));
 		Ok(())

--- a/src/bin/grin-wallet.yml
+++ b/src/bin/grin-wallet.yml
@@ -158,7 +158,9 @@ subcommands:
             short: f
             long: fluff
   - outputs:
-      about: Raw wallet output info (list of outputs)
+      about: Raw wallet self owned output info (list of outputs)
+  - payments:
+      about: Raw wallet payment output info (list of outputs)
   - txs:
       about: Display transaction information
       args:


### PR DESCRIPTION
Currently we only store self owned outputs in wallet database, i.e. our `change` output/s or received output.

The `payment` output (i.e. the one we send to others) is not stored on local wallet database.

But in some use cases, we need query the output which we sent.

So, in this PR, we add the following command:
1. wallet payments list. for example:
```
$ grin-wallet --floonet payments

----------------------------------------------------------------------------------------------------------------------------------------------------------------------------
 Output Commitment                                                   Block Height  Locked Until  Status       # Confirms  Value        Shared Transaction Id 
============================================================================================================================================================================
 08623af49f7ca6180f626a2c6f4f23f994dbc5b5699d9d7c17aae67bf61d121d76  75747         0             Unconfirmed  0           2.400000000  388f604a-d67c-4b7d-95b9-1a8ae50a4586 
----------------------------------------------------------------------------------------------------------------------------------------------------------------------------
 08792a45a9f41fa87afc1fd8b6ed671a4b42cf92c0e019511131af2847f83ab99d  75747         0             Confirmed    1           2.300000000  ce5d4a8b-94bc-4b1a-a1d7-d108aea6e4a0 
----------------------------------------------------------------------------------------------------------------------------------------------------------------------------
 08b6fa0628393acec5ab84e7f1ae99464d919908a24d580c1f10757c7c1bbac264  75726         0             Confirmed    22          2.200000000  f7ecacf0-73eb-4957-86d0-404ba4d43e3b 
----------------------------------------------------------------------------------------------------------------------------------------------------------------------------
```

2. `txs -i n` will show the payment output also. for example:
```
$ ./grin-wallet --floonet txs -i 16

Transaction Log - Account 'default' - Block Height: 75747
----------------------------------------------------------------------------------------------------------------------------------------------------------------------
 Id  Type     Shared Transaction Id                 Creation Time        Confirmed?  Confirmation Time    Num.    Num.     Amount    Amount   Fee    Net         Tx  
                                                                                                          Inputs  Outputs  Credited  Debited         Difference  Data 
======================================================================================================================================================================
 16  Sent Tx  ce5d4a8b-94bc-4b1a-a1d7-d108aea6e4a0  2019-03-08 09:03:56  true        2019-03-08 09:07:25  1       1        41.295    43.603   0.008  -2.308      Yes 
----------------------------------------------------------------------------------------------------------------------------------------------------------------------


Wallet Outputs - Account 'default' - Block Height: 75747
-------------------------------------------------------------------------------------------------------------------------------------------------------------
 Output Commitment                                                   MMR Index  Block Height  Locked Until  Status   Coinbase?  # Confirms  Value         Tx 
=============================================================================================================================================================
 0935fe8926aff61e6837188578cd1b45779ebaff3f237ef546c2c5b01b2836f3b0  None       75726         0             Spent    false      22          43.603000000  16 
-------------------------------------------------------------------------------------------------------------------------------------------------------------
 09815b2f7d67dcd6985ce349ecf9dcac2a260d9495e1162245745c63b4a056cd42  None       75747         0             Unspent  false      1           41.295000000  16 
-------------------------------------------------------------------------------------------------------------------------------------------------------------


Wallet Payments - Account 'default' - Block Height: 75747
--------------------------------------------------------------------------------------------------------------------------------------------------------------------------
 Output Commitment                                                   Block Height  Locked Until  Status     # Confirms  Value        Shared Transaction Id 
==========================================================================================================================================================================
 08792a45a9f41fa87afc1fd8b6ed671a4b42cf92c0e019511131af2847f83ab99d  75747         0             Confirmed  1           2.300000000  ce5d4a8b-94bc-4b1a-a1d7-d108aea6e4a0 
--------------------------------------------------------------------------------------------------------------------------------------------------------------------------


Transaction Messages - Transaction '16'
--------------------------------------------------------------------------------------------------------
 Participant Id  Message  Public Key                                                          Signature 
========================================================================================================
 0               None     038bb25be3340b577857e3bc3b6d8e26aff1334438f5b06969a24b2790fa865af5  None 
--------------------------------------------------------------------------------------------------------
 1               None     036166f585700419c60e1a28f56d61c9eace8328ccda1bad71cdef044e37d97cdc  None 
--------------------------------------------------------------------------------------------------------
```



