### PR TITLE
feat(ci): introduce code coverage

### DIFF
--- a/.ci/general-jobs
+++ b/.ci/general-jobs
@@ -25,4 +25,11 @@ case "${CI_JOB}" in
             cd - > /dev/null || exit 1
         done
         ;;
+
+    "coverage")
+        RUSTFLAGS="--cfg procmacro2_semver_exempt" \
+        cargo install --force cargo-tarpaulin
+        cargo tarpaulin --verbose --out Xml
+        bash <(curl -s https://codecov.io/bash)
+        ;;
 esac

--- a/.travis.yml
+++ b/.travis.yml
@@ -50,6 +50,7 @@ env:
     - RUST_FLAGS="-C debug-assertions"
 
 matrix:
+  fast_finish: true
   include:
     - os: linux
       env: CI_JOB="test"        CI_JOB_ARGS="config libwallet api"
@@ -61,6 +62,12 @@ matrix:
       env: CI_JOB="release"     CI_JOB_ARGS=
 #    - os: windows
 #      env: CI_JOB="release"     CI_JOB_ARGS=
+    # Coverage with Tarpaulin requires nightly Rust and currently is Linux only.
+    - os: linux
+      rust: nightly
+      env: CI_JOB="coverage"    CI_JOB_ARGS=
+  allow_failures:
+    - env: CI_JOB="coverage"    CI_JOB_ARGS=
 
 script: .ci/general-jobs
 


### PR DESCRIPTION
The build result is determined as soon as all the required jobs
finish, while the "coverage" job may continue and may even fail.