### PR TITLE
add .hooks for rustfmt

### DIFF
--- a/.hooks/pre-commit
+++ b/.hooks/pre-commit
@@ -1,0 +1,59 @@
+#!/usr/bin/env bash
+
+# Copyright 2018 The Grin Developers
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+rustfmt --version &>/dev/null
+if [ $? != 0 ]; then
+	printf "[pre_commit] \033[0;31merror\033[0m: \"rustfmt\" not available. \n"
+	printf "[pre_commit] \033[0;31merror\033[0m: rustfmt can be installed via - \n"
+	printf "[pre_commit] $ rustup component add rustfmt-preview \n"
+	exit 1
+fi
+
+result=0
+problem_files=()
+
+printf "[pre_commit] rustfmt "
+
+for file in $(git diff --name-only --cached); do
+	if [ ${file: -3} == ".rs" ]; then
+		# first collect all the files that need reformatting
+		rustfmt --check $file &>/dev/null
+		if [ $? != 0 ]; then
+			problem_files+=($file)
+			result=1
+		fi
+	fi
+done
+
+# now reformat all the files that need reformatting
+for file in ${problem_files[@]}; do
+	rustfmt $file
+done
+
+# and let the user know what just happened (and which files were affected)
+printf "\033[0;32mok\033[0m \n"
+if [ $result != 0 ]; then
+	# printf "\033[0;31mrustfmt\033[0m \n"
+	printf "[pre_commit] the following files were rustfmt'd (not yet committed): \n"
+
+	for file in ${problem_files[@]}; do
+		printf "\033[0;31m    $file\033[0m \n"
+	done
+fi
+
+exit 0
+# to actually fail the build on rustfmt failure -
+# exit $result


### PR DESCRIPTION
`.hooks` folder is left behind when draw it from grin repo, which is needed for rustfmt hook.