### PR TITLE
default to using a Plain kernel with no lock_height

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,6 +10,5 @@ target
 grin.log
 wallet.seed
 test_output
-wallet_data
-wallet/db
+wallet*
 .idea/

--- a/libwallet/src/internal/tx.rs
+++ b/libwallet/src/internal/tx.rs
@@ -38,7 +38,11 @@ where
 	let mut slate = Slate::blank(num_participants);
 	slate.amount = amount;
 	slate.height = current_height;
-	slate.lock_height = current_height;
+
+	// Set the lock_height explicitly to 0 here.
+	// This will generate a Plain kernel (rather than a HeightLocked kernel).
+	slate.lock_height = 0;
+
 	Ok(slate)
 }
 


### PR DESCRIPTION
We currently default to generating `HeightLocked` transaction kernels (locked at current block height).
This PR changes this to default to generating `Plain` transaction kernels.

We are exploring making the lock_height optional on kernels (it is not included in the tx kernel hash for `Plain` kernels).
First step toward making them truly optional is to stop using them where we don't need to. 

Eventually we will be able to reduce storage and bandwidth costs (a little) by only including the `lock_height` on `HeightLocked` kernels.

This PR leverages the existing grin behavior - a `Plain` tx kernel default to a `lock_height` of 0 (as we need something to store in the u64 lock_height). This is excluded from the kernel hash for `Plain` kernels.

TODO - 
- [ ] Some reasonably extensive testing to make sure `Plain` kernels are usable across all wallet and node scenarios.



