### PR TITLE
Updates for 1.1.0-beta.3 release

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -555,17 +555,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 [[package]]
 name = "grin_api"
 version = "1.1.0-beta.2"
-source = "git+https://github.com/mimblewimble/grin#884851cdeb59305b88300e9110500cbb15b51dc2"
+source = "git+https://github.com/mimblewimble/grin?tag=v1.1.0-beta.2#9ab23f6eef1d03aa2facc32d439852bda0127daf"
 dependencies = [
  "failure 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)",
  "failure_derive 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)",
  "futures 0.1.26 (registry+https://github.com/rust-lang/crates.io-index)",
- "grin_chain 1.1.0-beta.2 (git+https://github.com/mimblewimble/grin)",
- "grin_core 1.1.0-beta.2 (git+https://github.com/mimblewimble/grin)",
- "grin_p2p 1.1.0-beta.2 (git+https://github.com/mimblewimble/grin)",
- "grin_pool 1.1.0-beta.2 (git+https://github.com/mimblewimble/grin)",
- "grin_store 1.1.0-beta.2 (git+https://github.com/mimblewimble/grin)",
- "grin_util 1.1.0-beta.2 (git+https://github.com/mimblewimble/grin)",
+ "grin_chain 1.1.0-beta.2 (git+https://github.com/mimblewimble/grin?tag=v1.1.0-beta.2)",
+ "grin_core 1.1.0-beta.2 (git+https://github.com/mimblewimble/grin?tag=v1.1.0-beta.2)",
+ "grin_p2p 1.1.0-beta.2 (git+https://github.com/mimblewimble/grin?tag=v1.1.0-beta.2)",
+ "grin_pool 1.1.0-beta.2 (git+https://github.com/mimblewimble/grin?tag=v1.1.0-beta.2)",
+ "grin_store 1.1.0-beta.2 (git+https://github.com/mimblewimble/grin?tag=v1.1.0-beta.2)",
+ "grin_util 1.1.0-beta.2 (git+https://github.com/mimblewimble/grin?tag=v1.1.0-beta.2)",
  "http 0.1.17 (registry+https://github.com/rust-lang/crates.io-index)",
  "hyper 0.12.19 (registry+https://github.com/rust-lang/crates.io-index)",
  "hyper-rustls 0.14.0 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -587,7 +587,7 @@ dependencies = [
 [[package]]
 name = "grin_chain"
 version = "1.1.0-beta.2"
-source = "git+https://github.com/mimblewimble/grin#884851cdeb59305b88300e9110500cbb15b51dc2"
+source = "git+https://github.com/mimblewimble/grin?tag=v1.1.0-beta.2#9ab23f6eef1d03aa2facc32d439852bda0127daf"
 dependencies = [
  "bitflags 1.0.4 (registry+https://github.com/rust-lang/crates.io-index)",
  "byteorder 1.3.1 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -595,10 +595,10 @@ dependencies = [
  "croaring 0.3.9 (registry+https://github.com/rust-lang/crates.io-index)",
  "failure 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)",
  "failure_derive 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)",
- "grin_core 1.1.0-beta.2 (git+https://github.com/mimblewimble/grin)",
- "grin_keychain 1.1.0-beta.2 (git+https://github.com/mimblewimble/grin)",
- "grin_store 1.1.0-beta.2 (git+https://github.com/mimblewimble/grin)",
- "grin_util 1.1.0-beta.2 (git+https://github.com/mimblewimble/grin)",
+ "grin_core 1.1.0-beta.2 (git+https://github.com/mimblewimble/grin?tag=v1.1.0-beta.2)",
+ "grin_keychain 1.1.0-beta.2 (git+https://github.com/mimblewimble/grin?tag=v1.1.0-beta.2)",
+ "grin_store 1.1.0-beta.2 (git+https://github.com/mimblewimble/grin?tag=v1.1.0-beta.2)",
+ "grin_util 1.1.0-beta.2 (git+https://github.com/mimblewimble/grin?tag=v1.1.0-beta.2)",
  "lazy_static 1.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "log 0.4.6 (registry+https://github.com/rust-lang/crates.io-index)",
  "lru-cache 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -610,7 +610,7 @@ dependencies = [
 [[package]]
 name = "grin_core"
 version = "1.1.0-beta.2"
-source = "git+https://github.com/mimblewimble/grin#884851cdeb59305b88300e9110500cbb15b51dc2"
+source = "git+https://github.com/mimblewimble/grin?tag=v1.1.0-beta.2#9ab23f6eef1d03aa2facc32d439852bda0127daf"
 dependencies = [
  "blake2-rfc 0.2.18 (registry+https://github.com/rust-lang/crates.io-index)",
  "byteorder 1.3.1 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -619,8 +619,8 @@ dependencies = [
  "enum_primitive 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "failure 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)",
  "failure_derive 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)",
- "grin_keychain 1.1.0-beta.2 (git+https://github.com/mimblewimble/grin)",
- "grin_util 1.1.0-beta.2 (git+https://github.com/mimblewimble/grin)",
+ "grin_keychain 1.1.0-beta.2 (git+https://github.com/mimblewimble/grin?tag=v1.1.0-beta.2)",
+ "grin_util 1.1.0-beta.2 (git+https://github.com/mimblewimble/grin?tag=v1.1.0-beta.2)",
  "lazy_static 1.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "log 0.4.6 (registry+https://github.com/rust-lang/crates.io-index)",
  "lru-cache 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -636,12 +636,12 @@ dependencies = [
 [[package]]
 name = "grin_keychain"
 version = "1.1.0-beta.2"
-source = "git+https://github.com/mimblewimble/grin#884851cdeb59305b88300e9110500cbb15b51dc2"
+source = "git+https://github.com/mimblewimble/grin?tag=v1.1.0-beta.2#9ab23f6eef1d03aa2facc32d439852bda0127daf"
 dependencies = [
  "blake2-rfc 0.2.18 (registry+https://github.com/rust-lang/crates.io-index)",
  "byteorder 1.3.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "digest 0.7.6 (registry+https://github.com/rust-lang/crates.io-index)",
- "grin_util 1.1.0-beta.2 (git+https://github.com/mimblewimble/grin)",
+ "grin_util 1.1.0-beta.2 (git+https://github.com/mimblewimble/grin?tag=v1.1.0-beta.2)",
  "hmac 0.6.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "lazy_static 1.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "log 0.4.6 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -658,16 +658,16 @@ dependencies = [
 [[package]]
 name = "grin_p2p"
 version = "1.1.0-beta.2"
-source = "git+https://github.com/mimblewimble/grin#884851cdeb59305b88300e9110500cbb15b51dc2"
+source = "git+https://github.com/mimblewimble/grin?tag=v1.1.0-beta.2#9ab23f6eef1d03aa2facc32d439852bda0127daf"
 dependencies = [
  "bitflags 1.0.4 (registry+https://github.com/rust-lang/crates.io-index)",
  "bytes 0.4.12 (registry+https://github.com/rust-lang/crates.io-index)",
  "chrono 0.4.6 (registry+https://github.com/rust-lang/crates.io-index)",
  "enum_primitive 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "grin_chain 1.1.0-beta.2 (git+https://github.com/mimblewimble/grin)",
- "grin_core 1.1.0-beta.2 (git+https://github.com/mimblewimble/grin)",
- "grin_store 1.1.0-beta.2 (git+https://github.com/mimblewimble/grin)",
- "grin_util 1.1.0-beta.2 (git+https://github.com/mimblewimble/grin)",
+ "grin_chain 1.1.0-beta.2 (git+https://github.com/mimblewimble/grin?tag=v1.1.0-beta.2)",
+ "grin_core 1.1.0-beta.2 (git+https://github.com/mimblewimble/grin?tag=v1.1.0-beta.2)",
+ "grin_store 1.1.0-beta.2 (git+https://github.com/mimblewimble/grin?tag=v1.1.0-beta.2)",
+ "grin_util 1.1.0-beta.2 (git+https://github.com/mimblewimble/grin?tag=v1.1.0-beta.2)",
  "log 0.4.6 (registry+https://github.com/rust-lang/crates.io-index)",
  "net2 0.2.33 (registry+https://github.com/rust-lang/crates.io-index)",
  "num 0.1.42 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -680,16 +680,16 @@ dependencies = [
 [[package]]
 name = "grin_pool"
 version = "1.1.0-beta.2"
-source = "git+https://github.com/mimblewimble/grin#884851cdeb59305b88300e9110500cbb15b51dc2"
+source = "git+https://github.com/mimblewimble/grin?tag=v1.1.0-beta.2#9ab23f6eef1d03aa2facc32d439852bda0127daf"
 dependencies = [
  "blake2-rfc 0.2.18 (registry+https://github.com/rust-lang/crates.io-index)",
  "chrono 0.4.6 (registry+https://github.com/rust-lang/crates.io-index)",
  "failure 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)",
  "failure_derive 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)",
- "grin_core 1.1.0-beta.2 (git+https://github.com/mimblewimble/grin)",
- "grin_keychain 1.1.0-beta.2 (git+https://github.com/mimblewimble/grin)",
- "grin_store 1.1.0-beta.2 (git+https://github.com/mimblewimble/grin)",
- "grin_util 1.1.0-beta.2 (git+https://github.com/mimblewimble/grin)",
+ "grin_core 1.1.0-beta.2 (git+https://github.com/mimblewimble/grin?tag=v1.1.0-beta.2)",
+ "grin_keychain 1.1.0-beta.2 (git+https://github.com/mimblewimble/grin?tag=v1.1.0-beta.2)",
+ "grin_store 1.1.0-beta.2 (git+https://github.com/mimblewimble/grin?tag=v1.1.0-beta.2)",
+ "grin_util 1.1.0-beta.2 (git+https://github.com/mimblewimble/grin?tag=v1.1.0-beta.2)",
  "log 0.4.6 (registry+https://github.com/rust-lang/crates.io-index)",
  "rand 0.6.5 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde 1.0.90 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -713,15 +713,15 @@ dependencies = [
 [[package]]
 name = "grin_store"
 version = "1.1.0-beta.2"
-source = "git+https://github.com/mimblewimble/grin#884851cdeb59305b88300e9110500cbb15b51dc2"
+source = "git+https://github.com/mimblewimble/grin?tag=v1.1.0-beta.2#9ab23f6eef1d03aa2facc32d439852bda0127daf"
 dependencies = [
  "byteorder 1.3.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "croaring 0.3.9 (registry+https://github.com/rust-lang/crates.io-index)",
  "env_logger 0.5.13 (registry+https://github.com/rust-lang/crates.io-index)",
  "failure 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)",
  "failure_derive 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)",
- "grin_core 1.1.0-beta.2 (git+https://github.com/mimblewimble/grin)",
- "grin_util 1.1.0-beta.2 (git+https://github.com/mimblewimble/grin)",
+ "grin_core 1.1.0-beta.2 (git+https://github.com/mimblewimble/grin?tag=v1.1.0-beta.2)",
+ "grin_util 1.1.0-beta.2 (git+https://github.com/mimblewimble/grin?tag=v1.1.0-beta.2)",
  "libc 0.2.51 (registry+https://github.com/rust-lang/crates.io-index)",
  "lmdb-zero 0.4.4 (registry+https://github.com/rust-lang/crates.io-index)",
  "log 0.4.6 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -734,7 +734,7 @@ dependencies = [
 [[package]]
 name = "grin_util"
 version = "1.1.0-beta.2"
-source = "git+https://github.com/mimblewimble/grin#884851cdeb59305b88300e9110500cbb15b51dc2"
+source = "git+https://github.com/mimblewimble/grin?tag=v1.1.0-beta.2#9ab23f6eef1d03aa2facc32d439852bda0127daf"
 dependencies = [
  "backtrace 0.3.15 (registry+https://github.com/rust-lang/crates.io-index)",
  "base64 0.9.3 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -754,19 +754,19 @@ dependencies = [
 
 [[package]]
 name = "grin_wallet"
-version = "1.1.0-beta.2"
+version = "1.1.0-beta.3"
 dependencies = [
  "built 0.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "clap 2.33.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "ctrlc 3.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "failure 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)",
  "failure_derive 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)",
- "grin_wallet_api 1.1.0-beta.2",
- "grin_wallet_config 1.1.0-beta.2",
- "grin_wallet_controller 1.1.0-beta.2",
- "grin_wallet_impls 1.1.0-beta.2",
- "grin_wallet_libwallet 1.1.0-beta.2",
- "grin_wallet_util 1.1.0-beta.2",
+ "grin_wallet_api 1.1.0-beta.3",
+ "grin_wallet_config 1.1.0-beta.3",
+ "grin_wallet_controller 1.1.0-beta.3",
+ "grin_wallet_impls 1.1.0-beta.3",
+ "grin_wallet_libwallet 1.1.0-beta.3",
+ "grin_wallet_util 1.1.0-beta.3",
  "linefeed 0.5.4 (registry+https://github.com/rust-lang/crates.io-index)",
  "log 0.4.6 (registry+https://github.com/rust-lang/crates.io-index)",
  "prettytable-rs 0.7.0 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -775,16 +775,16 @@ dependencies = [
 
 [[package]]
 name = "grin_wallet_api"
-version = "1.1.0-beta.2"
+version = "1.1.0-beta.3"
 dependencies = [
  "chrono 0.4.6 (registry+https://github.com/rust-lang/crates.io-index)",
  "easy-jsonrpc 0.5.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "failure 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)",
  "failure_derive 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)",
- "grin_wallet_config 1.1.0-beta.2",
- "grin_wallet_impls 1.1.0-beta.2",
- "grin_wallet_libwallet 1.1.0-beta.2",
- "grin_wallet_util 1.1.0-beta.2",
+ "grin_wallet_config 1.1.0-beta.3",
+ "grin_wallet_impls 1.1.0-beta.3",
+ "grin_wallet_libwallet 1.1.0-beta.3",
+ "grin_wallet_util 1.1.0-beta.3",
  "log 0.4.6 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde_json 1.0.39 (registry+https://github.com/rust-lang/crates.io-index)",
  "tempfile 3.0.7 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -793,10 +793,10 @@ dependencies = [
 
 [[package]]
 name = "grin_wallet_config"
-version = "1.1.0-beta.2"
+version = "1.1.0-beta.3"
 dependencies = [
  "dirs 1.0.5 (registry+https://github.com/rust-lang/crates.io-index)",
- "grin_wallet_util 1.1.0-beta.2",
+ "grin_wallet_util 1.1.0-beta.3",
  "pretty_assertions 0.5.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "rand 0.5.6 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde 1.0.90 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -806,18 +806,18 @@ dependencies = [
 
 [[package]]
 name = "grin_wallet_controller"
-version = "1.1.0-beta.2"
+version = "1.1.0-beta.3"
 dependencies = [
  "chrono 0.4.6 (registry+https://github.com/rust-lang/crates.io-index)",
  "easy-jsonrpc 0.5.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "failure 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)",
  "failure_derive 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)",
  "futures 0.1.26 (registry+https://github.com/rust-lang/crates.io-index)",
- "grin_wallet_api 1.1.0-beta.2",
- "grin_wallet_config 1.1.0-beta.2",
- "grin_wallet_impls 1.1.0-beta.2",
- "grin_wallet_libwallet 1.1.0-beta.2",
- "grin_wallet_util 1.1.0-beta.2",
+ "grin_wallet_api 1.1.0-beta.3",
+ "grin_wallet_config 1.1.0-beta.3",
+ "grin_wallet_impls 1.1.0-beta.3",
+ "grin_wallet_libwallet 1.1.0-beta.3",
+ "grin_wallet_util 1.1.0-beta.3",
  "hyper 0.12.19 (registry+https://github.com/rust-lang/crates.io-index)",
  "lazy_static 1.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "log 0.4.6 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -837,16 +837,16 @@ dependencies = [
 
 [[package]]
 name = "grin_wallet_impls"
-version = "1.1.0-beta.2"
+version = "1.1.0-beta.3"
 dependencies = [
  "blake2-rfc 0.2.18 (registry+https://github.com/rust-lang/crates.io-index)",
  "chrono 0.4.6 (registry+https://github.com/rust-lang/crates.io-index)",
  "failure 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)",
  "failure_derive 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)",
  "futures 0.1.26 (registry+https://github.com/rust-lang/crates.io-index)",
- "grin_wallet_config 1.1.0-beta.2",
- "grin_wallet_libwallet 1.1.0-beta.2",
- "grin_wallet_util 1.1.0-beta.2",
+ "grin_wallet_config 1.1.0-beta.3",
+ "grin_wallet_libwallet 1.1.0-beta.3",
+ "grin_wallet_util 1.1.0-beta.3",
  "log 0.4.6 (registry+https://github.com/rust-lang/crates.io-index)",
  "rand 0.5.6 (registry+https://github.com/rust-lang/crates.io-index)",
  "ring 0.13.5 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -861,14 +861,14 @@ dependencies = [
 
 [[package]]
 name = "grin_wallet_libwallet"
-version = "1.1.0-beta.2"
+version = "1.1.0-beta.3"
 dependencies = [
  "blake2-rfc 0.2.18 (registry+https://github.com/rust-lang/crates.io-index)",
  "chrono 0.4.6 (registry+https://github.com/rust-lang/crates.io-index)",
  "failure 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)",
  "failure_derive 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)",
- "grin_wallet_config 1.1.0-beta.2",
- "grin_wallet_util 1.1.0-beta.2",
+ "grin_wallet_config 1.1.0-beta.3",
+ "grin_wallet_util 1.1.0-beta.3",
  "lazy_static 1.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "log 0.4.6 (registry+https://github.com/rust-lang/crates.io-index)",
  "rand 0.5.6 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -880,15 +880,15 @@ dependencies = [
 
 [[package]]
 name = "grin_wallet_util"
-version = "1.1.0-beta.2"
+version = "1.1.0-beta.3"
 dependencies = [
  "dirs 1.0.5 (registry+https://github.com/rust-lang/crates.io-index)",
- "grin_api 1.1.0-beta.2 (git+https://github.com/mimblewimble/grin)",
- "grin_chain 1.1.0-beta.2 (git+https://github.com/mimblewimble/grin)",
- "grin_core 1.1.0-beta.2 (git+https://github.com/mimblewimble/grin)",
- "grin_keychain 1.1.0-beta.2 (git+https://github.com/mimblewimble/grin)",
- "grin_store 1.1.0-beta.2 (git+https://github.com/mimblewimble/grin)",
- "grin_util 1.1.0-beta.2 (git+https://github.com/mimblewimble/grin)",
+ "grin_api 1.1.0-beta.2 (git+https://github.com/mimblewimble/grin?tag=v1.1.0-beta.2)",
+ "grin_chain 1.1.0-beta.2 (git+https://github.com/mimblewimble/grin?tag=v1.1.0-beta.2)",
+ "grin_core 1.1.0-beta.2 (git+https://github.com/mimblewimble/grin?tag=v1.1.0-beta.2)",
+ "grin_keychain 1.1.0-beta.2 (git+https://github.com/mimblewimble/grin?tag=v1.1.0-beta.2)",
+ "grin_store 1.1.0-beta.2 (git+https://github.com/mimblewimble/grin?tag=v1.1.0-beta.2)",
+ "grin_util 1.1.0-beta.2 (git+https://github.com/mimblewimble/grin?tag=v1.1.0-beta.2)",
  "pretty_assertions 0.5.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "rand 0.5.6 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde 1.0.90 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -2752,15 +2752,15 @@ dependencies = [
 "checksum generic-array 0.9.0 (registry+https://github.com/rust-lang/crates.io-index)" = "ef25c5683767570c2bbd7deba372926a55eaae9982d7726ee2a1050239d45b9d"
 "checksum git2 0.7.5 (registry+https://github.com/rust-lang/crates.io-index)" = "591f8be1674b421644b6c030969520bc3fa12114d2eb467471982ed3e9584e71"
 "checksum glob 0.2.11 (registry+https://github.com/rust-lang/crates.io-index)" = "8be18de09a56b60ed0edf84bc9df007e30040691af7acd1c41874faac5895bfb"
-"checksum grin_api 1.1.0-beta.2 (git+https://github.com/mimblewimble/grin)" = "<none>"
-"checksum grin_chain 1.1.0-beta.2 (git+https://github.com/mimblewimble/grin)" = "<none>"
-"checksum grin_core 1.1.0-beta.2 (git+https://github.com/mimblewimble/grin)" = "<none>"
-"checksum grin_keychain 1.1.0-beta.2 (git+https://github.com/mimblewimble/grin)" = "<none>"
-"checksum grin_p2p 1.1.0-beta.2 (git+https://github.com/mimblewimble/grin)" = "<none>"
-"checksum grin_pool 1.1.0-beta.2 (git+https://github.com/mimblewimble/grin)" = "<none>"
+"checksum grin_api 1.1.0-beta.2 (git+https://github.com/mimblewimble/grin?tag=v1.1.0-beta.2)" = "<none>"
+"checksum grin_chain 1.1.0-beta.2 (git+https://github.com/mimblewimble/grin?tag=v1.1.0-beta.2)" = "<none>"
+"checksum grin_core 1.1.0-beta.2 (git+https://github.com/mimblewimble/grin?tag=v1.1.0-beta.2)" = "<none>"
+"checksum grin_keychain 1.1.0-beta.2 (git+https://github.com/mimblewimble/grin?tag=v1.1.0-beta.2)" = "<none>"
+"checksum grin_p2p 1.1.0-beta.2 (git+https://github.com/mimblewimble/grin?tag=v1.1.0-beta.2)" = "<none>"
+"checksum grin_pool 1.1.0-beta.2 (git+https://github.com/mimblewimble/grin?tag=v1.1.0-beta.2)" = "<none>"
 "checksum grin_secp256k1zkp 0.7.5 (registry+https://github.com/rust-lang/crates.io-index)" = "75e9a265f3eeea4c204470f7262e2c6fe18f3d8ddf5fb24340cb550ac4f909c5"
-"checksum grin_store 1.1.0-beta.2 (git+https://github.com/mimblewimble/grin)" = "<none>"
-"checksum grin_util 1.1.0-beta.2 (git+https://github.com/mimblewimble/grin)" = "<none>"
+"checksum grin_store 1.1.0-beta.2 (git+https://github.com/mimblewimble/grin?tag=v1.1.0-beta.2)" = "<none>"
+"checksum grin_util 1.1.0-beta.2 (git+https://github.com/mimblewimble/grin?tag=v1.1.0-beta.2)" = "<none>"
 "checksum h2 0.1.18 (registry+https://github.com/rust-lang/crates.io-index)" = "85ab6286db06040ddefb71641b50017c06874614001a134b423783e2db2920bd"
 "checksum heck 0.3.1 (registry+https://github.com/rust-lang/crates.io-index)" = "20564e78d53d2bb135c343b3f47714a56af2061f1c928fdb541dc7b9fdd94205"
 "checksum hmac 0.6.3 (registry+https://github.com/rust-lang/crates.io-index)" = "733e1b3ac906631ca01ebb577e9bb0f5e37a454032b9036b5eaea4013ed6f99a"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "grin_wallet"
-version = "1.1.0-beta.2"
+version = "1.1.0-beta.3"
 authors = ["Grin Developers <mimblewimble@lists.launchpad.net>"]
 description = "Simple, private and scalable cryptocurrency implementation based on the MimbleWimble chain format."
 license = "Apache-2.0"
@@ -29,13 +29,13 @@ prettytable-rs = "0.7"
 log = "0.4"
 linefeed = "0.5"
 
-grin_wallet_api = { path = "./api", version = "1.1.0-beta.2" }
-grin_wallet_impls = { path = "./impls", version = "1.1.0-beta.2" }
-grin_wallet_libwallet = { path = "./libwallet", version = "1.1.0-beta.2" }
-grin_wallet_controller = { path = "./controller", version = "1.1.0-beta.2" }
-grin_wallet_config = { path = "./config", version = "1.1.0-beta.2" }
+grin_wallet_api = { path = "./api", version = "1.1.0-beta.3" }
+grin_wallet_impls = { path = "./impls", version = "1.1.0-beta.3" }
+grin_wallet_libwallet = { path = "./libwallet", version = "1.1.0-beta.3" }
+grin_wallet_controller = { path = "./controller", version = "1.1.0-beta.3" }
+grin_wallet_config = { path = "./config", version = "1.1.0-beta.3" }
 
-grin_wallet_util = { path = "./util", version = "1.1.0-beta.2" }
+grin_wallet_util = { path = "./util", version = "1.1.0-beta.3" }
 
 [build-dependencies]
 built = "0.3"

--- a/api/Cargo.toml
+++ b/api/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "grin_wallet_api"
-version = "1.1.0-beta.2"
+version = "1.1.0-beta.3"
 authors = ["Grin Developers <mimblewimble@lists.launchpad.net>"]
 description = "Grin Wallet API"
 license = "Apache-2.0"
@@ -18,11 +18,11 @@ serde_json = "1"
 easy-jsonrpc = "0.5.1"
 chrono = { version = "0.4.4", features = ["serde"] }
 
-grin_wallet_libwallet = { path = "../libwallet", version = "1.1.0-beta.2" }
-grin_wallet_config = { path = "../config", version = "1.1.0-beta.2" }
-grin_wallet_impls = { path = "../impls", version = "1.1.0-beta.2" }
+grin_wallet_libwallet = { path = "../libwallet", version = "1.1.0-beta.3" }
+grin_wallet_config = { path = "../config", version = "1.1.0-beta.3" }
+grin_wallet_impls = { path = "../impls", version = "1.1.0-beta.3" }
 
-grin_wallet_util = { path = "../util", version = "1.1.0-beta.2" }
+grin_wallet_util = { path = "../util", version = "1.1.0-beta.3" }
 
 [dev-dependencies]
 serde_json = "1"

--- a/config/Cargo.toml
+++ b/config/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "grin_wallet_config"
-version = "1.1.0-beta.2"
+version = "1.1.0-beta.3"
 authors = ["Grin Developers <mimblewimble@lists.launchpad.net>"]
 description = "Configuration for grin wallet , a simple, private and scalable cryptocurrency implementation based on the MimbleWimble chain format."
 license = "Apache-2.0"
@@ -16,7 +16,7 @@ serde_derive = "1"
 toml = "0.4"
 dirs = "1.0.3"
 
-grin_wallet_util = { path = "../util", version = "1.1.0-beta.2" }
+grin_wallet_util = { path = "../util", version = "1.1.0-beta.3" }
 
 [dev-dependencies]
 pretty_assertions = "0.5.1"

--- a/controller/Cargo.toml
+++ b/controller/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "grin_wallet_controller"
-version = "1.1.0-beta.2"
+version = "1.1.0-beta.3"
 authors = ["Grin Developers <mimblewimble@lists.launchpad.net>"]
 description = "Controllers for grin wallet instantiation"
 license = "Apache-2.0"
@@ -32,9 +32,9 @@ chrono = { version = "0.4.4", features = ["serde"] }
 easy-jsonrpc = "0.5.1"
 lazy_static = "1"
 
-grin_wallet_util = { path = "../util", version = "1.1.0-beta.2" }
+grin_wallet_util = { path = "../util", version = "1.1.0-beta.3" }
 
-grin_wallet_api = { path = "../api", version = "1.1.0-beta.2" }
-grin_wallet_impls = { path = "../impls", version = "1.1.0-beta.2" }
-grin_wallet_libwallet = { path = "../libwallet", version = "1.1.0-beta.2" }
-grin_wallet_config = { path = "../config", version = "1.1.0-beta.2" }
+grin_wallet_api = { path = "../api", version = "1.1.0-beta.3" }
+grin_wallet_impls = { path = "../impls", version = "1.1.0-beta.3" }
+grin_wallet_libwallet = { path = "../libwallet", version = "1.1.0-beta.3" }
+grin_wallet_config = { path = "../config", version = "1.1.0-beta.3" }

--- a/impls/Cargo.toml
+++ b/impls/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "grin_wallet_impls"
-version = "1.1.0-beta.2"
+version = "1.1.0-beta.3"
 authors = ["Grin Developers <mimblewimble@lists.launchpad.net>"]
 description = "Concrete types derived from libwallet traits"
 license = "Apache-2.0"
@@ -26,7 +26,7 @@ tokio-retry = "0.1"
 uuid = { version = "0.7", features = ["serde", "v4"] }
 chrono = { version = "0.4.4", features = ["serde"] }
 
-grin_wallet_util = { path = "../util", version = "1.1.0-beta.2" }
+grin_wallet_util = { path = "../util", version = "1.1.0-beta.3" }
 
-grin_wallet_libwallet = { path = "../libwallet", version = "1.1.0-beta.2" }
-grin_wallet_config = { path = "../config", version = "1.1.0-beta.2" }
+grin_wallet_libwallet = { path = "../libwallet", version = "1.1.0-beta.3" }
+grin_wallet_config = { path = "../config", version = "1.1.0-beta.3" }

--- a/impls/src/test_framework/testclient.rs
+++ b/impls/src/test_framework/testclient.rs
@@ -30,7 +30,7 @@ use crate::libwallet::{NodeClient, Slate, TxWrapper, WalletInst};
 use crate::util;
 use crate::util::secp::pedersen;
 use crate::util::secp::pedersen::Commitment;
-use crate::util::{Mutex, RwLock, StopState};
+use crate::util::{Mutex, RwLock};
 use crate::{libwallet, WalletCommAdapter};
 use failure::ResultExt;
 use serde_json;
@@ -105,7 +105,6 @@ where
 			pow::verify_size,
 			verifier_cache,
 			false,
-			Arc::new(Mutex::new(StopState::new())),
 		)
 		.unwrap();
 		let (tx, rx) = channel();

--- a/libwallet/Cargo.toml
+++ b/libwallet/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "grin_wallet_libwallet"
-version = "1.1.0-beta.2"
+version = "1.1.0-beta.3"
 authors = ["Grin Developers <mimblewimble@lists.launchpad.net>"]
 description = "Simple, private and scalable cryptocurrency implementation based on the MimbleWimble chain format."
 license = "Apache-2.0"
@@ -23,7 +23,7 @@ uuid = { version = "0.7", features = ["serde", "v4"] }
 chrono = { version = "0.4.4", features = ["serde"] }
 lazy_static = "1"
 
-grin_wallet_util = { path = "../util", version = "1.1.0-beta.2" }
+grin_wallet_util = { path = "../util", version = "1.1.0-beta.3" }
 
 [dev-dependencies]
-grin_wallet_config = { path = "../config", version = "1.1.0-beta.2" }
+grin_wallet_config = { path = "../config", version = "1.1.0-beta.3" }

--- a/util/Cargo.toml
+++ b/util/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "grin_wallet_util"
-version = "1.1.0-beta.2"
+version = "1.1.0-beta.3"
 authors = ["Grin Developers <mimblewimble@lists.launchpad.net>"]
 description = "Util, for generic utilities and to re-export grin crates"
 license = "Apache-2.0"
@@ -24,13 +24,21 @@ dirs = "1.0.3"
 #grin_api = "1.1.0-beta.1"
 #grin_store = "1.1.0-beta.1"
 
+# For beta release
+grin_core = { git = "https://github.com/mimblewimble/grin", tag = "v1.1.0-beta.2" }
+grin_keychain = { git = "https://github.com/mimblewimble/grin", tag = "v1.1.0-beta.2" }
+grin_chain = { git = "https://github.com/mimblewimble/grin", tag = "v1.1.0-beta.2" }
+grin_util = { git = "https://github.com/mimblewimble/grin", tag = "v1.1.0-beta.2" }
+grin_api = { git = "https://github.com/mimblewimble/grin", tag = "v1.1.0-beta.2" }
+grin_store = { git = "https://github.com/mimblewimble/grin", tag = "v1.1.0-beta.2" }
+
 # For bleeding edge
-grin_core = { git = "https://github.com/mimblewimble/grin", branch = "master" }
-grin_keychain = { git = "https://github.com/mimblewimble/grin", branch = "master" }
-grin_chain = { git = "https://github.com/mimblewimble/grin", branch = "master" }
-grin_util = { git = "https://github.com/mimblewimble/grin", branch = "master" }
-grin_api = { git = "https://github.com/mimblewimble/grin", branch = "master" }
-grin_store = { git = "https://github.com/mimblewimble/grin", branch = "master" }
+#grin_core = { git = "https://github.com/mimblewimble/grin", branch = "master" }
+#grin_keychain = { git = "https://github.com/mimblewimble/grin", branch = "master" }
+#grin_chain = { git = "https://github.com/mimblewimble/grin", branch = "master" }
+#grin_util = { git = "https://github.com/mimblewimble/grin", branch = "master" }
+#grin_api = { git = "https://github.com/mimblewimble/grin", branch = "master" }
+#grin_store = { git = "https://github.com/mimblewimble/grin", branch = "master" }
 
 # For local testing
 #grin_core = { path = "../../grin/core", version= "1.1.0-beta.2"}


### PR DESCRIPTION
* Update version to `1.1.0-beta.3`
* Build using grin tag `1.1.0-beta.2` as dependency instead of master
* Fix to call to grin Chain::init on latest Grin beta.2 tag, 