### PR TITLE
Command line implementation of invoice commands

### DIFF
--- a/controller/src/command.rs
+++ b/controller/src/command.rs
@@ -421,6 +421,104 @@ pub fn issue_invoice_tx(
 	Ok(())
 }
 
+/// Arguments for the process_invoice command
+pub struct ProcessInvoiceArgs {
+	pub message: Option<String>,
+	pub minimum_confirmations: u64,
+	pub selection_strategy: String,
+	pub method: String,
+	pub dest: String,
+	pub max_outputs: usize,
+	pub target_slate_version: Option<u16>,
+	pub input: String,
+	pub estimate_selection_strategies: bool,
+}
+
+/// Process invoice
+pub fn process_invoice(
+	wallet: Arc<Mutex<WalletInst<impl NodeClient + 'static, keychain::ExtKeychain>>>,
+	args: ProcessInvoiceArgs,
+	dark_scheme: bool,
+) -> Result<(), Error> {
+	let adapter = FileWalletCommAdapter::new();
+	let slate = adapter.receive_tx_async(&args.input)?;
+	controller::owner_single_use(wallet.clone(), |api| {
+		if args.estimate_selection_strategies {
+			let strategies = vec!["smallest", "all"]
+				.into_iter()
+				.map(|strategy| {
+					let init_args = InitTxArgs {
+						src_acct_name: None,
+						amount: slate.amount,
+						minimum_confirmations: args.minimum_confirmations,
+						max_outputs: args.max_outputs as u32,
+						num_change_outputs: 1u32,
+						selection_strategy_is_use_all: strategy == "all",
+						estimate_only: Some(true),
+						..Default::default()
+					};
+					let slate = api.init_send_tx(init_args).unwrap();
+					(strategy, slate.amount, slate.fee)
+				})
+				.collect();
+			display::estimate(slate.amount, strategies, dark_scheme);
+		} else {
+			let init_args = InitTxArgs {
+				src_acct_name: None,
+				amount: 0,
+				minimum_confirmations: args.minimum_confirmations,
+				max_outputs: args.max_outputs as u32,
+				num_change_outputs: 1u32,
+				selection_strategy_is_use_all: args.selection_strategy == "all",
+				message: args.message.clone(),
+				target_slate_version: args.target_slate_version,
+				send_args: None,
+				..Default::default()
+			};
+			if let Err(e) = api.verify_slate_messages(&slate) {
+				error!("Error validating participant messages: {}", e);
+				return Err(e);
+			}
+			let result = api.process_invoice_tx(&slate, init_args);
+			let mut slate = match result {
+				Ok(s) => {
+					info!(
+						"Invoice processed: {} grin to {} (strategy '{}')",
+						core::amount_to_hr_string(slate.amount, false),
+						args.dest,
+						args.selection_strategy,
+					);
+					s
+				}
+				Err(e) => {
+					info!("Tx not created: {}", e);
+					return Err(e);
+				}
+			};
+			let adapter = match args.method.as_str() {
+				"http" => HTTPWalletCommAdapter::new(),
+				"file" => FileWalletCommAdapter::new(),
+				"self" => NullWalletCommAdapter::new(),
+				_ => NullWalletCommAdapter::new(),
+			};
+			if adapter.supports_sync() {
+				slate = adapter.send_tx_sync(&args.dest, &slate)?;
+				api.tx_lock_outputs(&slate)?;
+				if args.method == "self" {
+					controller::foreign_single_use(wallet, |api| {
+						slate = api.finalize_invoice_tx(&slate)?;
+						Ok(())
+					})?;
+				}
+			} else {
+				adapter.send_tx_async(&args.dest, &slate)?;
+				api.tx_lock_outputs(&slate)?;
+			}
+		}
+		Ok(())
+	})?;
+	Ok(())
+}
 /// Info command args
 pub struct InfoArgs {
 	pub minimum_confirmations: u64,

--- a/controller/src/command.rs
+++ b/controller/src/command.rs
@@ -35,7 +35,7 @@ use crate::impls::{
 	LMDBBackend, NullWalletCommAdapter,
 };
 use crate::impls::{HTTPNodeClient, WalletSeed};
-use crate::libwallet::{InitTxArgs, NodeClient, WalletInst};
+use crate::libwallet::{InitTxArgs, IssueInvoiceTxArgs, NodeClient, WalletInst};
 use crate::{controller, display};
 
 /// Arguments common to all wallet commands
@@ -395,6 +395,29 @@ pub fn finalize(
 				Err(e)
 			}
 		}
+	})?;
+	Ok(())
+}
+
+/// Issue Invoice Args
+pub struct IssueInvoiceArgs {
+	/// output file
+	pub dest: String,
+	/// issue invoice tx args
+	pub issue_args: IssueInvoiceTxArgs,
+}
+
+pub fn issue_invoice_tx(
+	wallet: Arc<Mutex<WalletInst<impl NodeClient + 'static, keychain::ExtKeychain>>>,
+	args: IssueInvoiceArgs
+) -> Result<(), Error> {
+	controller::owner_single_use(wallet.clone(), |api| {
+		let slate =
+			api.issue_invoice_tx(args.issue_args)?;
+		let mut tx_file = File::create(args.dest.clone())?;
+			tx_file.write_all(json::to_string(&slate).unwrap().as_bytes())?;
+			tx_file.sync_all()?;
+		Ok(())
 	})?;
 	Ok(())
 }

--- a/controller/src/command.rs
+++ b/controller/src/command.rs
@@ -387,7 +387,9 @@ pub fn finalize(
 		match part_data {
 			None => {
 				error!("Expected slate participant data missing");
-				return Err(ErrorKind::ArgumentError("Expected Slate participant data missing".into()))?;
+				return Err(ErrorKind::ArgumentError(
+					"Expected Slate participant data missing".into(),
+				))?;
 			}
 			Some(p) => !p.is_complete(),
 		}

--- a/controller/src/command.rs
+++ b/controller/src/command.rs
@@ -409,14 +409,13 @@ pub struct IssueInvoiceArgs {
 
 pub fn issue_invoice_tx(
 	wallet: Arc<Mutex<WalletInst<impl NodeClient + 'static, keychain::ExtKeychain>>>,
-	args: IssueInvoiceArgs
+	args: IssueInvoiceArgs,
 ) -> Result<(), Error> {
 	controller::owner_single_use(wallet.clone(), |api| {
-		let slate =
-			api.issue_invoice_tx(args.issue_args)?;
+		let slate = api.issue_invoice_tx(args.issue_args)?;
 		let mut tx_file = File::create(args.dest.clone())?;
-			tx_file.write_all(json::to_string(&slate).unwrap().as_bytes())?;
-			tx_file.sync_all()?;
+		tx_file.write_all(json::to_string(&slate).unwrap().as_bytes())?;
+		tx_file.sync_all()?;
 		Ok(())
 	})?;
 	Ok(())

--- a/controller/tests/invoice.rs
+++ b/controller/tests/invoice.rs
@@ -124,6 +124,7 @@ fn invoice_tx_impl(test_dir: &str) -> Result<(), libwallet::Error> {
 				..Default::default()
 			};
 			slate = api.process_invoice_tx(&slate, args)?;
+			api.tx_lock_outputs(&slate)?;
 			Ok(())
 		})?;
 

--- a/libwallet/src/api_impl/owner.rs
+++ b/libwallet/src/api_impl/owner.rs
@@ -330,9 +330,6 @@ where
 		batch.commit()?;
 	}
 
-	// Always lock the context for now
-	selection::lock_tx_context(&mut *w, slate, &context)?;
-	tx::update_message(&mut *w, &mut ret_slate)?;
 	Ok(ret_slate)
 }
 

--- a/libwallet/src/slate.rs
+++ b/libwallet/src/slate.rs
@@ -382,7 +382,7 @@ impl Slate {
 		self.finalize_transaction(keychain, &final_sig)
 	}
 
-	/// Return the participant with the given id 
+	/// Return the participant with the given id
 	pub fn participant_with_id(&self, id: usize) -> Option<ParticipantData> {
 		for p in self.participant_data.iter() {
 			if p.id as usize == id {

--- a/libwallet/src/slate.rs
+++ b/libwallet/src/slate.rs
@@ -374,13 +374,22 @@ impl Slate {
 
 	/// Creates the final signature, callable by either the sender or recipient
 	/// (after phase 3: sender confirmation)
-	/// TODO: Only callable by receiver at the moment
 	pub fn finalize<K>(&mut self, keychain: &K) -> Result<(), Error>
 	where
 		K: Keychain,
 	{
 		let final_sig = self.finalize_signature(keychain)?;
 		self.finalize_transaction(keychain, &final_sig)
+	}
+
+	/// Return the participant with the given id 
+	pub fn participant_with_id(&self, id: usize) -> Option<ParticipantData> {
+		for p in self.participant_data.iter() {
+			if p.id as usize == id {
+				return Some(p.clone());
+			}
+		}
+		None
 	}
 
 	/// Return the sum of public nonces

--- a/libwallet/src/slate.rs
+++ b/libwallet/src/slate.rs
@@ -27,15 +27,15 @@ use crate::grin_core::core::verifier_cache::LruVerifierCache;
 use crate::grin_core::libtx::{aggsig, build, secp_ser, tx_fee};
 use crate::grin_core::map_vec;
 use crate::grin_keychain::{BlindSum, BlindingFactor, Keychain};
-use crate::grin_util::{self, secp, RwLock};
 use crate::grin_util::secp::key::{PublicKey, SecretKey};
 use crate::grin_util::secp::Signature;
+use crate::grin_util::{self, secp, RwLock};
 use failure::ResultExt;
 use rand::rngs::mock::StepRng;
 use rand::thread_rng;
 use serde_json;
-use std::sync::Arc;
 use std::fmt;
+use std::sync::Arc;
 use uuid::Uuid;
 
 use crate::slate_versions::v0::SlateV0;
@@ -125,7 +125,11 @@ impl fmt::Display for ParticipantMessageData {
 		writeln!(f, "---------------------")?;
 		let static_secp = grin_util::static_secp_instance();
 		let static_secp = static_secp.lock();
-		writeln!(f, "Public Key: {}", &grin_util::to_hex(self.public_key.serialize_vec(&static_secp, true).to_vec()))?;
+		writeln!(
+			f,
+			"Public Key: {}",
+			&grin_util::to_hex(self.public_key.serialize_vec(&static_secp, true).to_vec())
+		)?;
 		let message = match self.message.clone() {
 			None => "None".to_owned(),
 			Some(m) => m,

--- a/libwallet/src/slate_versions/v2.rs
+++ b/libwallet/src/slate_versions/v2.rs
@@ -29,7 +29,7 @@
 //! * TxKernel fields serialized as hex strings instead of arrays:
 //!    commit
 //!    signature
-//! * version_info field removed
+//! * version field removed
 //! * VersionCompatInfo struct created with fields and added to beginning of struct
 //!    version: u16
 //!    orig_verion: u16,

--- a/src/bin/cmd/wallet_args.rs
+++ b/src/bin/cmd/wallet_args.rs
@@ -12,7 +12,6 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-
 use crate::api::TLSConfig;
 use crate::util::file::get_first_line;
 use crate::util::{Mutex, ZeroingString};
@@ -25,13 +24,13 @@ use grin_wallet_controller::{Error, ErrorKind};
 use grin_wallet_impls::{instantiate_wallet, FileWalletCommAdapter, WalletSeed};
 use grin_wallet_libwallet::{IssueInvoiceTxArgs, NodeClient, Slate, WalletInst};
 use grin_wallet_util::grin_core as core;
+use grin_wallet_util::grin_core::core::amount_to_hr_string;
 use grin_wallet_util::grin_keychain as keychain;
 use linefeed::terminal::Signal;
 use linefeed::{Interface, ReadResult};
 use rpassword;
 use std::path::Path;
 use std::sync::Arc;
-use grin_wallet_util::grin_core::core::amount_to_hr_string;
 
 // define what to do on argument error
 macro_rules! arg_parse {
@@ -146,12 +145,19 @@ fn prompt_pay_invoice(slate: &Slate, method: &str, dest: &str) -> Result<bool, P
 	let interface = Arc::new(Interface::new("pay")?);
 	let amount = amount_to_hr_string(slate.amount, false);
 	interface.set_report_signal(Signal::Interrupt, true);
-	interface.set_prompt("To proceed, type the exact amount of the invoice as displayed above (or Q/q to quit) > ")?;
+	interface.set_prompt(
+		"To proceed, type the exact amount of the invoice as displayed above (or Q/q to quit) > ",
+	)?;
 	println!();
-	println!("This command will pay the amount specified in the invoice using your wallet's funds.");
+	println!(
+		"This command will pay the amount specified in the invoice using your wallet's funds."
+	);
 	println!("After you confirm, the following will occur: ");
 	println!();
-	println!("* {} of your wallet funds will be added to the transaction to pay this invoice.", amount);
+	println!(
+		"* {} of your wallet funds will be added to the transaction to pay this invoice.",
+		amount
+	);
 	if method == "http" {
 		println!("* The resulting transaction will IMMEDIATELY be sent to the wallet listening at: '{}'.", dest);
 	} else {
@@ -174,17 +180,19 @@ fn prompt_pay_invoice(slate: &Slate, method: &str, dest: &str) -> Result<bool, P
 					return Err(ParseError::CancelledError);
 				}
 			}
-			ReadResult::Input(line) => match line.trim() {
-				"Q" | "q" => return Err(ParseError::CancelledError),
-				result => {
-					if result == amount {
-						return Ok(true);
-					} else {
-						println!("Please enter exact amount of the invoice as shown above or Q to quit");
-						println!();
+			ReadResult::Input(line) => {
+				match line.trim() {
+					"Q" | "q" => return Err(ParseError::CancelledError),
+					result => {
+						if result == amount {
+							return Ok(true);
+						} else {
+							println!("Please enter exact amount of the invoice as shown above or Q to quit");
+							println!();
+						}
 					}
-				},
-			},
+				}
+			}
 		}
 	}
 }

--- a/src/bin/cmd/wallet_args.rs
+++ b/src/bin/cmd/wallet_args.rs
@@ -500,6 +500,84 @@ pub fn parse_issue_invoice_args(
 	})
 }
 
+pub fn parse_process_invoice_args(args: &ArgMatches) -> Result<command::ProcessInvoiceArgs, ParseError> {
+	// TODO: display and prompt for confirmation of what we're doing
+	// message
+	let message = match args.is_present("message") {
+		true => Some(args.value_of("message").unwrap().to_owned()),
+		false => None,
+	};
+
+	// minimum_confirmations
+	let min_c = parse_required(args, "minimum_confirmations")?;
+	let min_c = parse_u64(min_c, "minimum_confirmations")?;
+
+	// selection_strategy
+	let selection_strategy = parse_required(args, "selection_strategy")?;
+
+	// estimate_selection_strategies
+	let estimate_selection_strategies = args.is_present("estimate_selection_strategies");
+
+	// method
+	let method = parse_required(args, "method")?;
+
+	// dest
+	let dest = {
+		if method == "self" {
+			match args.value_of("dest") {
+				Some(d) => d,
+				None => "default",
+			}
+		} else {
+			if !estimate_selection_strategies {
+				parse_required(args, "dest")?
+			} else {
+				""
+			}
+		}
+	};
+	if !estimate_selection_strategies
+		&& method == "http"
+		&& !dest.starts_with("http://")
+		&& !dest.starts_with("https://")
+	{
+		let msg = format!(
+			"HTTP Destination should start with http://: or https://: {}",
+			dest,
+		);
+		return Err(ParseError::ArgumentError(msg));
+	}
+
+	// max_outputs
+	let max_outputs = 500;
+
+	// target slate version to create/send
+	let target_slate_version = {
+		match args.is_present("slate_version") {
+			true => {
+				let v = parse_required(args, "slate_version")?;
+				Some(parse_u64(v, "slate_version")? as u16)
+			}
+			false => None,
+		}
+	};
+
+	// file input only
+	let tx_file = parse_required(args, "input")?;
+
+	Ok(command::ProcessInvoiceArgs {
+		message: message,
+		minimum_confirmations: min_c,
+		selection_strategy: selection_strategy.to_owned(),
+		estimate_selection_strategies,
+		method: method.to_owned(),
+		dest: dest.to_owned(),
+		max_outputs: max_outputs,
+		target_slate_version: target_slate_version,
+		input: tx_file.to_owned(),
+	})
+}
+
 pub fn parse_info_args(args: &ArgMatches) -> Result<command::InfoArgs, ParseError> {
 	// minimum_confirmations
 	let mc = parse_required(args, "minimum_confirmations")?;
@@ -656,6 +734,14 @@ pub fn wallet_command(
 		("issue_invoice", Some(args)) => {
 			let a = arg_parse!(parse_issue_invoice_args(&args));
 			command::issue_invoice_tx(inst_wallet(), a)
+		}
+		("process_invoice", Some(args)) => {
+			let a = arg_parse!(parse_process_invoice_args(&args));
+			command::process_invoice(
+				inst_wallet(),
+				a,
+				wallet_config.dark_background_color_scheme.unwrap_or(true),
+			)
 		}
 		("info", Some(args)) => {
 			let a = arg_parse!(parse_info_args(&args));

--- a/src/bin/cmd/wallet_args.rs
+++ b/src/bin/cmd/wallet_args.rs
@@ -458,7 +458,6 @@ pub fn parse_finalize_args(args: &ArgMatches) -> Result<command::FinalizeArgs, P
 }
 
 pub fn parse_issue_invoice_args(
-	g_args: &command::GlobalArgs,
 	args: &ArgMatches,
 ) -> Result<command::IssueInvoiceArgs, ParseError> {
 	let amount = parse_required(args, "amount")?;
@@ -493,7 +492,7 @@ pub fn parse_issue_invoice_args(
 	Ok(command::IssueInvoiceArgs {
 		dest: dest.into(),
 		issue_args: IssueInvoiceTxArgs {
-			dest_acct_name: Some(g_args.account.to_owned()),
+			dest_acct_name: None,
 			amount,
 			message,
 			target_slate_version,
@@ -655,8 +654,7 @@ pub fn wallet_command(
 			command::finalize(inst_wallet(), a)
 		}
 		("issue_invoice", Some(args)) => {
-			let g = global_wallet_args.clone();
-			let a = arg_parse!(parse_issue_invoice_args(&g, &args));
+			let a = arg_parse!(parse_issue_invoice_args(&args));
 			command::issue_invoice_tx(inst_wallet(), a)
 		}
 		("info", Some(args)) => {

--- a/src/bin/cmd/wallet_args.rs
+++ b/src/bin/cmd/wallet_args.rs
@@ -733,11 +733,11 @@ pub fn wallet_command(
 			let a = arg_parse!(parse_finalize_args(&args));
 			command::finalize(inst_wallet(), a)
 		}
-		("issue_invoice", Some(args)) => {
+		("invoice", Some(args)) => {
 			let a = arg_parse!(parse_issue_invoice_args(&args));
 			command::issue_invoice_tx(inst_wallet(), a)
 		}
-		("process_invoice", Some(args)) => {
+		("pay", Some(args)) => {
 			let a = arg_parse!(parse_process_invoice_args(&args));
 			command::process_invoice(
 				inst_wallet(),

--- a/src/bin/cmd/wallet_args.rs
+++ b/src/bin/cmd/wallet_args.rs
@@ -500,7 +500,9 @@ pub fn parse_issue_invoice_args(
 	})
 }
 
-pub fn parse_process_invoice_args(args: &ArgMatches) -> Result<command::ProcessInvoiceArgs, ParseError> {
+pub fn parse_process_invoice_args(
+	args: &ArgMatches,
+) -> Result<command::ProcessInvoiceArgs, ParseError> {
 	// TODO: display and prompt for confirmation of what we're doing
 	// message
 	let message = match args.is_present("message") {

--- a/src/bin/cmd/wallet_args.rs
+++ b/src/bin/cmd/wallet_args.rs
@@ -459,8 +459,8 @@ pub fn parse_finalize_args(args: &ArgMatches) -> Result<command::FinalizeArgs, P
 
 pub fn parse_issue_invoice_args(
 	g_args: &command::GlobalArgs,
-	args: &ArgMatches)
--> Result<command::IssueInvoiceArgs, ParseError> {
+	args: &ArgMatches,
+) -> Result<command::IssueInvoiceArgs, ParseError> {
 	let amount = parse_required(args, "amount")?;
 	let amount = core::core::amount_from_hr_string(amount);
 	let amount = match amount {
@@ -497,7 +497,7 @@ pub fn parse_issue_invoice_args(
 			amount,
 			message,
 			target_slate_version,
-		}
+		},
 	})
 }
 

--- a/src/bin/cmd/wallet_tests.rs
+++ b/src/bin/cmd/wallet_tests.rs
@@ -513,6 +513,21 @@ mod wallet_tests {
 		];
 		execute_command(&app, test_dir, "wallet1", &client1, arg_vec)?;
 
+		// and finalize, wallet 2 
+		let arg_vec = vec![
+			"grin-wallet",
+			"-p",
+			"password",
+			"finalize",
+			"-i",
+			&output_file_name,
+		];
+		execute_command(&app, test_dir, "wallet2", &client2, arg_vec)?;
+
+		// bit more mining
+		let _ = test_framework::award_blocks_to_wallet(&chain, wallet1.clone(), 5, false);
+		//bh += 5;
+
 		// txs and outputs (mostly spit out for a visual in test logs)
 		let arg_vec = vec!["grin-wallet", "-p", "password", "-a", "mining", "txs"];
 		execute_command(&app, test_dir, "wallet1", &client1, arg_vec)?;
@@ -533,6 +548,12 @@ mod wallet_tests {
 		// txs and outputs (mostly spit out for a visual in test logs)
 		let arg_vec = vec!["grin-wallet", "-p", "password", "-a", "mining", "outputs"];
 		execute_command(&app, test_dir, "wallet1", &client1, arg_vec)?;
+
+		let arg_vec = vec!["grin-wallet", "-p", "password", "txs"];
+		execute_command(&app, test_dir, "wallet2", &client2, arg_vec)?;
+
+		let arg_vec = vec!["grin-wallet", "-p", "password", "outputs"];
+		execute_command(&app, test_dir, "wallet2", &client2, arg_vec)?;
 
 		// let logging finish
 		thread::sleep(Duration::from_millis(200));

--- a/src/bin/cmd/wallet_tests.rs
+++ b/src/bin/cmd/wallet_tests.rs
@@ -480,6 +480,23 @@ mod wallet_tests {
 		];
 		execute_command(&app, test_dir, "wallet1", &client1, arg_vec)?;
 
+		// issue an invoice tx
+		let file_name = format!("{}/issue_invoice.slate", test_dir);
+		let arg_vec = vec![
+			"grin-wallet",
+			"-p",
+			"password",
+			"-a",
+			"mining",
+			"issue_invoice",
+			"-d",
+			&file_name,
+			"-g",
+			"Please give me your precious grins. Love, Yeast",
+			"65",
+		];
+		execute_command(&app, test_dir, "wallet1", &client1, arg_vec)?;
+
 		// txs and outputs (mostly spit out for a visual in test logs)
 		let arg_vec = vec!["grin-wallet", "-p", "password", "-a", "mining", "txs"];
 		execute_command(&app, test_dir, "wallet1", &client1, arg_vec)?;

--- a/src/bin/cmd/wallet_tests.rs
+++ b/src/bin/cmd/wallet_tests.rs
@@ -481,14 +481,14 @@ mod wallet_tests {
 		execute_command(&app, test_dir, "wallet1", &client1, arg_vec)?;
 
 		// issue an invoice tx
-		let file_name = format!("{}/issue_invoice.slate", test_dir);
+		let file_name = format!("{}/invoice.slate", test_dir);
 		let arg_vec = vec![
 			"grin-wallet",
 			"-p",
 			"password",
 			"-a",
 			"mining",
-			"issue_invoice",
+			"invoice",
 			"-d",
 			&file_name,
 			"-g",

--- a/src/bin/cmd/wallet_tests.rs
+++ b/src/bin/cmd/wallet_tests.rs
@@ -480,20 +480,36 @@ mod wallet_tests {
 		];
 		execute_command(&app, test_dir, "wallet1", &client1, arg_vec)?;
 
-		// issue an invoice tx
+		// issue an invoice tx, wallet 2
 		let file_name = format!("{}/invoice.slate", test_dir);
 		let arg_vec = vec![
 			"grin-wallet",
 			"-p",
 			"password",
-			"-a",
-			"mining",
 			"invoice",
 			"-d",
 			&file_name,
 			"-g",
 			"Please give me your precious grins. Love, Yeast",
 			"65",
+		];
+		execute_command(&app, test_dir, "wallet2", &client2, arg_vec)?;
+		let output_file_name = format!("{}/invoice.slate.paid", test_dir);
+
+		// now pay the invoice tx, wallet 1
+		let arg_vec = vec![
+			"grin-wallet",
+			"-a",
+			"mining",
+			"-p",
+			"password",
+			"pay",
+			"-i",
+			&file_name,
+			"-d",
+			&output_file_name,
+			"-g",
+			"Here you go",
 		];
 		execute_command(&app, test_dir, "wallet1", &client1, arg_vec)?;
 

--- a/src/bin/cmd/wallet_tests.rs
+++ b/src/bin/cmd/wallet_tests.rs
@@ -513,7 +513,7 @@ mod wallet_tests {
 		];
 		execute_command(&app, test_dir, "wallet1", &client1, arg_vec)?;
 
-		// and finalize, wallet 2 
+		// and finalize, wallet 2
 		let arg_vec = vec![
 			"grin-wallet",
 			"-p",

--- a/src/bin/grin-wallet.yml
+++ b/src/bin/grin-wallet.yml
@@ -183,6 +183,53 @@ subcommands:
             short: d
             long: dest
             takes_value: true
+  - process_invoice:
+      about: Spend coins to pay the provided invoice transaction
+      args:
+        - minimum_confirmations:
+            help: Minimum number of confirmations required for an output to be spendable
+            short: c
+            long: min_conf
+            default_value: "10"
+            takes_value: true
+        - selection_strategy:
+            help: Coin/Output selection strategy.
+            short: s
+            long: selection
+            possible_values:
+              - all
+              - smallest
+            default_value: all
+            takes_value: true
+        - estimate_selection_strategies:
+            help: Estimates all possible Coin/Output selection strategies.
+            short: e
+            long: estimate-selection
+        - method:
+            help: Method for sending the processed invoice back to the invoice creator
+            short: m
+            long: method
+            possible_values:
+              - file
+              - http
+              - self
+            default_value: file
+            takes_value: true
+        - dest:
+            help: Send the transaction to the provided server (start with http://) or save as file.
+            short: d
+            long: dest
+            takes_value: true
+        - message:
+            help: Optional participant message to include
+            short: g
+            long: message
+            takes_value: true
+        - input:
+            help: Partial transaction to process, expects the invoicer's transaction file.
+            short: i
+            long: input
+            takes_value: true
   - outputs:
       about: Raw wallet output info (list of outputs)
   - txs:

--- a/src/bin/grin-wallet.yml
+++ b/src/bin/grin-wallet.yml
@@ -162,6 +162,27 @@ subcommands:
             help: Fluff the transaction (ignore Dandelion relay protocol)
             short: f
             long: fluff
+  - issue_invoice:
+      about: Initialize an invoice transction.
+      args:
+        - amount:
+            help: Number of coins to invoice  with optional fraction, e.g. 12.423
+            index: 1
+        - message:
+            help: Optional participant message to include
+            short: g
+            long: message
+            takes_value: true
+        - slate_version:
+            help: Target slate version to output/send to receiver
+            short: v
+            long: slate_version
+            takes_value: true
+        - dest:
+            help: Name of destination slate output file
+            short: d
+            long: dest
+            takes_value: true
   - outputs:
       about: Raw wallet output info (list of outputs)
   - txs:

--- a/src/bin/grin-wallet.yml
+++ b/src/bin/grin-wallet.yml
@@ -162,7 +162,7 @@ subcommands:
             help: Fluff the transaction (ignore Dandelion relay protocol)
             short: f
             long: fluff
-  - issue_invoice:
+  - invoice:
       about: Initialize an invoice transction.
       args:
         - amount:
@@ -183,7 +183,7 @@ subcommands:
             short: d
             long: dest
             takes_value: true
-  - process_invoice:
+  - pay:
       about: Spend coins to pay the provided invoice transaction
       args:
         - minimum_confirmations:


### PR DESCRIPTION
Following from #90, the actual command line implementation exercising the invoice commands.

The code will mostly be a lot of boilerplate copying from the parsing and api execution system that's in place, but the particular file to watch for comments on the UI (if you can even call it that) is the command line arg yaml definition file:

`src/bin/grin-wallet.yml`

- [x] invoice command
- [x] pay command
- [x] finalize  command
- [ ] community review, particularly on naming, arguments, and process_invoice workflow
- [x] test implementation exercising new commands (ongoing)