### PR TITLE
fix: invoice transaction pay need update the slate height

### DIFF
--- a/libwallet/src/api_impl/owner.rs
+++ b/libwallet/src/api_impl/owner.rs
@@ -308,6 +308,9 @@ where
 		None => None,
 	};
 
+	// update slate current height
+	ret_slate.height = w.w2n_client().get_chain_height()?;
+
 	let context = tx::add_inputs_to_slate(
 		&mut *w,
 		&mut ret_slate,


### PR DESCRIPTION
Invoice transaction payment error:
```
20190521 03:21:17.681 INFO grin_wallet_controller::command - Tx not created: Not enough funds. Required: 0.155000000, Available: 0.000000000
Wallet command failed: LibWallet Error: Not enough funds. Required: 0.155000000, Available: 0.000000000
```

but actually the current spendable balance is enough:
```
Currently Spendable              | 1.474000000 
```

The root cause is the slate `height`:
```
  "amount": "150000000",
  "fee": "0",
  "height": "179846",
```
In case the payer has an output at height `179842` for example, and current chain height is `179942`, there will be a mistake judgement for `Spendable` with the origin slate height `179846`.

The fix solution is we always need update the slate height (to the latest height) on invoice pay function.



