### PR TITLE
Fix wallet for non-Copy SecretKey

### DIFF
--- a/libwallet/src/slate.rs
+++ b/libwallet/src/slate.rs
@@ -483,7 +483,7 @@ impl Slate {
 		let blind_offset = keychain.blind_sum(
 			&BlindSum::new()
 				.add_blinding_factor(BlindingFactor::from_secret_key(sec_key.clone()))
-				.sub_blinding_factor(self.tx.offset),
+				.sub_blinding_factor(self.tx.offset.clone()),
 		)?;
 		*sec_key = blind_offset.secret_key(&keychain.secp())?;
 		Ok(())
@@ -631,7 +631,7 @@ impl Slate {
 	where
 		K: Keychain,
 	{
-		let kernel_offset = self.tx.offset;
+		let kernel_offset = self.tx.offset.clone();
 
 		self.check_fees()?;
 
@@ -840,7 +840,7 @@ impl From<Transaction> for TransactionV2 {
 impl From<&Transaction> for TransactionV2 {
 	fn from(tx: &Transaction) -> TransactionV2 {
 		let Transaction { offset, body } = tx;
-		let offset = *offset;
+		let offset = offset.clone();
 		let body = TransactionBodyV2::from(body);
 		TransactionV2 { offset, body }
 	}


### PR DESCRIPTION
This PR makes grin-wallet able to compile in case `secp::SecretKey` made non-`Copy` by this PR: https://github.com/mimblewimble/rust-secp256k1-zkp/pull/51

Do not merge it unless abovementioned PR is merged so things won't break.

*Update*: https://github.com/mimblewimble/rust-secp256k1-zkp/pull/51 is merged, so this PR can be merged as well.