### PR TITLE
Final Owner API Changes

### DIFF
--- a/api/src/foreign_rpc.rs
+++ b/api/src/foreign_rpc.rs
@@ -423,9 +423,7 @@ pub fn run_doctest_foreign(
 			max_outputs: 500,
 			num_change_outputs: 1,
 			selection_strategy_is_use_all: true,
-			message: None,
-			target_slate_version: None,
-			send_args: None,
+			..Default::default()
 		};
 		let slate = api_impl::owner::initiate_tx(&mut *w, args, true).unwrap();
 		println!("INIT SLATE");

--- a/api/src/foreign_rpc.rs
+++ b/api/src/foreign_rpc.rs
@@ -427,12 +427,7 @@ pub fn run_doctest_foreign(
 			target_slate_version: None,
 			send_args: None,
 		};
-		let slate = api_impl::owner::initiate_tx(
-			&mut *w, 
-			args,
-			true,
-		)
-		.unwrap();
+		let slate = api_impl::owner::initiate_tx(&mut *w, args, true).unwrap();
 		println!("INIT SLATE");
 		// Spit out slate for input to finalize_tx
 		println!("{}", serde_json::to_string_pretty(&slate).unwrap());

--- a/api/src/foreign_rpc.rs
+++ b/api/src/foreign_rpc.rs
@@ -16,7 +16,7 @@
 
 use crate::keychain::Keychain;
 use crate::libwallet::slate::Slate;
-use crate::libwallet::types::{BlockFees, CbData, NodeClient, WalletBackend};
+use crate::libwallet::types::{BlockFees, CbData, InitTxArgs, NodeClient, WalletBackend};
 use crate::libwallet::ErrorKind;
 use crate::Foreign;
 use easy_jsonrpc;
@@ -416,14 +416,21 @@ pub fn run_doctest_foreign(
 		let amount = 60_000_000_000;
 		let mut w = wallet1.lock();
 		w.open_with_credentials().unwrap();
+		let args = InitTxArgs {
+			src_acct_name: None,
+			amount,
+			minimum_confirmations: 2,
+			max_outputs: 500,
+			num_change_outputs: 1,
+			selection_strategy_is_use_all: true,
+			message: None,
+			target_slate_version: None,
+			send_args: None,
+		};
 		let slate = api_impl::owner::initiate_tx(
-			&mut *w, None,   // account
-			amount, // amount
-			2,      // minimum confirmations
-			500,    // max outputs
-			1,      // num change outputs
-			true,   // select all outputs
-			None, None, true,
+			&mut *w, 
+			args,
+			true,
 		)
 		.unwrap();
 		println!("INIT SLATE");

--- a/api/src/lib.rs
+++ b/api/src/lib.rs
@@ -25,8 +25,8 @@
 use grin_wallet_util::grin_core as core;
 use grin_wallet_util::grin_keychain as keychain;
 use grin_wallet_util::grin_util as util;
-extern crate grin_wallet_libwallet as libwallet;
 extern crate grin_wallet_impls as impls;
+extern crate grin_wallet_libwallet as libwallet;
 
 extern crate failure_derive;
 extern crate serde_json;

--- a/api/src/lib.rs
+++ b/api/src/lib.rs
@@ -26,6 +26,7 @@ use grin_wallet_util::grin_core as core;
 use grin_wallet_util::grin_keychain as keychain;
 use grin_wallet_util::grin_util as util;
 extern crate grin_wallet_libwallet as libwallet;
+extern crate grin_wallet_impls as impls;
 
 extern crate failure_derive;
 extern crate serde_json;

--- a/api/src/owner.rs
+++ b/api/src/owner.rs
@@ -25,8 +25,8 @@ use crate::keychain::{Identifier, Keychain};
 use crate::libwallet::api_impl::owner;
 use crate::libwallet::slate::Slate;
 use crate::libwallet::types::{
-	AcctPathMapping, NodeClient, NodeHeightResult, OutputCommitMapping, TxEstimation, TxLogEntry, WalletBackend,
-	WalletInfo,
+	AcctPathMapping, NodeClient, NodeHeightResult, OutputCommitMapping, TxEstimation, TxLogEntry,
+	WalletBackend, WalletInfo,
 };
 use crate::libwallet::Error;
 

--- a/api/src/owner.rs
+++ b/api/src/owner.rs
@@ -467,8 +467,7 @@ where
 	/// 	num_change_outputs: 1,
 	/// 	selection_strategy_is_use_all: true,
 	/// 	message: Some("Have some Grins. Love, Yeastplume".to_owned()),
-	/// 	target_slate_version: None,
-	/// 	send_args: None,
+	/// 	..Default::default()
 	/// };
 	/// let result = api_owner.initiate_tx(
 	/// 	args,
@@ -518,19 +517,19 @@ where
 	/// # grin_wallet_api::doctest_helper_setup_doc_env!(wallet, wallet_config);
 	///
 	/// let mut api_owner = Owner::new(wallet.clone());
-	/// let amount = 2_000_000_000;
-	///
-	/// // Attempt to create a transaction using the 'default' account
+	/// let args = InitTxArgs {
+	/// 	src_acct_name: None,
+	/// 	amount: 2_000_000_000,
+	/// 	minimum_confirmations: 10,
+	/// 	max_outputs: 500,
+	/// 	num_change_outputs: 1,
+	/// 	selection_strategy_is_use_all: true,
+	/// 	message: Some("Remember to lock this when we're happy this is sent".to_owned()),
+	/// 	..Default::default()
+	/// };
 	/// let result = api_owner.initiate_tx(
-	///		None,
-	///		amount,     // amount
-	///		10,         // minimum confirmations
-	///		500,        // max outputs
-	///		1,          // num change outputs
-	///		true,       // select all outputs
-	///		Some("Remember to lock when we're happy this is sent".to_owned()),
-	///		None,       // Use the default slate version
-	///	);
+	/// 	args,
+	/// );
 	///
 	/// if let Ok(slate) = result {
 	///		// Send slate somehow
@@ -576,19 +575,19 @@ where
 	/// # grin_wallet_api::doctest_helper_setup_doc_env!(wallet, wallet_config);
 	///
 	/// let mut api_owner = Owner::new(wallet.clone());
-	/// let amount = 2_000_000_000;
-	///
-	/// // Attempt to create a transaction using the 'default' account
+	/// let args = InitTxArgs {
+	/// 	src_acct_name: None,
+	/// 	amount: 2_000_000_000,
+	/// 	minimum_confirmations: 10,
+	/// 	max_outputs: 500,
+	/// 	num_change_outputs: 1,
+	/// 	selection_strategy_is_use_all: true,
+	/// 	message: Some("Finalize this tx now".to_owned()),
+	/// 	..Default::default()
+	/// };
 	/// let result = api_owner.initiate_tx(
-	///		None,
-	///		amount,     // amount
-	///		10,         // minimum confirmations
-	///		500,        // max outputs
-	///		1,          // num change outputs
-	///		true,       // select all outputs
-	///		Some("Finalize this tx now".to_owned()),
-	///		None,       // Use the default slate version
-	///	);
+	/// 	args,
+	/// );
 	///
 	/// if let Ok(slate) = result {
 	///		// Send slate somehow
@@ -633,19 +632,19 @@ where
 	/// # grin_wallet_api::doctest_helper_setup_doc_env!(wallet, wallet_config);
 	///
 	/// let mut api_owner = Owner::new(wallet.clone());
-	/// let amount = 2_000_000_000;
-	///
-	/// // Attempt to create a transaction using the 'default' account
+	/// let args = InitTxArgs {
+	/// 	src_acct_name: None,
+	/// 	amount: 2_000_000_000,
+	/// 	minimum_confirmations: 10,
+	/// 	max_outputs: 500,
+	/// 	num_change_outputs: 1,
+	/// 	selection_strategy_is_use_all: true,
+	/// 	message: Some("Post this tx".to_owned()),
+	/// 	..Default::default()
+	/// };
 	/// let result = api_owner.initiate_tx(
-	///		None,
-	///		amount,     // amount
-	///		10,         // minimum confirmations
-	///		500,        // max outputs
-	///		1,          // num change outputs
-	///		true,       // select all outputs
-	///		Some("Finalize this tx now".to_owned()),
-	///		None,       // Use the default slate version
-	///	);
+	/// 	args,
+	/// );
 	///
 	/// if let Ok(slate) = result {
 	///		// Send slate somehow
@@ -694,19 +693,19 @@ where
 	/// # grin_wallet_api::doctest_helper_setup_doc_env!(wallet, wallet_config);
 	///
 	/// let mut api_owner = Owner::new(wallet.clone());
-	/// let amount = 2_000_000_000;
-	///
-	/// // Attempt to create a transaction using the 'default' account
+	/// let args = InitTxArgs {
+	/// 	src_acct_name: None,
+	/// 	amount: 2_000_000_000,
+	/// 	minimum_confirmations: 10,
+	/// 	max_outputs: 500,
+	/// 	num_change_outputs: 1,
+	/// 	selection_strategy_is_use_all: true,
+	/// 	message: Some("Cancel this tx".to_owned()),
+	/// 	..Default::default()
+	/// };
 	/// let result = api_owner.initiate_tx(
-	///		None,
-	///		amount,     // amount
-	///		10,         // minimum confirmations
-	///		500,        // max outputs
-	///		1,          // num change outputs
-	///		true,       // select all outputs
-	///		Some("Cancel this tx".to_owned()),
-	///		None,       // Use the default slate version
-	///	);
+	/// 	args,
+	/// );
 	///
 	/// if let Ok(slate) = result {
 	///		// Send slate somehow
@@ -787,19 +786,19 @@ where
 	/// # grin_wallet_api::doctest_helper_setup_doc_env!(wallet, wallet_config);
 	///
 	/// let mut api_owner = Owner::new(wallet.clone());
-	/// let amount = 2_000_000_000;
-	///
-	/// // Attempt to create a transaction using the 'default' account
+	/// let args = InitTxArgs {
+	/// 	src_acct_name: None,
+	/// 	amount: 2_000_000_000,
+	/// 	minimum_confirmations: 10,
+	/// 	max_outputs: 500,
+	/// 	num_change_outputs: 1,
+	/// 	selection_strategy_is_use_all: true,
+	/// 	message: Some("Just verify messages".to_owned()),
+	/// 	..Default::default()
+	/// };
 	/// let result = api_owner.initiate_tx(
-	///		None,
-	///		amount,     // amount
-	///		10,         // minimum confirmations
-	///		500,        // max outputs
-	///		1,          // num change outputs
-	///		true,       // select all outputs
-	///		Some("Finalize this tx now".to_owned()),
-	///		None,       // Use the default slate version
-	///	);
+	/// 	args,
+	/// );
 	///
 	/// if let Ok(slate) = result {
 	///		// Send slate somehow

--- a/api/src/owner.rs
+++ b/api/src/owner.rs
@@ -25,8 +25,8 @@ use crate::keychain::{Identifier, Keychain};
 use crate::libwallet::api_impl::owner;
 use crate::libwallet::slate::Slate;
 use crate::libwallet::types::{
-	AcctPathMapping, NodeClient, NodeHeightResult, InitTxArgs, OutputCommitMapping, TxEstimation, TxLogEntry,
-	WalletBackend, WalletInfo,
+	AcctPathMapping, InitTxArgs, NodeClient, NodeHeightResult, OutputCommitMapping, TxEstimation,
+	TxLogEntry, WalletBackend, WalletInfo,
 };
 use crate::libwallet::Error;
 
@@ -482,17 +482,10 @@ where
 	/// }
 	/// ```
 
-	pub fn initiate_tx(
-		&self,
-		args: InitTxArgs,
-	) -> Result<Slate, Error> {
+	pub fn initiate_tx(&self, args: InitTxArgs) -> Result<Slate, Error> {
 		let mut w = self.wallet.lock();
 		w.open_with_credentials()?;
-		let res = owner::initiate_tx(
-			&mut *w,
-			args,
-			self.doctest_mode,
-		);
+		let res = owner::initiate_tx(&mut *w, args, self.doctest_mode);
 		w.close()?;
 		res
 	}

--- a/api/src/owner.rs
+++ b/api/src/owner.rs
@@ -25,7 +25,7 @@ use crate::keychain::{Identifier, Keychain};
 use crate::libwallet::api_impl::owner;
 use crate::libwallet::slate::Slate;
 use crate::libwallet::types::{
-	AcctPathMapping, InitTxArgs, NodeClient, NodeHeightResult, OutputCommitMapping, TxEstimate,
+	AcctPathMapping, InitTxArgs, NodeClient, NodeHeightResult, OutputCommitMapping,
 	TxLogEntry, WalletBackend, WalletInfo,
 };
 use crate::libwallet::Error;
@@ -486,52 +486,6 @@ where
 		let mut w = self.wallet.lock();
 		w.open_with_credentials()?;
 		let res = owner::initiate_tx(&mut *w, args, self.doctest_mode);
-		w.close()?;
-		res
-	}
-
-	/// Estimates the amount to be locked and fee for the transaction without creating one.
-	///
-	/// # Arguments
-	/// * `args` - [`InitTxArgs`](../grin_wallet_libwallet/types/struct.InitTxArgs.html),
-	/// transaction initialization arguments. See struct documentation for further detail.
-	///
-	/// # Returns
-	/// * a result containing a
-	/// [`TxEstimate`](../grin_wallet_libwallet/types/struct.TxEstimate.html)
-	///
-	/// # Example
-	/// Set up as in [new](struct.Owner.html#method.new) method above.
-	/// ```
-	/// # grin_wallet_api::doctest_helper_setup_doc_env!(wallet, wallet_config);
-	///
-	/// let mut api_owner = Owner::new(wallet.clone());
-	///
-	/// // Estimate transaction using default account
-	/// let args = InitTxArgs {
-	/// 	src_acct_name: None,
-	/// 	amount: 2_000_000_000,
-	/// 	minimum_confirmations: 10,
-	/// 	max_outputs: 500,
-	/// 	num_change_outputs: 1,
-	/// 	selection_strategy_is_use_all: true,
-	/// 	message: None,
-	/// 	target_slate_version: None,
-	/// 	send_args: None,
-	/// };
-	/// let result = api_owner.estimate_initiate_tx(
-	/// 	args,
-	/// );
-	///
-	/// if let Ok(est) = result {
-	///		// ...
-	/// }
-	/// ```
-
-	pub fn estimate_initiate_tx(&self, args: InitTxArgs) -> Result<TxEstimate, Error> {
-		let mut w = self.wallet.lock();
-		w.open_with_credentials()?;
-		let res = owner::estimate_initiate_tx(&mut *w, args);
 		w.close()?;
 		res
 	}

--- a/api/src/owner.rs
+++ b/api/src/owner.rs
@@ -25,7 +25,7 @@ use crate::keychain::{Identifier, Keychain};
 use crate::libwallet::api_impl::owner;
 use crate::libwallet::slate::Slate;
 use crate::libwallet::types::{
-	AcctPathMapping, InitTxArgs, NodeClient, NodeHeightResult, OutputCommitMapping, TxEstimation,
+	AcctPathMapping, InitTxArgs, NodeClient, NodeHeightResult, OutputCommitMapping, TxEstimate,
 	TxLogEntry, WalletBackend, WalletInfo,
 };
 use crate::libwallet::Error;
@@ -493,11 +493,12 @@ where
 	/// Estimates the amount to be locked and fee for the transaction without creating one.
 	///
 	/// # Arguments
-	/// * As found in [`initiate_tx`](struct.Owner.html#method.initiate_tx) above.
+	/// * `args` - [`InitTxArgs`](../grin_wallet_libwallet/types/struct.InitTxArgs.html),
+	/// transaction initialization arguments. See struct documentation for further detail.
 	///
 	/// # Returns
 	/// * a result containing a
-	/// [`TxEstimation`](../grin_wallet_libwallet/types/struct.TxEstimation.html)
+	/// [`TxEstimate`](../grin_wallet_libwallet/types/struct.TxEstimate.html)
 	///
 	/// # Example
 	/// Set up as in [new](struct.Owner.html#method.new) method above.
@@ -505,17 +506,22 @@ where
 	/// # grin_wallet_api::doctest_helper_setup_doc_env!(wallet, wallet_config);
 	///
 	/// let mut api_owner = Owner::new(wallet.clone());
-	/// let amount = 2_000_000_000;
 	///
 	/// // Estimate transaction using default account
+	/// let args = InitTxArgs {
+	/// 	src_acct_name: None,
+	/// 	amount: 2_000_000_000,
+	/// 	minimum_confirmations: 10,
+	/// 	max_outputs: 500,
+	/// 	num_change_outputs: 1,
+	/// 	selection_strategy_is_use_all: true,
+	/// 	message: None,
+	/// 	target_slate_version: None,
+	/// 	send_args: None,
+	/// };
 	/// let result = api_owner.estimate_initiate_tx(
-	///		None,
-	///		amount,     // amount
-	///		10,         // minimum confirmations
-	///		500,        // max outputs
-	///		1,          // num change outputs
-	///		true,       // select all outputs
-	///	);
+	/// 	args,
+	/// );
 	///
 	/// if let Ok(est) = result {
 	///		// ...
@@ -524,23 +530,13 @@ where
 
 	pub fn estimate_initiate_tx(
 		&self,
-		src_acct_name: Option<&str>,
-		amount: u64,
-		minimum_confirmations: u64,
-		max_outputs: usize,
-		num_change_outputs: usize,
-		selection_strategy_is_use_all: bool,
-	) -> Result<TxEstimation, Error> {
+		args: InitTxArgs,
+	) -> Result<TxEstimate, Error> {
 		let mut w = self.wallet.lock();
 		w.open_with_credentials()?;
 		let res = owner::estimate_initiate_tx(
 			&mut *w,
-			src_acct_name,
-			amount,
-			minimum_confirmations,
-			max_outputs,
-			num_change_outputs,
-			selection_strategy_is_use_all,
+			args,
 		);
 		w.close()?;
 		res

--- a/api/src/owner.rs
+++ b/api/src/owner.rs
@@ -21,8 +21,8 @@ use std::sync::Arc;
 use uuid::Uuid;
 
 use crate::core::core::Transaction;
-use crate::keychain::{Identifier, Keychain};
 use crate::impls::{HTTPWalletCommAdapter, KeybaseWalletCommAdapter};
+use crate::keychain::{Identifier, Keychain};
 use crate::libwallet::api_impl::owner;
 use crate::libwallet::slate::Slate;
 use crate::libwallet::types::{
@@ -501,7 +501,9 @@ where
 		match send_args {
 			Some(sa) => {
 				match sa.method.as_ref() {
-					"http" => slate = HTTPWalletCommAdapter::new().send_tx_sync(&sa.dest, &slate)?,
+					"http" => {
+						slate = HTTPWalletCommAdapter::new().send_tx_sync(&sa.dest, &slate)?
+					}
 					"keybase" => {
 						//TODO: in case of keybase, the response might take 60s and leave the service hanging
 						slate = KeybaseWalletCommAdapter::new().send_tx_sync(&sa.dest, &slate)?;
@@ -523,7 +525,7 @@ where
 					self.post_tx(&slate.tx, sa.fluff)?;
 				}
 				Ok(slate)
-			},
+			}
 			None => Ok(slate),
 		}
 	}

--- a/api/src/owner.rs
+++ b/api/src/owner.rs
@@ -528,16 +528,10 @@ where
 	/// }
 	/// ```
 
-	pub fn estimate_initiate_tx(
-		&self,
-		args: InitTxArgs,
-	) -> Result<TxEstimate, Error> {
+	pub fn estimate_initiate_tx(&self, args: InitTxArgs) -> Result<TxEstimate, Error> {
 		let mut w = self.wallet.lock();
 		w.open_with_credentials()?;
-		let res = owner::estimate_initiate_tx(
-			&mut *w,
-			args,
-		);
+		let res = owner::estimate_initiate_tx(&mut *w, args);
 		w.close()?;
 		res
 	}

--- a/api/src/owner.rs
+++ b/api/src/owner.rs
@@ -25,8 +25,8 @@ use crate::keychain::{Identifier, Keychain};
 use crate::libwallet::api_impl::owner;
 use crate::libwallet::slate::Slate;
 use crate::libwallet::types::{
-	AcctPathMapping, InitTxArgs, NodeClient, NodeHeightResult, OutputCommitMapping,
-	TxLogEntry, WalletBackend, WalletInfo,
+	AcctPathMapping, InitTxArgs, NodeClient, NodeHeightResult, OutputCommitMapping, TxLogEntry,
+	WalletBackend, WalletInfo,
 };
 use crate::libwallet::Error;
 

--- a/api/src/owner_rpc.rs
+++ b/api/src/owner_rpc.rs
@@ -19,7 +19,7 @@ use crate::core::core::Transaction;
 use crate::keychain::{Identifier, Keychain};
 use crate::libwallet::slate::Slate;
 use crate::libwallet::types::{
-	AcctPathMapping, NodeClient, OutputCommitMapping, TxEstimation, TxLogEntry, WalletBackend,
+	AcctPathMapping, NodeClient, NodeHeightResult, OutputCommitMapping, TxEstimation, TxLogEntry, WalletBackend,
 	WalletInfo,
 };
 use crate::libwallet::ErrorKind;
@@ -1029,17 +1029,17 @@ pub trait OwnerRpc {
 		"id": 1,
 		"jsonrpc": "2.0",
 		"result": {
-			"Ok": [
-				5,
-				true
-			]
+			"Ok": {
+				"height": "5",
+				"updated_from_node": true
+			}
 		}
 	}
 	# "#
 	# , 5, false, false, false);
 	```
 	 */
-	fn node_height(&self) -> Result<(u64, bool), ErrorKind>;
+	fn node_height(&self) -> Result<NodeHeightResult, ErrorKind>;
 }
 
 impl<W: ?Sized, C, K> OwnerRpc for Owner<W, C, K>
@@ -1165,7 +1165,7 @@ where
 		Owner::check_repair(self, delete_unconfirmed).map_err(|e| e.kind())
 	}
 
-	fn node_height(&self) -> Result<(u64, bool), ErrorKind> {
+	fn node_height(&self) -> Result<NodeHeightResult, ErrorKind> {
 		Owner::node_height(self).map_err(|e| e.kind())
 	}
 }

--- a/api/src/owner_rpc.rs
+++ b/api/src/owner_rpc.rs
@@ -19,8 +19,8 @@ use crate::core::core::Transaction;
 use crate::keychain::{Identifier, Keychain};
 use crate::libwallet::slate::Slate;
 use crate::libwallet::types::{
-	AcctPathMapping, InitTxArgs, NodeClient, NodeHeightResult, OutputCommitMapping,
-	TxLogEntry, WalletBackend, WalletInfo,
+	AcctPathMapping, InitTxArgs, NodeClient, NodeHeightResult, OutputCommitMapping, TxLogEntry,
+	WalletBackend, WalletInfo,
 };
 use crate::libwallet::ErrorKind;
 use crate::Owner;

--- a/api/src/owner_rpc.rs
+++ b/api/src/owner_rpc.rs
@@ -19,8 +19,8 @@ use crate::core::core::Transaction;
 use crate::keychain::{Identifier, Keychain};
 use crate::libwallet::slate::Slate;
 use crate::libwallet::types::{
-	AcctPathMapping, NodeClient, NodeHeightResult, OutputCommitMapping, TxEstimation, TxLogEntry, WalletBackend,
-	WalletInfo,
+	AcctPathMapping, NodeClient, NodeHeightResult, OutputCommitMapping, TxEstimation, TxLogEntry,
+	WalletBackend, WalletInfo,
 };
 use crate::libwallet::ErrorKind;
 use crate::Owner;

--- a/api/src/owner_rpc.rs
+++ b/api/src/owner_rpc.rs
@@ -444,10 +444,7 @@ pub trait OwnerRpc {
 	# ,4, false, false, false);
 	```
 	 */
-	fn estimate_initiate_tx(
-		&self,
-		args: InitTxArgs,
-	) -> Result<TxEstimate, ErrorKind>;
+	fn estimate_initiate_tx(&self, args: InitTxArgs) -> Result<TxEstimate, ErrorKind>;
 
 	/**
 	Networked version of [Owner::tx_lock_outputs](struct.Owner.html#method.tx_lock_outputs).
@@ -1100,15 +1097,8 @@ where
 		Owner::initiate_tx(self, args).map_err(|e| e.kind())
 	}
 
-	fn estimate_initiate_tx(
-		&self,
-		args: InitTxArgs,
-	) -> Result<TxEstimate, ErrorKind> {
-		Owner::estimate_initiate_tx(
-			self,
-			args,
-		)
-		.map_err(|e| e.kind())
+	fn estimate_initiate_tx(&self, args: InitTxArgs) -> Result<TxEstimate, ErrorKind> {
+		Owner::estimate_initiate_tx(self, args).map_err(|e| e.kind())
 	}
 
 	fn finalize_tx(&self, mut slate: Slate) -> Result<Slate, ErrorKind> {

--- a/api/src/owner_rpc.rs
+++ b/api/src/owner_rpc.rs
@@ -19,7 +19,7 @@ use crate::core::core::Transaction;
 use crate::keychain::{Identifier, Keychain};
 use crate::libwallet::slate::Slate;
 use crate::libwallet::types::{
-	AcctPathMapping, InitTxArgs, NodeClient, NodeHeightResult, OutputCommitMapping, TxEstimate,
+	AcctPathMapping, InitTxArgs, NodeClient, NodeHeightResult, OutputCommitMapping,
 	TxLogEntry, WalletBackend, WalletInfo,
 };
 use crate::libwallet::ErrorKind;
@@ -403,52 +403,7 @@ pub trait OwnerRpc {
 	fn initiate_tx(&self, args: InitTxArgs) -> Result<Slate, ErrorKind>;
 
 	/**
-	Networked version of [Owner::estimate_initiate_tx](struct.Owner.html#method.estimate_initiate_tx).
-
-
-	```
-	# grin_wallet_api::doctest_helper_json_rpc_owner_assert_response!(
-	# r#"
-	{
-		"jsonrpc": "2.0",
-		"method": "estimate_initiate_tx",
-		"params": {
-			"args": {
-				"src_acct_name": null,
-				"amount": "6000000000",
-				"minimum_confirmations": 2,
-				"max_outputs": 500,
-				"num_change_outputs": 1,
-				"selection_strategy_is_use_all": true,
-				"message": null,
-				"target_slate_version": null,
-				"send_args": null
-			}
-		},
-		"id": 1
-	}
-	# "#
-	# ,
-	# r#"
-	{
-		"id": 1,
-		"jsonrpc": "2.0",
-		"result": {
-			"Ok": {
-				"total": "60000000000",
-				"fee": "8000000"
-			}
-		}
-	}
-	# "#
-	# ,4, false, false, false);
-	```
-	 */
-	fn estimate_initiate_tx(&self, args: InitTxArgs) -> Result<TxEstimate, ErrorKind>;
-
-	/**
 	Networked version of [Owner::tx_lock_outputs](struct.Owner.html#method.tx_lock_outputs).
-
 
 	```
 	# grin_wallet_api::doctest_helper_json_rpc_owner_assert_response!(
@@ -1097,10 +1052,6 @@ where
 		Owner::initiate_tx(self, args).map_err(|e| e.kind())
 	}
 
-	fn estimate_initiate_tx(&self, args: InitTxArgs) -> Result<TxEstimate, ErrorKind> {
-		Owner::estimate_initiate_tx(self, args).map_err(|e| e.kind())
-	}
-
 	fn finalize_tx(&self, mut slate: Slate) -> Result<Slate, ErrorKind> {
 		Owner::finalize_tx(self, &mut slate).map_err(|e| e.kind())
 	}
@@ -1219,9 +1170,7 @@ pub fn run_doctest_owner(
 			max_outputs: 500,
 			num_change_outputs: 1,
 			selection_strategy_is_use_all: true,
-			message: None,
-			target_slate_version: None,
-			send_args: None,
+			..Default::default()
 		};
 		let mut slate = api_impl::owner::initiate_tx(&mut *w, args, true).unwrap();
 		{

--- a/api/src/owner_rpc.rs
+++ b/api/src/owner_rpc.rs
@@ -19,7 +19,7 @@ use crate::core::core::Transaction;
 use crate::keychain::{Identifier, Keychain};
 use crate::libwallet::slate::Slate;
 use crate::libwallet::types::{
-	AcctPathMapping, InitTxArgs, NodeClient, NodeHeightResult, OutputCommitMapping, TxEstimation,
+	AcctPathMapping, InitTxArgs, NodeClient, NodeHeightResult, OutputCommitMapping, TxEstimate,
 	TxLogEntry, WalletBackend, WalletInfo,
 };
 use crate::libwallet::ErrorKind;
@@ -412,7 +412,19 @@ pub trait OwnerRpc {
 	{
 		"jsonrpc": "2.0",
 		"method": "estimate_initiate_tx",
-		"params": [null, 6000000000, 2, 500, 1, true],
+		"params": {
+			"args": {
+				"src_acct_name": null,
+				"amount": "6000000000",
+				"minimum_confirmations": 2,
+				"max_outputs": 500,
+				"num_change_outputs": 1,
+				"selection_strategy_is_use_all": true,
+				"message": null,
+				"target_slate_version": null,
+				"send_args": null
+			}
+		},
 		"id": 1
 	}
 	# "#
@@ -434,13 +446,8 @@ pub trait OwnerRpc {
 	 */
 	fn estimate_initiate_tx(
 		&self,
-		src_acct_name: Option<String>,
-		amount: u64,
-		minimum_confirmations: u64,
-		max_outputs: usize,
-		num_change_outputs: usize,
-		selection_strategy_is_use_all: bool,
-	) -> Result<TxEstimation, ErrorKind>;
+		args: InitTxArgs,
+	) -> Result<TxEstimate, ErrorKind>;
 
 	/**
 	Networked version of [Owner::tx_lock_outputs](struct.Owner.html#method.tx_lock_outputs).
@@ -1095,21 +1102,11 @@ where
 
 	fn estimate_initiate_tx(
 		&self,
-		src_acct_name: Option<String>,
-		amount: u64,
-		minimum_confirmations: u64,
-		max_outputs: usize,
-		num_change_outputs: usize,
-		selection_strategy_is_use_all: bool,
-	) -> Result<TxEstimation, ErrorKind> {
+		args: InitTxArgs,
+	) -> Result<TxEstimate, ErrorKind> {
 		Owner::estimate_initiate_tx(
 			self,
-			src_acct_name.as_ref().map(String::as_str),
-			amount,
-			minimum_confirmations,
-			max_outputs,
-			num_change_outputs,
-			selection_strategy_is_use_all,
+			args,
 		)
 		.map_err(|e| e.kind())
 	}

--- a/api/src/owner_rpc.rs
+++ b/api/src/owner_rpc.rs
@@ -19,8 +19,8 @@ use crate::core::core::Transaction;
 use crate::keychain::{Identifier, Keychain};
 use crate::libwallet::slate::Slate;
 use crate::libwallet::types::{
-	AcctPathMapping, NodeClient, NodeHeightResult, InitTxArgs, OutputCommitMapping, TxEstimation, TxLogEntry,
-	WalletBackend, WalletInfo,
+	AcctPathMapping, InitTxArgs, NodeClient, NodeHeightResult, OutputCommitMapping, TxEstimation,
+	TxLogEntry, WalletBackend, WalletInfo,
 };
 use crate::libwallet::ErrorKind;
 use crate::Owner;
@@ -400,10 +400,7 @@ pub trait OwnerRpc {
 	```
 	*/
 
-	fn initiate_tx(
-		&self,
-		args: InitTxArgs,
-	) -> Result<Slate, ErrorKind>;
+	fn initiate_tx(&self, args: InitTxArgs) -> Result<Slate, ErrorKind>;
 
 	/**
 	Networked version of [Owner::estimate_initiate_tx](struct.Owner.html#method.estimate_initiate_tx).
@@ -1092,15 +1089,8 @@ where
 			.map_err(|e| e.kind())
 	}
 
-	fn initiate_tx(
-		&self,
-		args: InitTxArgs,
-		) -> Result<Slate, ErrorKind> {
-		Owner::initiate_tx(
-			self,
-			args,
-		)
-		.map_err(|e| e.kind())
+	fn initiate_tx(&self, args: InitTxArgs) -> Result<Slate, ErrorKind> {
+		Owner::initiate_tx(self, args).map_err(|e| e.kind())
 	}
 
 	fn estimate_initiate_tx(
@@ -1246,12 +1236,7 @@ pub fn run_doctest_owner(
 			target_slate_version: None,
 			send_args: None,
 		};
-		let mut slate = api_impl::owner::initiate_tx(
-			&mut *w,
-			args,
-			true,
-		)
-		.unwrap();
+		let mut slate = api_impl::owner::initiate_tx(&mut *w, args, true).unwrap();
 		{
 			let mut w2 = wallet2.lock();
 			w2.open_with_credentials().unwrap();

--- a/controller/src/command.rs
+++ b/controller/src/command.rs
@@ -35,7 +35,7 @@ use crate::impls::{
 	LMDBBackend, NullWalletCommAdapter,
 };
 use crate::impls::{HTTPNodeClient, WalletSeed};
-use crate::libwallet::types::{NodeClient, InitTxArgs, WalletInst};
+use crate::libwallet::types::{InitTxArgs, NodeClient, WalletInst};
 use crate::{controller, display};
 
 /// Arguments common to all wallet commands
@@ -273,9 +273,7 @@ pub fn send(
 				target_slate_version: args.target_slate_version,
 				send_args: None,
 			};
-			let result = api.initiate_tx(
-				init_args,
-			);
+			let result = api.initiate_tx(init_args);
 			let mut slate = match result {
 				Ok(s) => {
 					info!(

--- a/controller/src/command.rs
+++ b/controller/src/command.rs
@@ -421,9 +421,9 @@ pub fn outputs(
 	dark_scheme: bool,
 ) -> Result<(), Error> {
 	controller::owner_single_use(wallet.clone(), |api| {
-		let (height, _) = api.node_height()?;
+		let res = api.node_height()?;
 		let (validated, outputs) = api.retrieve_outputs(g_args.show_spent, true, None)?;
-		display::outputs(&g_args.account, height, validated, outputs, dark_scheme)?;
+		display::outputs(&g_args.account, res.height, validated, outputs, dark_scheme)?;
 		Ok(())
 	})?;
 	Ok(())
@@ -441,12 +441,12 @@ pub fn txs(
 	dark_scheme: bool,
 ) -> Result<(), Error> {
 	controller::owner_single_use(wallet.clone(), |api| {
-		let (height, _) = api.node_height()?;
+		let res = api.node_height()?;
 		let (validated, txs) = api.retrieve_txs(true, args.id, None)?;
 		let include_status = !args.id.is_some();
 		display::txs(
 			&g_args.account,
-			height,
+			res.height,
 			validated,
 			&txs,
 			include_status,
@@ -456,7 +456,7 @@ pub fn txs(
 		// inputs/outputs and messages
 		if args.id.is_some() {
 			let (_, outputs) = api.retrieve_outputs(true, false, args.id)?;
-			display::outputs(&g_args.account, height, validated, outputs, dark_scheme)?;
+			display::outputs(&g_args.account, res.height, validated, outputs, dark_scheme)?;
 			// should only be one here, but just in case
 			for tx in txs {
 				display::tx_messages(&tx, dark_scheme)?;

--- a/controller/src/command.rs
+++ b/controller/src/command.rs
@@ -254,7 +254,7 @@ pub fn send(
 						max_outputs: args.max_outputs as u32,
 						num_change_outputs: args.change_outputs as u32,
 						selection_strategy_is_use_all: strategy == "all",
-						estimate_only: true,
+						estimate_only: Some(true),
 						..Default::default()
 					};
 					let slate = api.initiate_tx(init_args).unwrap();

--- a/controller/src/command.rs
+++ b/controller/src/command.rs
@@ -254,12 +254,11 @@ pub fn send(
 						max_outputs: args.max_outputs as u32,
 						num_change_outputs: args.change_outputs as u32,
 						selection_strategy_is_use_all: strategy == "all",
-						message: None,
-						target_slate_version: None,
-						send_args: None,
+						estimate_only: true,
+						..Default::default()
 					};
-					let est = api.estimate_initiate_tx(init_args).unwrap();
-					(strategy, est.total, est.fee)
+					let slate = api.initiate_tx(init_args).unwrap();
+					(strategy, slate.amount, slate.fee)
 				})
 				.collect();
 			display::estimate(args.amount, strategies, dark_scheme);
@@ -274,6 +273,7 @@ pub fn send(
 				message: args.message.clone(),
 				target_slate_version: args.target_slate_version,
 				send_args: None,
+				..Default::default()
 			};
 			let result = api.initiate_tx(init_args);
 			let mut slate = match result {

--- a/controller/src/command.rs
+++ b/controller/src/command.rs
@@ -35,7 +35,7 @@ use crate::impls::{
 	LMDBBackend, NullWalletCommAdapter,
 };
 use crate::impls::{HTTPNodeClient, WalletSeed};
-use crate::libwallet::types::{NodeClient, WalletInst};
+use crate::libwallet::types::{NodeClient, InitTxArgs, WalletInst};
 use crate::{controller, display};
 
 /// Arguments common to all wallet commands
@@ -262,15 +262,19 @@ pub fn send(
 				.collect();
 			display::estimate(args.amount, strategies, dark_scheme);
 		} else {
+			let init_args = InitTxArgs {
+				src_acct_name: None,
+				amount: args.amount,
+				minimum_confirmations: args.minimum_confirmations,
+				max_outputs: args.max_outputs as u32,
+				num_change_outputs: args.change_outputs as u32,
+				selection_strategy_is_use_all: args.selection_strategy == "all",
+				message: args.message.clone(),
+				target_slate_version: args.target_slate_version,
+				send_args: None,
+			};
 			let result = api.initiate_tx(
-				None,
-				args.amount,
-				args.minimum_confirmations,
-				args.max_outputs,
-				args.change_outputs,
-				args.selection_strategy == "all",
-				args.message.clone(),
-				args.target_slate_version,
+				init_args,
 			);
 			let mut slate = match result {
 				Ok(s) => {

--- a/controller/src/command.rs
+++ b/controller/src/command.rs
@@ -247,15 +247,21 @@ pub fn send(
 			let strategies = vec!["smallest", "all"]
 				.into_iter()
 				.map(|strategy| {
+							let init_args = InitTxArgs {
+								src_acct_name: None,
+								amount: args.amount,
+								minimum_confirmations: args.minimum_confirmations,
+								max_outputs: args.max_outputs as u32,
+								num_change_outputs: args.change_outputs as u32,
+								selection_strategy_is_use_all: strategy == "all",
+								message: None,
+								target_slate_version: None,
+								send_args: None,
+							};
 					let est = api
 						.estimate_initiate_tx(
-							None,
-							args.amount,
-							args.minimum_confirmations,
-							args.max_outputs,
-							args.change_outputs,
-							strategy == "all",
-						)
+							init_args,
+										)
 						.unwrap();
 					(strategy, est.total, est.fee)
 				})

--- a/controller/src/command.rs
+++ b/controller/src/command.rs
@@ -247,22 +247,18 @@ pub fn send(
 			let strategies = vec!["smallest", "all"]
 				.into_iter()
 				.map(|strategy| {
-							let init_args = InitTxArgs {
-								src_acct_name: None,
-								amount: args.amount,
-								minimum_confirmations: args.minimum_confirmations,
-								max_outputs: args.max_outputs as u32,
-								num_change_outputs: args.change_outputs as u32,
-								selection_strategy_is_use_all: strategy == "all",
-								message: None,
-								target_slate_version: None,
-								send_args: None,
-							};
-					let est = api
-						.estimate_initiate_tx(
-							init_args,
-										)
-						.unwrap();
+					let init_args = InitTxArgs {
+						src_acct_name: None,
+						amount: args.amount,
+						minimum_confirmations: args.minimum_confirmations,
+						max_outputs: args.max_outputs as u32,
+						num_change_outputs: args.change_outputs as u32,
+						selection_strategy_is_use_all: strategy == "all",
+						message: None,
+						target_slate_version: None,
+						send_args: None,
+					};
+					let est = api.estimate_initiate_tx(init_args).unwrap();
 					(strategy, est.total, est.fee)
 				})
 				.collect();

--- a/controller/src/controller.rs
+++ b/controller/src/controller.rs
@@ -23,7 +23,7 @@ use crate::impls::{FileWalletCommAdapter, HTTPWalletCommAdapter, KeybaseWalletCo
 use crate::keychain::Keychain;
 use crate::libwallet::slate::Slate;
 use crate::libwallet::types::{
-	CbData, NodeClient, OutputCommitMapping, SendTXArgs, TxLogEntry, WalletBackend, WalletInfo,
+	CbData, NodeClient, InitTxArgs, OutputCommitMapping, SendTXArgs, TxLogEntry, WalletBackend, WalletInfo,
 };
 use crate::libwallet::{Error, ErrorKind};
 use crate::util::to_base64;
@@ -321,15 +321,19 @@ where
 		api: Owner<T, C, K>,
 	) -> Box<dyn Future<Item = Slate, Error = Error> + Send> {
 		Box::new(parse_body(req).and_then(move |args: SendTXArgs| {
+			let init_args = InitTxArgs {
+				src_acct_name: None,
+				amount: args.amount,
+				minimum_confirmations: args.minimum_confirmations,
+				max_outputs: args.max_outputs as u32,
+				num_change_outputs: args.num_change_outputs as u32,
+				selection_strategy_is_use_all: args.selection_strategy_is_use_all,
+				message: args.message.clone(),
+				target_slate_version: args.target_slate_version,
+				send_args: None,
+			};
 			let result = api.initiate_tx(
-				None,
-				args.amount,
-				args.minimum_confirmations,
-				args.max_outputs,
-				args.num_change_outputs,
-				args.selection_strategy_is_use_all,
-				args.message,
-				args.target_slate_version,
+				init_args,
 			);
 			let mut slate = match result {
 				Ok(s) => {

--- a/controller/src/controller.rs
+++ b/controller/src/controller.rs
@@ -23,7 +23,8 @@ use crate::impls::{FileWalletCommAdapter, HTTPWalletCommAdapter, KeybaseWalletCo
 use crate::keychain::Keychain;
 use crate::libwallet::slate::Slate;
 use crate::libwallet::types::{
-	CbData, NodeClient, InitTxArgs, OutputCommitMapping, SendTXArgs, TxLogEntry, WalletBackend, WalletInfo,
+	CbData, InitTxArgs, NodeClient, OutputCommitMapping, SendTXArgs, TxLogEntry, WalletBackend,
+	WalletInfo,
 };
 use crate::libwallet::{Error, ErrorKind};
 use crate::util::to_base64;
@@ -332,9 +333,7 @@ where
 				target_slate_version: args.target_slate_version,
 				send_args: None,
 			};
-			let result = api.initiate_tx(
-				init_args,
-			);
+			let result = api.initiate_tx(init_args);
 			let mut slate = match result {
 				Ok(s) => {
 					info!(

--- a/controller/src/controller.rs
+++ b/controller/src/controller.rs
@@ -289,7 +289,8 @@ where
 		_req: &Request<Body>,
 		api: Owner<T, C, K>,
 	) -> Result<(u64, bool), Error> {
-		api.node_height()
+		let res = api.node_height()?;
+		Ok((res.height, res.updated_from_node))
 	}
 
 	fn handle_get_request(&self, req: &Request<Body>) -> Result<Response<Body>, Error> {
@@ -299,7 +300,7 @@ where
 			match req
 				.uri()
 				.path()
-				.trim_right_matches("/")
+				.trim_end_matches("/")
 				.rsplit("/")
 				.next()
 				.unwrap()
@@ -554,7 +555,7 @@ where
 		match req
 			.uri()
 			.path()
-			.trim_right_matches("/")
+			.trim_end_matches("/")
 			.rsplit("/")
 			.next()
 			.unwrap()
@@ -688,7 +689,7 @@ where
 		match req
 			.uri()
 			.path()
-			.trim_right_matches("/")
+			.trim_end_matches("/")
 			.rsplit("/")
 			.next()
 			.unwrap()

--- a/controller/src/controller.rs
+++ b/controller/src/controller.rs
@@ -332,6 +332,7 @@ where
 				message: args.message.clone(),
 				target_slate_version: args.target_slate_version,
 				send_args: None,
+				..Default::default()
 			};
 			let result = api.initiate_tx(init_args);
 			let mut slate = match result {

--- a/controller/tests/accounts.rs
+++ b/controller/tests/accounts.rs
@@ -29,6 +29,7 @@ use impls::test_framework::{self, LocalWalletClient, WalletProxy};
 use std::fs;
 use std::thread;
 use std::time::Duration;
+use libwallet::types::InitTxArgs;
 
 fn clean_output_dir(test_dir: &str) {
 	let _ = fs::remove_dir_all(test_dir);
@@ -179,13 +180,19 @@ fn accounts_test_impl(test_dir: &str) -> Result<(), libwallet::Error> {
 	}
 
 	wallet::controller::owner_single_use(wallet1.clone(), |api| {
+		let args = InitTxArgs {
+			src_acct_name: None,
+			amount: reward,
+			minimum_confirmations: 2,
+			max_outputs: 500,
+			num_change_outputs: 1,
+			selection_strategy_is_use_all: true,
+			message: None,
+			target_slate_version: None,
+			send_args: None,
+		};
 		let mut slate = api.initiate_tx(
-			None, reward, // amount
-			2,      // minimum confirmations
-			500,    // max outputs
-			1,      // num change outputs
-			true,   // select all outputs
-			None, None,
+			args,
 		)?;
 		slate = client1.send_tx_slate_direct("wallet2", &slate)?;
 		api.tx_lock_outputs(&slate)?;

--- a/controller/tests/accounts.rs
+++ b/controller/tests/accounts.rs
@@ -187,9 +187,7 @@ fn accounts_test_impl(test_dir: &str) -> Result<(), libwallet::Error> {
 			max_outputs: 500,
 			num_change_outputs: 1,
 			selection_strategy_is_use_all: true,
-			message: None,
-			target_slate_version: None,
-			send_args: None,
+			..Default::default()
 		};
 		let mut slate = api.initiate_tx(args)?;
 		slate = client1.send_tx_slate_direct("wallet2", &slate)?;

--- a/controller/tests/accounts.rs
+++ b/controller/tests/accounts.rs
@@ -26,10 +26,10 @@ use self::core::global::ChainTypes;
 use self::keychain::{ExtKeychain, Keychain};
 use grin_wallet_libwallet as libwallet;
 use impls::test_framework::{self, LocalWalletClient, WalletProxy};
+use libwallet::types::InitTxArgs;
 use std::fs;
 use std::thread;
 use std::time::Duration;
-use libwallet::types::InitTxArgs;
 
 fn clean_output_dir(test_dir: &str) {
 	let _ = fs::remove_dir_all(test_dir);
@@ -191,9 +191,7 @@ fn accounts_test_impl(test_dir: &str) -> Result<(), libwallet::Error> {
 			target_slate_version: None,
 			send_args: None,
 		};
-		let mut slate = api.initiate_tx(
-			args,
-		)?;
+		let mut slate = api.initiate_tx(args)?;
 		slate = client1.send_tx_slate_direct("wallet2", &slate)?;
 		api.tx_lock_outputs(&slate)?;
 		slate = api.finalize_tx(&slate)?;

--- a/controller/tests/check.rs
+++ b/controller/tests/check.rs
@@ -28,7 +28,7 @@ use self::keychain::ExtKeychain;
 use grin_wallet_libwallet as libwallet;
 use impls::test_framework::{self, LocalWalletClient, WalletProxy};
 use impls::FileWalletCommAdapter;
-use libwallet::types::WalletInst;
+use libwallet::types::{InitTxArgs, WalletInst};
 use std::fs;
 use std::thread;
 use std::time::Duration;
@@ -178,15 +178,19 @@ fn check_repair_impl(test_dir: &str) -> Result<(), libwallet::Error> {
 	// perform a transaction, but don't let it finish
 	wallet::controller::owner_single_use(wallet1.clone(), |api| {
 		// send to send
+		let args = InitTxArgs {
+			src_acct_name: None,
+			amount: reward * 2,
+			minimum_confirmations: cm,
+			max_outputs: 500,
+			num_change_outputs: 1,
+			selection_strategy_is_use_all: true,
+			message: None,
+			target_slate_version: None,
+			send_args: None,
+		};
 		let mut slate = api.initiate_tx(
-			None,
-			reward * 2, // amount
-			cm,         // minimum confirmations
-			500,        // max outputs
-			1,          // num change outputs
-			true,       // select all outputs
-			None,       // optional message
-			None,
+			args,
 		)?;
 		// output tx file
 		let file_adapter = FileWalletCommAdapter::new();

--- a/controller/tests/check.rs
+++ b/controller/tests/check.rs
@@ -189,9 +189,7 @@ fn check_repair_impl(test_dir: &str) -> Result<(), libwallet::Error> {
 			target_slate_version: None,
 			send_args: None,
 		};
-		let mut slate = api.initiate_tx(
-			args,
-		)?;
+		let mut slate = api.initiate_tx(args)?;
 		// output tx file
 		let file_adapter = FileWalletCommAdapter::new();
 		let send_file = format!("{}/part_tx_1.tx", test_dir);

--- a/controller/tests/check.rs
+++ b/controller/tests/check.rs
@@ -185,9 +185,7 @@ fn check_repair_impl(test_dir: &str) -> Result<(), libwallet::Error> {
 			max_outputs: 500,
 			num_change_outputs: 1,
 			selection_strategy_is_use_all: true,
-			message: None,
-			target_slate_version: None,
-			send_args: None,
+			..Default::default()
 		};
 		let mut slate = api.initiate_tx(args)?;
 		// output tx file

--- a/controller/tests/file.rs
+++ b/controller/tests/file.rs
@@ -31,6 +31,8 @@ use std::fs;
 use std::thread;
 use std::time::Duration;
 
+use grin_wallet_libwallet::types::InitTxArgs;
+
 use serde_json;
 
 fn clean_output_dir(test_dir: &str) {
@@ -105,15 +107,19 @@ fn file_exchange_test_impl(test_dir: &str) -> Result<(), libwallet::Error> {
 		assert_eq!(wallet1_info.last_confirmed_height, bh);
 		assert_eq!(wallet1_info.total, bh * reward);
 		// send to send
+		let args = InitTxArgs {
+			src_acct_name: Some("mining".to_owned()),
+			amount: reward * 2,
+			minimum_confirmations: 2,
+			max_outputs: 500,
+			num_change_outputs: 1,
+			selection_strategy_is_use_all: true,
+			message: Some(message.to_owned()),
+			target_slate_version: None,
+			send_args: None,
+		};
 		let mut slate = api.initiate_tx(
-			Some("mining"),
-			reward * 2,               // amount
-			2,                        // minimum confirmations
-			500,                      // max outputs
-			1,                        // num change outputs
-			true,                     // select all outputs
-			Some(message.to_owned()), // optional message
-			None,
+			args,
 		)?;
 		// output tx file
 		let file_adapter = FileWalletCommAdapter::new();

--- a/controller/tests/file.rs
+++ b/controller/tests/file.rs
@@ -118,9 +118,7 @@ fn file_exchange_test_impl(test_dir: &str) -> Result<(), libwallet::Error> {
 			target_slate_version: None,
 			send_args: None,
 		};
-		let mut slate = api.initiate_tx(
-			args,
-		)?;
+		let mut slate = api.initiate_tx(args)?;
 		// output tx file
 		let file_adapter = FileWalletCommAdapter::new();
 		file_adapter.send_tx_async(&send_file, &mut slate)?;

--- a/controller/tests/file.rs
+++ b/controller/tests/file.rs
@@ -115,8 +115,7 @@ fn file_exchange_test_impl(test_dir: &str) -> Result<(), libwallet::Error> {
 			num_change_outputs: 1,
 			selection_strategy_is_use_all: true,
 			message: Some(message.to_owned()),
-			target_slate_version: None,
-			send_args: None,
+			..Default::default()
 		};
 		let mut slate = api.initiate_tx(args)?;
 		// output tx file

--- a/controller/tests/repost.rs
+++ b/controller/tests/repost.rs
@@ -115,9 +115,7 @@ fn file_repost_test_impl(test_dir: &str) -> Result<(), libwallet::Error> {
 			target_slate_version: None,
 			send_args: None,
 		};
-		let mut slate = api.initiate_tx(
-			args,
-		)?;
+		let mut slate = api.initiate_tx(args)?;
 		// output tx file
 		let file_adapter = FileWalletCommAdapter::new();
 		file_adapter.send_tx_async(&send_file, &mut slate)?;
@@ -216,9 +214,7 @@ fn file_repost_test_impl(test_dir: &str) -> Result<(), libwallet::Error> {
 			target_slate_version: None,
 			send_args: None,
 		};
-		let slate_i = sender_api.initiate_tx(
-			args,
-		)?;
+		let slate_i = sender_api.initiate_tx(args)?;
 		slate = client1.send_tx_slate_direct("wallet2", &slate_i)?;
 		sender_api.tx_lock_outputs(&slate)?;
 		slate = sender_api.finalize_tx(&mut slate)?;

--- a/controller/tests/repost.rs
+++ b/controller/tests/repost.rs
@@ -26,6 +26,7 @@ use self::core::global;
 use self::core::global::ChainTypes;
 use self::keychain::ExtKeychain;
 use self::libwallet::slate::Slate;
+use self::libwallet::types::InitTxArgs;
 use impls::test_framework::{self, LocalWalletClient, WalletProxy};
 use impls::FileWalletCommAdapter;
 use std::fs;
@@ -103,15 +104,19 @@ fn file_repost_test_impl(test_dir: &str) -> Result<(), libwallet::Error> {
 		assert_eq!(wallet1_info.last_confirmed_height, bh);
 		assert_eq!(wallet1_info.total, bh * reward);
 		// send to send
+		let args = InitTxArgs {
+			src_acct_name: Some("mining".to_owned()),
+			amount: reward * 2,
+			minimum_confirmations: 2,
+			max_outputs: 500,
+			num_change_outputs: 1,
+			selection_strategy_is_use_all: true,
+			message: None,
+			target_slate_version: None,
+			send_args: None,
+		};
 		let mut slate = api.initiate_tx(
-			Some("mining"),
-			reward * 2, // amount
-			2,          // minimum confirmations
-			500,        // max outputs
-			1,          // num change outputs
-			true,       // select all outputs
-			None,
-			None,
+			args,
 		)?;
 		// output tx file
 		let file_adapter = FileWalletCommAdapter::new();
@@ -200,15 +205,19 @@ fn file_repost_test_impl(test_dir: &str) -> Result<(), libwallet::Error> {
 
 	wallet::controller::owner_single_use(wallet1.clone(), |sender_api| {
 		// note this will increment the block count as part of the transaction "Posting"
+		let args = InitTxArgs {
+			src_acct_name: None,
+			amount: reward * 2,
+			minimum_confirmations: 2,
+			max_outputs: 500,
+			num_change_outputs: 1,
+			selection_strategy_is_use_all: true,
+			message: None,
+			target_slate_version: None,
+			send_args: None,
+		};
 		let slate_i = sender_api.initiate_tx(
-			None,
-			amount * 2, // amount
-			2,          // minimum confirmations
-			500,        // max outputs
-			1,          // num change outputs
-			true,       // select all outputs
-			None,
-			None,
+			args,
 		)?;
 		slate = client1.send_tx_slate_direct("wallet2", &slate_i)?;
 		sender_api.tx_lock_outputs(&slate)?;

--- a/controller/tests/repost.rs
+++ b/controller/tests/repost.rs
@@ -111,9 +111,7 @@ fn file_repost_test_impl(test_dir: &str) -> Result<(), libwallet::Error> {
 			max_outputs: 500,
 			num_change_outputs: 1,
 			selection_strategy_is_use_all: true,
-			message: None,
-			target_slate_version: None,
-			send_args: None,
+			..Default::default()
 		};
 		let mut slate = api.initiate_tx(args)?;
 		// output tx file
@@ -210,9 +208,7 @@ fn file_repost_test_impl(test_dir: &str) -> Result<(), libwallet::Error> {
 			max_outputs: 500,
 			num_change_outputs: 1,
 			selection_strategy_is_use_all: true,
-			message: None,
-			target_slate_version: None,
-			send_args: None,
+			..Default::default()
 		};
 		let slate_i = sender_api.initiate_tx(args)?;
 		slate = client1.send_tx_slate_direct("wallet2", &slate_i)?;

--- a/controller/tests/restore.rs
+++ b/controller/tests/restore.rs
@@ -26,7 +26,7 @@ use self::core::global;
 use self::core::global::ChainTypes;
 use self::keychain::{ExtKeychain, Identifier, Keychain};
 use self::libwallet::slate::Slate;
-use self::libwallet::types::AcctPathMapping;
+use self::libwallet::types::{InitTxArgs, AcctPathMapping};
 use impls::test_framework::{self, LocalWalletClient, WalletProxy};
 use std::fs;
 use std::sync::atomic::Ordering;
@@ -237,13 +237,19 @@ fn setup_restore(test_dir: &str) -> Result<(), libwallet::Error> {
 	let mut slate = Slate::blank(1);
 	wallet::controller::owner_single_use(wallet1.clone(), |sender_api| {
 		// note this will increment the block count as part of the transaction "Posting"
+		let args = InitTxArgs {
+			src_acct_name: None,
+			amount: amount,
+			minimum_confirmations: 2,
+			max_outputs: 500,
+			num_change_outputs: 1,
+			selection_strategy_is_use_all: true,
+			message: None,
+			target_slate_version: None,
+			send_args: None,
+		};
 		let slate_i = sender_api.initiate_tx(
-			None, amount, // amount
-			2,      // minimum confirmations
-			500,    // max outputs
-			1,      // num change outputs
-			true,   // select all outputs
-			None, None,
+			args,
 		)?;
 		slate = client1.send_tx_slate_direct("wallet2", &slate_i)?;
 		sender_api.tx_lock_outputs(&slate)?;
@@ -258,15 +264,19 @@ fn setup_restore(test_dir: &str) -> Result<(), libwallet::Error> {
 	// Send some to wallet 3
 	wallet::controller::owner_single_use(wallet1.clone(), |sender_api| {
 		// note this will increment the block count as part of the transaction "Posting"
+		let args = InitTxArgs {
+			src_acct_name: None,
+			amount: amount * 2,
+			minimum_confirmations: 2,
+			max_outputs: 500,
+			num_change_outputs: 1,
+			selection_strategy_is_use_all: true,
+			message: None,
+			target_slate_version: None,
+			send_args: None,
+		};
 		let slate_i = sender_api.initiate_tx(
-			None,
-			amount * 2, // amount
-			2,          // minimum confirmations
-			500,        // max outputs
-			1,          // num change outputs
-			true,       // select all outputs
-			None,
-			None,
+			args,
 		)?;
 		slate = client1.send_tx_slate_direct("wallet3", &slate_i)?;
 		sender_api.tx_lock_outputs(&slate)?;
@@ -281,15 +291,19 @@ fn setup_restore(test_dir: &str) -> Result<(), libwallet::Error> {
 	// Wallet3 to wallet 2
 	wallet::controller::owner_single_use(wallet3.clone(), |sender_api| {
 		// note this will increment the block count as part of the transaction "Posting"
+		let args = InitTxArgs {
+			src_acct_name: None,
+			amount: amount * 3,
+			minimum_confirmations: 2,
+			max_outputs: 500,
+			num_change_outputs: 1,
+			selection_strategy_is_use_all: true,
+			message: None,
+			target_slate_version: None,
+			send_args: None,
+		};
 		let slate_i = sender_api.initiate_tx(
-			None,
-			amount * 3, // amount
-			2,          // minimum confirmations
-			500,        // max outputs
-			1,          // num change outputs
-			true,       // select all outputs
-			None,
-			None,
+			args,
 		)?;
 		slate = client3.send_tx_slate_direct("wallet2", &slate_i)?;
 		sender_api.tx_lock_outputs(&slate)?;
@@ -310,15 +324,19 @@ fn setup_restore(test_dir: &str) -> Result<(), libwallet::Error> {
 	// Wallet3 to wallet 2 again (to another account)
 	wallet::controller::owner_single_use(wallet3.clone(), |sender_api| {
 		// note this will increment the block count as part of the transaction "Posting"
+		let args = InitTxArgs {
+			src_acct_name: None,
+			amount: amount * 3,
+			minimum_confirmations: 2,
+			max_outputs: 500,
+			num_change_outputs: 1,
+			selection_strategy_is_use_all: true,
+			message: None,
+			target_slate_version: None,
+			send_args: None,
+		};
 		let slate_i = sender_api.initiate_tx(
-			None,
-			amount * 3, // amount
-			2,          // minimum confirmations
-			500,        // max outputs
-			1,          // num change outputs
-			true,       // select all outputs
-			None,
-			None,
+			args,
 		)?;
 		slate = client3.send_tx_slate_direct("wallet2", &slate_i)?;
 		sender_api.tx_lock_outputs(&slate)?;

--- a/controller/tests/restore.rs
+++ b/controller/tests/restore.rs
@@ -244,9 +244,7 @@ fn setup_restore(test_dir: &str) -> Result<(), libwallet::Error> {
 			max_outputs: 500,
 			num_change_outputs: 1,
 			selection_strategy_is_use_all: true,
-			message: None,
-			target_slate_version: None,
-			send_args: None,
+			..Default::default()
 		};
 		let slate_i = sender_api.initiate_tx(args)?;
 		slate = client1.send_tx_slate_direct("wallet2", &slate_i)?;
@@ -269,9 +267,7 @@ fn setup_restore(test_dir: &str) -> Result<(), libwallet::Error> {
 			max_outputs: 500,
 			num_change_outputs: 1,
 			selection_strategy_is_use_all: true,
-			message: None,
-			target_slate_version: None,
-			send_args: None,
+			..Default::default()
 		};
 		let slate_i = sender_api.initiate_tx(args)?;
 		slate = client1.send_tx_slate_direct("wallet3", &slate_i)?;
@@ -294,9 +290,7 @@ fn setup_restore(test_dir: &str) -> Result<(), libwallet::Error> {
 			max_outputs: 500,
 			num_change_outputs: 1,
 			selection_strategy_is_use_all: true,
-			message: None,
-			target_slate_version: None,
-			send_args: None,
+			..Default::default()
 		};
 		let slate_i = sender_api.initiate_tx(args)?;
 		slate = client3.send_tx_slate_direct("wallet2", &slate_i)?;
@@ -325,9 +319,7 @@ fn setup_restore(test_dir: &str) -> Result<(), libwallet::Error> {
 			max_outputs: 500,
 			num_change_outputs: 1,
 			selection_strategy_is_use_all: true,
-			message: None,
-			target_slate_version: None,
-			send_args: None,
+			..Default::default()
 		};
 		let slate_i = sender_api.initiate_tx(args)?;
 		slate = client3.send_tx_slate_direct("wallet2", &slate_i)?;

--- a/controller/tests/restore.rs
+++ b/controller/tests/restore.rs
@@ -26,7 +26,7 @@ use self::core::global;
 use self::core::global::ChainTypes;
 use self::keychain::{ExtKeychain, Identifier, Keychain};
 use self::libwallet::slate::Slate;
-use self::libwallet::types::{InitTxArgs, AcctPathMapping};
+use self::libwallet::types::{AcctPathMapping, InitTxArgs};
 use impls::test_framework::{self, LocalWalletClient, WalletProxy};
 use std::fs;
 use std::sync::atomic::Ordering;
@@ -248,9 +248,7 @@ fn setup_restore(test_dir: &str) -> Result<(), libwallet::Error> {
 			target_slate_version: None,
 			send_args: None,
 		};
-		let slate_i = sender_api.initiate_tx(
-			args,
-		)?;
+		let slate_i = sender_api.initiate_tx(args)?;
 		slate = client1.send_tx_slate_direct("wallet2", &slate_i)?;
 		sender_api.tx_lock_outputs(&slate)?;
 		slate = sender_api.finalize_tx(&slate)?;
@@ -275,9 +273,7 @@ fn setup_restore(test_dir: &str) -> Result<(), libwallet::Error> {
 			target_slate_version: None,
 			send_args: None,
 		};
-		let slate_i = sender_api.initiate_tx(
-			args,
-		)?;
+		let slate_i = sender_api.initiate_tx(args)?;
 		slate = client1.send_tx_slate_direct("wallet3", &slate_i)?;
 		sender_api.tx_lock_outputs(&slate)?;
 		slate = sender_api.finalize_tx(&slate)?;
@@ -302,9 +298,7 @@ fn setup_restore(test_dir: &str) -> Result<(), libwallet::Error> {
 			target_slate_version: None,
 			send_args: None,
 		};
-		let slate_i = sender_api.initiate_tx(
-			args,
-		)?;
+		let slate_i = sender_api.initiate_tx(args)?;
 		slate = client3.send_tx_slate_direct("wallet2", &slate_i)?;
 		sender_api.tx_lock_outputs(&slate)?;
 		slate = sender_api.finalize_tx(&slate)?;
@@ -335,9 +329,7 @@ fn setup_restore(test_dir: &str) -> Result<(), libwallet::Error> {
 			target_slate_version: None,
 			send_args: None,
 		};
-		let slate_i = sender_api.initiate_tx(
-			args,
-		)?;
+		let slate_i = sender_api.initiate_tx(args)?;
 		slate = client3.send_tx_slate_direct("wallet2", &slate_i)?;
 		sender_api.tx_lock_outputs(&slate)?;
 		slate = sender_api.finalize_tx(&slate)?;

--- a/controller/tests/self_send.rs
+++ b/controller/tests/self_send.rs
@@ -94,9 +94,7 @@ fn self_send_test_impl(test_dir: &str) -> Result<(), libwallet::Error> {
 			max_outputs: 500,
 			num_change_outputs: 1,
 			selection_strategy_is_use_all: true,
-			message: None,
-			target_slate_version: None,
-			send_args: None,
+			..Default::default()
 		};
 		let mut slate = api.initiate_tx(args)?;
 		api.tx_lock_outputs(&slate)?;

--- a/controller/tests/self_send.rs
+++ b/controller/tests/self_send.rs
@@ -29,6 +29,7 @@ use impls::test_framework::{self, LocalWalletClient, WalletProxy};
 use std::fs;
 use std::thread;
 use std::time::Duration;
+use libwallet::types::InitTxArgs;
 
 fn clean_output_dir(test_dir: &str) {
 	let _ = fs::remove_dir_all(test_dir);
@@ -86,15 +87,19 @@ fn self_send_test_impl(test_dir: &str) -> Result<(), libwallet::Error> {
 		assert_eq!(wallet1_info.last_confirmed_height, bh);
 		assert_eq!(wallet1_info.total, bh * reward);
 		// send to send
+		let args = InitTxArgs {
+			src_acct_name: Some("mining".to_owned()),
+			amount: reward * 2,
+			minimum_confirmations: 2,
+			max_outputs: 500,
+			num_change_outputs: 1,
+			selection_strategy_is_use_all: true,
+			message: None,
+			target_slate_version: None,
+			send_args: None,
+		};
 		let mut slate = api.initiate_tx(
-			Some("mining"),
-			reward * 2, // amount
-			2,          // minimum confirmations
-			500,        // max outputs
-			1,          // num change outputs
-			true,       // select all outputs
-			None,
-			None,
+			args,
 		)?;
 		api.tx_lock_outputs(&slate)?;
 		// Send directly to self

--- a/controller/tests/self_send.rs
+++ b/controller/tests/self_send.rs
@@ -26,10 +26,10 @@ use self::core::global::ChainTypes;
 use self::keychain::ExtKeychain;
 use grin_wallet_libwallet as libwallet;
 use impls::test_framework::{self, LocalWalletClient, WalletProxy};
+use libwallet::types::InitTxArgs;
 use std::fs;
 use std::thread;
 use std::time::Duration;
-use libwallet::types::InitTxArgs;
 
 fn clean_output_dir(test_dir: &str) {
 	let _ = fs::remove_dir_all(test_dir);
@@ -98,9 +98,7 @@ fn self_send_test_impl(test_dir: &str) -> Result<(), libwallet::Error> {
 			target_slate_version: None,
 			send_args: None,
 		};
-		let mut slate = api.initiate_tx(
-			args,
-		)?;
+		let mut slate = api.initiate_tx(args)?;
 		api.tx_lock_outputs(&slate)?;
 		// Send directly to self
 		wallet::controller::foreign_single_use(wallet1.clone(), |api| {

--- a/controller/tests/transaction.rs
+++ b/controller/tests/transaction.rs
@@ -254,24 +254,36 @@ fn basic_transaction_api(test_dir: &str) -> Result<(), libwallet::Error> {
 
 	// Estimate fee and locked amount for a transaction
 	wallet::controller::owner_single_use(wallet1.clone(), |sender_api| {
+							let init_args = InitTxArgs {
+								src_acct_name: None,
+								amount: amount * 2,
+								minimum_confirmations: 2,
+								max_outputs: 500,
+								num_change_outputs: 1,
+								selection_strategy_is_use_all: true,
+								message: None,
+								target_slate_version: None,
+								send_args: None,
+							};
 		let est = sender_api.estimate_initiate_tx(
-			None,
-			amount * 2, // amount
-			2,          // minimum confirmations
-			500,        // max outputs
-			1,          // num change outputs
-			true,       // select all outputs
+			init_args,
 		)?;
 		assert_eq!(est.total, 600_000_000_000);
 		assert_eq!(est.fee, 4_000_000);
 
+							let init_args = InitTxArgs {
+								src_acct_name: None,
+								amount: amount * 2,
+								minimum_confirmations: 2,
+								max_outputs: 500,
+								num_change_outputs: 1,
+								selection_strategy_is_use_all: false,  //select smallest number
+								message: None,
+								target_slate_version: None,
+								send_args: None,
+							};
 		let est = sender_api.estimate_initiate_tx(
-			None,
-			amount * 2, // amount
-			2,          // minimum confirmations
-			500,        // max outputs
-			1,          // num change outputs
-			false,      // select the smallest amount of outputs
+			init_args,
 		)?;
 		assert_eq!(est.total, 180_000_000_000);
 		assert_eq!(est.fee, 6_000_000);

--- a/controller/tests/transaction.rs
+++ b/controller/tests/transaction.rs
@@ -379,7 +379,7 @@ fn tx_rollback(test_dir: &str) -> Result<(), libwallet::Error> {
 	// few values to keep things shorter
 	let reward = core::consensus::REWARD;
 	let cm = global::coinbase_maturity(); // assume all testing precedes soft fork height
-	// mine a few blocks
+									   // mine a few blocks
 	let _ = test_framework::award_blocks_to_wallet(&chain, wallet1.clone(), 5, false);
 
 	let amount = 30_000_000_000;

--- a/controller/tests/transaction.rs
+++ b/controller/tests/transaction.rs
@@ -107,9 +107,7 @@ fn basic_transaction_api(test_dir: &str) -> Result<(), libwallet::Error> {
 			max_outputs: 500,
 			num_change_outputs: 1,
 			selection_strategy_is_use_all: true,
-			message: None,
-			target_slate_version: None,
-			send_args: None,
+			..Default::default()
 		};
 		let slate_i = sender_api.initiate_tx(args)?;
 
@@ -261,12 +259,11 @@ fn basic_transaction_api(test_dir: &str) -> Result<(), libwallet::Error> {
 			max_outputs: 500,
 			num_change_outputs: 1,
 			selection_strategy_is_use_all: true,
-			message: None,
-			target_slate_version: None,
-			send_args: None,
+			estimate_only: true,
+			..Default::default()
 		};
-		let est = sender_api.estimate_initiate_tx(init_args)?;
-		assert_eq!(est.total, 600_000_000_000);
+		let est = sender_api.initiate_tx(init_args)?;
+		assert_eq!(est.amount, 600_000_000_000);
 		assert_eq!(est.fee, 4_000_000);
 
 		let init_args = InitTxArgs {
@@ -276,12 +273,11 @@ fn basic_transaction_api(test_dir: &str) -> Result<(), libwallet::Error> {
 			max_outputs: 500,
 			num_change_outputs: 1,
 			selection_strategy_is_use_all: false, //select smallest number
-			message: None,
-			target_slate_version: None,
-			send_args: None,
+			estimate_only: true,
+			..Default::default()
 		};
-		let est = sender_api.estimate_initiate_tx(init_args)?;
-		assert_eq!(est.total, 180_000_000_000);
+		let est = sender_api.initiate_tx(init_args)?;
+		assert_eq!(est.amount, 180_000_000_000);
 		assert_eq!(est.fee, 6_000_000);
 
 		Ok(())
@@ -298,9 +294,7 @@ fn basic_transaction_api(test_dir: &str) -> Result<(), libwallet::Error> {
 			max_outputs: 500,
 			num_change_outputs: 1,
 			selection_strategy_is_use_all: true,
-			message: None,
-			target_slate_version: None,
-			send_args: None,
+			..Default::default()
 		};
 		let slate_i = sender_api.initiate_tx(args)?;
 		slate = client1.send_tx_slate_direct("wallet2", &slate_i)?;
@@ -385,7 +379,7 @@ fn tx_rollback(test_dir: &str) -> Result<(), libwallet::Error> {
 	// few values to keep things shorter
 	let reward = core::consensus::REWARD;
 	let cm = global::coinbase_maturity(); // assume all testing precedes soft fork height
-									   // mine a few blocks
+	// mine a few blocks
 	let _ = test_framework::award_blocks_to_wallet(&chain, wallet1.clone(), 5, false);
 
 	let amount = 30_000_000_000;
@@ -399,9 +393,7 @@ fn tx_rollback(test_dir: &str) -> Result<(), libwallet::Error> {
 			max_outputs: 500,
 			num_change_outputs: 1,
 			selection_strategy_is_use_all: true,
-			message: None,
-			target_slate_version: None,
-			send_args: None,
+			..Default::default()
 		};
 
 		let slate_i = sender_api.initiate_tx(args)?;

--- a/controller/tests/transaction.rs
+++ b/controller/tests/transaction.rs
@@ -27,7 +27,7 @@ use self::core::global;
 use self::core::global::ChainTypes;
 use self::keychain::ExtKeychain;
 use self::libwallet::slate::Slate;
-use self::libwallet::types::OutputStatus;
+use self::libwallet::types::{InitTxArgs, OutputStatus};
 use impls::test_framework::{self, LocalWalletClient, WalletProxy};
 use std::fs;
 use std::thread;
@@ -100,13 +100,19 @@ fn basic_transaction_api(test_dir: &str) -> Result<(), libwallet::Error> {
 	let mut slate = Slate::blank(1);
 	wallet::controller::owner_single_use(wallet1.clone(), |sender_api| {
 		// note this will increment the block count as part of the transaction "Posting"
+		let args = InitTxArgs {
+			src_acct_name: None,
+			amount: amount,
+			minimum_confirmations: 2,
+			max_outputs: 500,
+			num_change_outputs: 1,
+			selection_strategy_is_use_all: true,
+			message: None,
+			target_slate_version: None,
+			send_args: None,
+		};
 		let slate_i = sender_api.initiate_tx(
-			None, amount, // amount
-			2,      // minimum confirmations
-			500,    // max outputs
-			1,      // num change outputs
-			true,   // select all outputs
-			None, None,
+			args,
 		)?;
 
 		// Check we are creating a tx with the expected lock_height of 0.
@@ -279,15 +285,19 @@ fn basic_transaction_api(test_dir: &str) -> Result<(), libwallet::Error> {
 	// the stored transaction instead
 	wallet::controller::owner_single_use(wallet1.clone(), |sender_api| {
 		// note this will increment the block count as part of the transaction "Posting"
+		let args = InitTxArgs {
+			src_acct_name: None,
+			amount: amount * 2,
+			minimum_confirmations: 2,
+			max_outputs: 500,
+			num_change_outputs: 1,
+			selection_strategy_is_use_all: true,
+			message: None,
+			target_slate_version: None,
+			send_args: None,
+		};
 		let slate_i = sender_api.initiate_tx(
-			None,
-			amount * 2, // amount
-			2,          // minimum confirmations
-			500,        // max outputs
-			1,          // num change outputs
-			true,       // select all outputs
-			None,
-			None,
+			args,
 		)?;
 		slate = client1.send_tx_slate_direct("wallet2", &slate_i)?;
 		sender_api.tx_lock_outputs(&slate)?;
@@ -378,13 +388,20 @@ fn tx_rollback(test_dir: &str) -> Result<(), libwallet::Error> {
 	let mut slate = Slate::blank(1);
 	wallet::controller::owner_single_use(wallet1.clone(), |sender_api| {
 		// note this will increment the block count as part of the transaction "Posting"
+		let args = InitTxArgs {
+			src_acct_name: None,
+			amount: amount,
+			minimum_confirmations: 2,
+			max_outputs: 500,
+			num_change_outputs: 1,
+			selection_strategy_is_use_all: true,
+			message: None,
+			target_slate_version: None,
+			send_args: None,
+		};
+
 		let slate_i = sender_api.initiate_tx(
-			None, amount, // amount
-			2,      // minimum confirmations
-			500,    // max outputs
-			1,      // num change outputs
-			true,   // select all outputs
-			None, None,
+			args,
 		)?;
 		slate = client1.send_tx_slate_direct("wallet2", &slate_i)?;
 		sender_api.tx_lock_outputs(&slate)?;

--- a/controller/tests/transaction.rs
+++ b/controller/tests/transaction.rs
@@ -111,9 +111,7 @@ fn basic_transaction_api(test_dir: &str) -> Result<(), libwallet::Error> {
 			target_slate_version: None,
 			send_args: None,
 		};
-		let slate_i = sender_api.initiate_tx(
-			args,
-		)?;
+		let slate_i = sender_api.initiate_tx(args)?;
 
 		// Check we are creating a tx with the expected lock_height of 0.
 		// We will check this produces a Plain kernel later.
@@ -296,9 +294,7 @@ fn basic_transaction_api(test_dir: &str) -> Result<(), libwallet::Error> {
 			target_slate_version: None,
 			send_args: None,
 		};
-		let slate_i = sender_api.initiate_tx(
-			args,
-		)?;
+		let slate_i = sender_api.initiate_tx(args)?;
 		slate = client1.send_tx_slate_direct("wallet2", &slate_i)?;
 		sender_api.tx_lock_outputs(&slate)?;
 		slate = sender_api.finalize_tx(&slate)?;
@@ -400,9 +396,7 @@ fn tx_rollback(test_dir: &str) -> Result<(), libwallet::Error> {
 			send_args: None,
 		};
 
-		let slate_i = sender_api.initiate_tx(
-			args,
-		)?;
+		let slate_i = sender_api.initiate_tx(args)?;
 		slate = client1.send_tx_slate_direct("wallet2", &slate_i)?;
 		sender_api.tx_lock_outputs(&slate)?;
 		slate = sender_api.finalize_tx(&slate)?;

--- a/controller/tests/transaction.rs
+++ b/controller/tests/transaction.rs
@@ -259,7 +259,7 @@ fn basic_transaction_api(test_dir: &str) -> Result<(), libwallet::Error> {
 			max_outputs: 500,
 			num_change_outputs: 1,
 			selection_strategy_is_use_all: true,
-			estimate_only: true,
+			estimate_only: Some(true),
 			..Default::default()
 		};
 		let est = sender_api.initiate_tx(init_args)?;
@@ -273,7 +273,7 @@ fn basic_transaction_api(test_dir: &str) -> Result<(), libwallet::Error> {
 			max_outputs: 500,
 			num_change_outputs: 1,
 			selection_strategy_is_use_all: false, //select smallest number
-			estimate_only: true,
+			estimate_only: Some(true),
 			..Default::default()
 		};
 		let est = sender_api.initiate_tx(init_args)?;

--- a/controller/tests/transaction.rs
+++ b/controller/tests/transaction.rs
@@ -254,37 +254,33 @@ fn basic_transaction_api(test_dir: &str) -> Result<(), libwallet::Error> {
 
 	// Estimate fee and locked amount for a transaction
 	wallet::controller::owner_single_use(wallet1.clone(), |sender_api| {
-							let init_args = InitTxArgs {
-								src_acct_name: None,
-								amount: amount * 2,
-								minimum_confirmations: 2,
-								max_outputs: 500,
-								num_change_outputs: 1,
-								selection_strategy_is_use_all: true,
-								message: None,
-								target_slate_version: None,
-								send_args: None,
-							};
-		let est = sender_api.estimate_initiate_tx(
-			init_args,
-		)?;
+		let init_args = InitTxArgs {
+			src_acct_name: None,
+			amount: amount * 2,
+			minimum_confirmations: 2,
+			max_outputs: 500,
+			num_change_outputs: 1,
+			selection_strategy_is_use_all: true,
+			message: None,
+			target_slate_version: None,
+			send_args: None,
+		};
+		let est = sender_api.estimate_initiate_tx(init_args)?;
 		assert_eq!(est.total, 600_000_000_000);
 		assert_eq!(est.fee, 4_000_000);
 
-							let init_args = InitTxArgs {
-								src_acct_name: None,
-								amount: amount * 2,
-								minimum_confirmations: 2,
-								max_outputs: 500,
-								num_change_outputs: 1,
-								selection_strategy_is_use_all: false,  //select smallest number
-								message: None,
-								target_slate_version: None,
-								send_args: None,
-							};
-		let est = sender_api.estimate_initiate_tx(
-			init_args,
-		)?;
+		let init_args = InitTxArgs {
+			src_acct_name: None,
+			amount: amount * 2,
+			minimum_confirmations: 2,
+			max_outputs: 500,
+			num_change_outputs: 1,
+			selection_strategy_is_use_all: false, //select smallest number
+			message: None,
+			target_slate_version: None,
+			send_args: None,
+		};
+		let est = sender_api.estimate_initiate_tx(init_args)?;
 		assert_eq!(est.total, 180_000_000_000);
 		assert_eq!(est.fee, 6_000_000);
 

--- a/impls/src/test_framework/mod.rs
+++ b/impls/src/test_framework/mod.rs
@@ -23,7 +23,7 @@ use crate::keychain;
 use crate::libwallet;
 use crate::libwallet::api_impl::{foreign, owner};
 use crate::libwallet::types::{
-	BlockFees, CbData, NodeClient, WalletBackend, WalletInfo, WalletInst,
+	BlockFees, CbData, NodeClient, InitTxArgs, WalletBackend, WalletInfo, WalletInst,
 };
 use crate::lmdb_wallet::LMDBBackend;
 use crate::util;
@@ -196,14 +196,21 @@ where
 	let slate = {
 		let mut w = wallet.lock();
 		w.open_with_credentials()?;
+		let args = InitTxArgs {
+			src_acct_name: None,
+			amount,
+			minimum_confirmations: 2,
+			max_outputs: 500,
+			num_change_outputs: 1,
+			selection_strategy_is_use_all: true,
+			message: None,
+			target_slate_version: None,
+			send_args: None,
+		};
 		let slate_i = owner::initiate_tx(
-			&mut *w, None,   // account
-			amount, // amount
-			2,      // minimum confirmations
-			500,    // max outputs
-			1,      // num change outputs
-			true,   // select all outputs
-			None, None, test_mode,
+			&mut *w,
+			args,
+			test_mode,
 		)?;
 		let slate = client.send_tx_slate_direct(dest, &slate_i)?;
 		owner::tx_lock_outputs(&mut *w, &slate)?;

--- a/impls/src/test_framework/mod.rs
+++ b/impls/src/test_framework/mod.rs
@@ -203,9 +203,7 @@ where
 			max_outputs: 500,
 			num_change_outputs: 1,
 			selection_strategy_is_use_all: true,
-			message: None,
-			target_slate_version: None,
-			send_args: None,
+			..Default::default()
 		};
 		let slate_i = owner::initiate_tx(&mut *w, args, test_mode)?;
 		let slate = client.send_tx_slate_direct(dest, &slate_i)?;

--- a/impls/src/test_framework/mod.rs
+++ b/impls/src/test_framework/mod.rs
@@ -23,7 +23,7 @@ use crate::keychain;
 use crate::libwallet;
 use crate::libwallet::api_impl::{foreign, owner};
 use crate::libwallet::types::{
-	BlockFees, CbData, NodeClient, InitTxArgs, WalletBackend, WalletInfo, WalletInst,
+	BlockFees, CbData, InitTxArgs, NodeClient, WalletBackend, WalletInfo, WalletInst,
 };
 use crate::lmdb_wallet::LMDBBackend;
 use crate::util;
@@ -207,11 +207,7 @@ where
 			target_slate_version: None,
 			send_args: None,
 		};
-		let slate_i = owner::initiate_tx(
-			&mut *w,
-			args,
-			test_mode,
-		)?;
+		let slate_i = owner::initiate_tx(&mut *w, args, test_mode)?;
 		let slate = client.send_tx_slate_direct(dest, &slate_i)?;
 		owner::tx_lock_outputs(&mut *w, &slate)?;
 		let slate = owner::finalize_tx(&mut *w, &slate)?;

--- a/libwallet/src/api_impl/owner.rs
+++ b/libwallet/src/api_impl/owner.rs
@@ -25,8 +25,8 @@ use crate::grin_keychain::{Identifier, Keychain};
 use crate::internal::{keys, selection, tx, updater};
 use crate::slate::Slate;
 use crate::types::{
-	AcctPathMapping, NodeClient, NodeHeightResult, OutputCommitMapping, TxEstimation, TxLogEntry, TxWrapper,
-	WalletBackend, WalletInfo,
+	AcctPathMapping, NodeClient, NodeHeightResult, OutputCommitMapping, TxEstimation, TxLogEntry,
+	TxWrapper, WalletBackend, WalletInfo,
 };
 use crate::{Error, ErrorKind};
 
@@ -356,22 +356,20 @@ where
 {
 	let res = w.w2n_client().get_chain_height();
 	match res {
-		Ok(height) => Ok(NodeHeightResult{
-				height,
-				updated_from_node: true
-			}
-		),
+		Ok(height) => Ok(NodeHeightResult {
+			height,
+			updated_from_node: true,
+		}),
 		Err(_) => {
 			let outputs = retrieve_outputs(w, true, false, None)?;
 			let height = match outputs.1.iter().map(|m| m.output.height).max() {
 				Some(height) => height,
 				None => 0,
 			};
-			Ok(NodeHeightResult{
+			Ok(NodeHeightResult {
 				height,
 				updated_from_node: false,
-				}
-			)
+			})
 		}
 	}
 }

--- a/libwallet/src/api_impl/owner.rs
+++ b/libwallet/src/api_impl/owner.rs
@@ -25,8 +25,8 @@ use crate::grin_keychain::{Identifier, Keychain};
 use crate::internal::{keys, selection, tx, updater};
 use crate::slate::Slate;
 use crate::types::{
-	AcctPathMapping, NodeClient, NodeHeightResult, OutputCommitMapping, InitTxArgs, TxEstimation, TxLogEntry,
-	TxWrapper, WalletBackend, WalletInfo,
+	AcctPathMapping, InitTxArgs, NodeClient, NodeHeightResult, OutputCommitMapping, TxEstimation,
+	TxLogEntry, TxWrapper, WalletBackend, WalletInfo,
 };
 use crate::{Error, ErrorKind};
 

--- a/libwallet/src/api_impl/owner.rs
+++ b/libwallet/src/api_impl/owner.rs
@@ -168,7 +168,7 @@ where
 
 	// if we just want to estimate, don't save a context, just send the results
 	// back
-	if args.estimate_only {
+	if let Some(true) = args.estimate_only {
 		let (total, fee) = tx::estimate_send_tx(
 			&mut *w,
 			args.amount,

--- a/libwallet/src/api_impl/owner.rs
+++ b/libwallet/src/api_impl/owner.rs
@@ -25,7 +25,7 @@ use crate::grin_keychain::{Identifier, Keychain};
 use crate::internal::{keys, selection, tx, updater};
 use crate::slate::Slate;
 use crate::types::{
-	AcctPathMapping, InitTxArgs, NodeClient, NodeHeightResult, OutputCommitMapping, TxEstimation,
+	AcctPathMapping, InitTxArgs, NodeClient, NodeHeightResult, OutputCommitMapping, TxEstimate,
 	TxLogEntry, TxWrapper, WalletBackend, WalletInfo,
 };
 use crate::{Error, ErrorKind};
@@ -195,21 +195,16 @@ where
 /// Estimate
 pub fn estimate_initiate_tx<T: ?Sized, C, K>(
 	w: &mut T,
-	src_acct_name: Option<&str>,
-	amount: u64,
-	minimum_confirmations: u64,
-	max_outputs: usize,
-	num_change_outputs: usize,
-	selection_strategy_is_use_all: bool,
-) -> Result<TxEstimation, Error>
+	args: InitTxArgs,
+	) -> Result<TxEstimate, Error>
 where
 	T: WalletBackend<C, K>,
 	C: NodeClient,
 	K: Keychain,
 {
-	let parent_key_id = match src_acct_name {
+	let parent_key_id = match args.src_acct_name {
 		Some(d) => {
-			let pm = w.get_acct_path(d.to_owned())?;
+			let pm = w.get_acct_path(d)?;
 			match pm {
 				Some(p) => p.path,
 				None => w.parent_key_id(),
@@ -219,14 +214,14 @@ where
 	};
 	let (total, fee) = tx::estimate_send_tx(
 		&mut *w,
-		amount,
-		minimum_confirmations,
-		max_outputs,
-		num_change_outputs,
-		selection_strategy_is_use_all,
+		args.amount,
+		args.minimum_confirmations,
+		args.max_outputs as usize,
+		args.num_change_outputs as usize,
+		args.selection_strategy_is_use_all,
 		&parent_key_id,
 	)?;
-	Ok(TxEstimation { total, fee })
+	Ok(TxEstimate { total, fee })
 }
 
 /// Lock sender outputs

--- a/libwallet/src/api_impl/owner.rs
+++ b/libwallet/src/api_impl/owner.rs
@@ -196,7 +196,7 @@ where
 pub fn estimate_initiate_tx<T: ?Sized, C, K>(
 	w: &mut T,
 	args: InitTxArgs,
-	) -> Result<TxEstimate, Error>
+) -> Result<TxEstimate, Error>
 where
 	T: WalletBackend<C, K>,
 	C: NodeClient,

--- a/libwallet/src/api_impl/owner.rs
+++ b/libwallet/src/api_impl/owner.rs
@@ -25,8 +25,8 @@ use crate::grin_keychain::{Identifier, Keychain};
 use crate::internal::{keys, selection, tx, updater};
 use crate::slate::Slate;
 use crate::types::{
-	AcctPathMapping, InitTxArgs, NodeClient, NodeHeightResult, OutputCommitMapping,
-	TxLogEntry, TxWrapper, WalletBackend, WalletInfo,
+	AcctPathMapping, InitTxArgs, NodeClient, NodeHeightResult, OutputCommitMapping, TxLogEntry,
+	TxWrapper, WalletBackend, WalletInfo,
 };
 use crate::{Error, ErrorKind};
 
@@ -195,7 +195,6 @@ where
 		message,
 		use_test_rng,
 	)?;
-
 
 	// Save the aggsig context in our DB for when we
 	// recieve the transaction back

--- a/libwallet/src/types.rs
+++ b/libwallet/src/types.rs
@@ -766,6 +766,11 @@ pub struct InitTxArgs {
 	/// down to the minimum slate version compatible with the current. If `None` the slate
 	/// is generated with the latest version.
 	pub target_slate_version: Option<u16>,
+	/// If true, just return an estimate of the resulting slate, containing fees and amounts
+	/// locked without actually locking outputs or creating the transaction. Note if this is set to
+	/// 'true', the amount field in the slate will contain the total amount locked, not the provided
+	/// transaction amount
+	pub estimate_only: bool,
 	/// Sender arguments. If present, the underlying function will also attempt to send the
 	/// transaction to a destination and optionally finalize the result
 	pub send_args: Option<InitTxSendArgs>,
@@ -781,6 +786,23 @@ pub struct InitTxSendArgs {
 	pub dest: String,
 	/// Whether to finalize the result immediately if the send was successful
 	pub finalize: bool,
+}
+
+impl Default for InitTxArgs {
+	fn default() -> InitTxArgs {
+		InitTxArgs {
+			src_acct_name: None,
+			amount: 0,
+			minimum_confirmations: 10,
+			max_outputs: 500,
+			num_change_outputs: 1,
+			selection_strategy_is_use_all: true,
+			message: None,
+			target_slate_version: None,
+			estimate_only: false,
+			send_args: None,
+		}
+	}
 }
 
 /// Fees in block to use for coinbase amount calculation
@@ -825,17 +847,6 @@ pub struct OutputCommitMapping {
 		deserialize_with = "secp_ser::commitment_from_hex"
 	)]
 	pub commit: pedersen::Commitment,
-}
-
-/// Transaction Estimate
-#[derive(Serialize, Deserialize, Debug, Clone)]
-pub struct TxEstimate {
-	/// Total amount to be locked
-	#[serde(with = "secp_ser::string_or_u64")]
-	pub total: u64,
-	/// Transaction Fee
-	#[serde(with = "secp_ser::string_or_u64")]
-	pub fee: u64,
 }
 
 /// Node height result

--- a/libwallet/src/types.rs
+++ b/libwallet/src/types.rs
@@ -701,6 +701,8 @@ pub struct TxWrapper {
 // Types to facilitate API arguments and serialization
 
 /// Send TX API Args
+// TODO: This is here to ensure the legacy V1 API remains intact
+// remove this when v1 api is removed
 #[derive(Clone, Serialize, Deserialize)]
 pub struct SendTXArgs {
 	/// amount to send
@@ -721,6 +723,64 @@ pub struct SendTXArgs {
 	pub message: Option<String>,
 	/// Optional slate version to target when sending
 	pub target_slate_version: Option<u16>,
+}
+
+/// V2 Init / Send TX API Args
+#[derive(Clone, Serialize, Deserialize)]
+pub struct InitTxArgs {
+	/// The human readable account name from which to draw outputs
+	/// for the transaction, overriding whatever the active account is as set via the
+	/// [`set_active_account`](../grin_wallet_api/owner/struct.Owner.html#method.set_active_account) method.
+	pub src_acct_name: Option<String>,
+	#[serde(with = "secp_ser::string_or_u64")]
+	/// The amount to send, in nanogrins. (`1 G = 1_000_000_000nG`)
+	pub amount: u64,
+	#[serde(with = "secp_ser::string_or_u64")]
+	/// The minimum number of confirmations an output
+	/// should have in order to be included in the transaction.
+	pub minimum_confirmations: u64,
+	/// By default, the wallet selects as many inputs as possible in a
+	/// transaction, to reduce the Output set and the fees. The wallet will attempt to spend
+	/// include up to `max_outputs` in a transaction, however if this is not enough to cover
+	/// the whole amount, the wallet will include more outputs. This parameter should be considered
+	/// a soft limit.
+	pub max_outputs: u32,
+	/// The target number of change outputs to create in the transaction.
+	/// The actual number created will be `num_change_outputs` + whatever remainder is needed.
+	pub num_change_outputs: u32,
+	/// If `true`, attempt to use up as many outputs as
+	/// possible to create the transaction, up the 'soft limit' of `max_outputs`. This helps
+	/// to reduce the size of the UTXO set and the amount of data stored in the wallet, and
+	/// minimizes fees. This will generally result in many inputs and a large change output(s),
+	/// usually much larger than the amount being sent. If `false`, the transaction will include
+	/// as many outputs as are needed to meet the amount, (and no more) starting with the smallest
+	/// value outputs.
+	pub selection_strategy_is_use_all: bool,
+	/// An optional participant message to include alongside the sender's public
+	/// ParticipantData within the slate. This message will include a signature created with the
+	/// sender's private excess value, and will be publically verifiable. Note this message is for
+	/// the convenience of the participants during the exchange; it is not included in the final
+	/// transaction sent to the chain. The message will be truncated to 256 characters.
+	pub message: Option<String>,
+	/// Optionally set the output target slate version (acceptable
+	/// down to the minimum slate version compatible with the current. If `None` the slate
+	/// is generated with the latest version.
+	pub target_slate_version: Option<u16>,
+	/// Sender arguments. If present, the underlying function will also attempt to send the
+	/// transaction to a destination and optionally finalize the result
+	pub send_args: Option<InitTxSendArgs>,
+}
+
+/// Send TX API Args, for convenience functionality that inits the transaction and sends
+/// in one go
+#[derive(Clone, Serialize, Deserialize)]
+pub struct InitTxSendArgs {
+	/// The transaction method. Can currently be 'http' or 'keybase'.
+	pub method: String,
+	/// The destination, contents will depend on the particular method
+	pub dest: String,
+	/// Whether to finalize the result immediately if the send was successful
+	pub finalize: bool,
 }
 
 /// Fees in block to use for coinbase amount calculation

--- a/libwallet/src/types.rs
+++ b/libwallet/src/types.rs
@@ -373,29 +373,6 @@ impl fmt::Display for OutputStatus {
 	}
 }
 
-/// Map Outputdata to commits
-#[derive(Serialize, Deserialize, Debug, Clone)]
-pub struct OutputCommitMapping {
-	/// Output Data
-	pub output: OutputData,
-	/// The commit
-	#[serde(
-		serialize_with = "secp_ser::as_hex",
-		deserialize_with = "secp_ser::commitment_from_hex"
-	)]
-	pub commit: pedersen::Commitment,
-}
-
-/// Transaction Estimate
-#[derive(Serialize, Deserialize, Debug, Clone)]
-pub struct TxEstimation {
-	/// Total amount to be locked
-	#[serde(with = "secp_ser::string_or_u64")]
-	pub total: u64,
-	/// Transaction Fee
-	#[serde(with = "secp_ser::string_or_u64")]
-	pub fee: u64,
-}
 #[derive(Serialize, Deserialize, Clone, Debug)]
 /// Holds the context for a single aggsig transaction
 pub struct Context {
@@ -543,37 +520,6 @@ impl<'de> serde::de::Visitor<'de> for BlockIdentifierVisitor {
 		let block_hash = Hash::from_hex(s).unwrap();
 		Ok(BlockIdentifier(block_hash))
 	}
-}
-
-/// Fees in block to use for coinbase amount calculation
-#[derive(Serialize, Deserialize, Debug, Clone)]
-pub struct BlockFees {
-	/// fees
-	#[serde(with = "secp_ser::string_or_u64")]
-	pub fees: u64,
-	/// height
-	#[serde(with = "secp_ser::string_or_u64")]
-	pub height: u64,
-	/// key id
-	pub key_id: Option<Identifier>,
-}
-
-impl BlockFees {
-	/// return key id
-	pub fn key_id(&self) -> Option<Identifier> {
-		self.key_id.clone()
-	}
-}
-
-/// Response to build a coinbase output.
-#[derive(Serialize, Deserialize, Debug, Clone)]
-pub struct CbData {
-	/// Output
-	pub output: Output,
-	/// Kernel
-	pub kernel: TxKernel,
-	/// Key Id
-	pub key_id: Option<Identifier>,
 }
 
 /// a contained wallet info struct, so automated tests can parse wallet info
@@ -752,6 +698,8 @@ pub struct TxWrapper {
 	pub tx_hex: String,
 }
 
+// Types to facilitate API arguments and serialization
+
 /// Send TX API Args
 #[derive(Clone, Serialize, Deserialize)]
 pub struct SendTXArgs {
@@ -773,4 +721,69 @@ pub struct SendTXArgs {
 	pub message: Option<String>,
 	/// Optional slate version to target when sending
 	pub target_slate_version: Option<u16>,
+}
+
+/// Fees in block to use for coinbase amount calculation
+#[derive(Serialize, Deserialize, Debug, Clone)]
+pub struct BlockFees {
+	/// fees
+	#[serde(with = "secp_ser::string_or_u64")]
+	pub fees: u64,
+	/// height
+	#[serde(with = "secp_ser::string_or_u64")]
+	pub height: u64,
+	/// key id
+	pub key_id: Option<Identifier>,
+}
+
+impl BlockFees {
+	/// return key id
+	pub fn key_id(&self) -> Option<Identifier> {
+		self.key_id.clone()
+	}
+}
+
+/// Response to build a coinbase output.
+#[derive(Serialize, Deserialize, Debug, Clone)]
+pub struct CbData {
+	/// Output
+	pub output: Output,
+	/// Kernel
+	pub kernel: TxKernel,
+	/// Key Id
+	pub key_id: Option<Identifier>,
+}
+
+/// Map Outputdata to commits
+#[derive(Serialize, Deserialize, Debug, Clone)]
+pub struct OutputCommitMapping {
+	/// Output Data
+	pub output: OutputData,
+	/// The commit
+	#[serde(
+		serialize_with = "secp_ser::as_hex",
+		deserialize_with = "secp_ser::commitment_from_hex"
+	)]
+	pub commit: pedersen::Commitment,
+}
+
+/// Transaction Estimate
+#[derive(Serialize, Deserialize, Debug, Clone)]
+pub struct TxEstimation {
+	/// Total amount to be locked
+	#[serde(with = "secp_ser::string_or_u64")]
+	pub total: u64,
+	/// Transaction Fee
+	#[serde(with = "secp_ser::string_or_u64")]
+	pub fee: u64,
+}
+
+/// Node height result
+#[derive(Serialize, Deserialize, Debug, Clone)]
+pub struct NodeHeightResult {
+	/// Last known height
+	#[serde(with = "secp_ser::string_or_u64")]
+	pub height: u64,
+	/// Whether this height was updated from the node
+	pub updated_from_node: bool,
 }

--- a/libwallet/src/types.rs
+++ b/libwallet/src/types.rs
@@ -770,7 +770,7 @@ pub struct InitTxArgs {
 	/// locked without actually locking outputs or creating the transaction. Note if this is set to
 	/// 'true', the amount field in the slate will contain the total amount locked, not the provided
 	/// transaction amount
-	pub estimate_only: bool,
+	pub estimate_only: Option<bool>,
 	/// Sender arguments. If present, the underlying function will also attempt to send the
 	/// transaction to a destination and optionally finalize the result
 	pub send_args: Option<InitTxSendArgs>,
@@ -799,7 +799,7 @@ impl Default for InitTxArgs {
 			selection_strategy_is_use_all: true,
 			message: None,
 			target_slate_version: None,
-			estimate_only: false,
+			estimate_only: Some(false),
 			send_args: None,
 		}
 	}

--- a/libwallet/src/types.rs
+++ b/libwallet/src/types.rs
@@ -786,6 +786,10 @@ pub struct InitTxSendArgs {
 	pub dest: String,
 	/// Whether to finalize the result immediately if the send was successful
 	pub finalize: bool,
+	/// Whether to post the transasction if the send and finalize were successful
+	pub post_tx: bool,
+	/// Whether to use dandelion when posting. If false, skip the dandelion relay
+	pub fluff: bool,
 }
 
 impl Default for InitTxArgs {

--- a/libwallet/src/types.rs
+++ b/libwallet/src/types.rs
@@ -829,7 +829,7 @@ pub struct OutputCommitMapping {
 
 /// Transaction Estimate
 #[derive(Serialize, Deserialize, Debug, Clone)]
-pub struct TxEstimation {
+pub struct TxEstimate {
 	/// Total amount to be locked
 	#[serde(with = "secp_ser::string_or_u64")]
 	pub total: u64,


### PR DESCRIPTION
Final round of changes and documentation for the V2 Owner API, most notably:
* move parameters for `initiate_tx` into a separate struct
* remove `estimate_initiate_tx` and roll functionality into the main `initiate_tx` function via a parameter
* add parameters to `initiate_tx` instructing API to exchange, finalize and post transactions in one go, to emulate the `send_tx` functionality in V1
* Clean up of documentation