### PR TITLE
Version Info API Function tweak, remove 'min_compat_version' from slate

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -875,6 +875,8 @@ dependencies = [
  "serde 1.0.90 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde_derive 1.0.90 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde_json 1.0.39 (registry+https://github.com/rust-lang/crates.io-index)",
+ "strum 0.15.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "strum_macros 0.15.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "uuid 0.7.4 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
@@ -2093,6 +2095,22 @@ version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
+name = "strum"
+version = "0.15.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+
+[[package]]
+name = "strum_macros"
+version = "0.15.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "heck 0.3.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "proc-macro2 0.4.27 (registry+https://github.com/rust-lang/crates.io-index)",
+ "quote 0.6.12 (registry+https://github.com/rust-lang/crates.io-index)",
+ "syn 0.15.32 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
 name = "supercow"
 version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2896,6 +2914,8 @@ dependencies = [
 "checksum stable_deref_trait 1.1.1 (registry+https://github.com/rust-lang/crates.io-index)" = "dba1a27d3efae4351c8051072d619e3ade2820635c3958d826bfea39d59b54c8"
 "checksum string 0.1.3 (registry+https://github.com/rust-lang/crates.io-index)" = "b639411d0b9c738748b5397d5ceba08e648f4f1992231aa859af1a017f31f60b"
 "checksum strsim 0.8.0 (registry+https://github.com/rust-lang/crates.io-index)" = "8ea5119cdb4c55b55d432abb513a0429384878c15dde60cc77b1c99de1a95a6a"
+"checksum strum 0.15.0 (registry+https://github.com/rust-lang/crates.io-index)" = "e5d1c33039533f051704951680f1adfd468fd37ac46816ded0d9ee068e60f05f"
+"checksum strum_macros 0.15.0 (registry+https://github.com/rust-lang/crates.io-index)" = "47cd23f5c7dee395a00fa20135e2ec0fffcdfa151c56182966d7a3261343432e"
 "checksum supercow 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)" = "171758edb47aa306a78dfa4ab9aeb5167405bd4e3dc2b64e88f6a84bbe98bd63"
 "checksum syn 0.15.32 (registry+https://github.com/rust-lang/crates.io-index)" = "846620ec526c1599c070eff393bfeeeb88a93afa2513fc3b49f1fea84cf7b0ed"
 "checksum synstructure 0.10.1 (registry+https://github.com/rust-lang/crates.io-index)" = "73687139bf99285483c96ac0add482c3776528beac1d97d444f6e91f203a2015"

--- a/api/src/foreign_rpc.rs
+++ b/api/src/foreign_rpc.rs
@@ -50,8 +50,12 @@ pub trait ForeignRpc {
 		"jsonrpc": "2.0",
 		"result": {
 			"Ok": {
-				"default_slate_version": 2,
-				"foreign_api_version": 2
+				"foreign_api_version": 2,
+				"supported_slate_versions": [
+					"V0",
+					"V1",
+					"V2"
+				]
 			}
 		}
 	}

--- a/api/src/foreign_rpc.rs
+++ b/api/src/foreign_rpc.rs
@@ -172,7 +172,6 @@ pub trait ForeignRpc {
 					"offset": "d202964900000000d302964900000000d402964900000000d502964900000000"
 				},
 				"version_info": {
-				"min_compat_version": 0,
 				"orig_version": 2,
 				"version": 2
 				}
@@ -211,8 +210,7 @@ pub trait ForeignRpc {
 			{
 			"version_info": {
 				"version": 2,
-				"orig_version": 2,
-				"min_compat_version": 0
+				"orig_version": 2
 			},
 			"num_participants": 2,
 			"id": "0436430c-2b02-624c-2032-570501212b00",
@@ -335,7 +333,6 @@ pub trait ForeignRpc {
 				"offset": "d202964900000000d302964900000000d402964900000000d502964900000000"
 				},
 				"version_info": {
-				"min_compat_version": 0,
 				"orig_version": 2,
 				"version": 2
 				}
@@ -369,8 +366,7 @@ pub trait ForeignRpc {
 		"params": [{
 			"version_info": {
 				"version": 2,
-				"orig_version": 2,
-				"min_compat_version": 0
+				"orig_version": 2
 			},
 			"num_participants": 2,
 			"id": "0436430c-2b02-624c-2032-570501212b00",
@@ -503,7 +499,6 @@ pub trait ForeignRpc {
 					"offset": "d202964900000000d302964900000000d402964900000000d502964900000000"
 				},
 				"version_info": {
-					"min_compat_version": 0,
 					"orig_version": 2,
 					"version": 2
 				}

--- a/api/src/owner_rpc.rs
+++ b/api/src/owner_rpc.rs
@@ -389,7 +389,6 @@ pub trait OwnerRpc {
 			"offset": "d202964900000000d302964900000000d402964900000000d502964900000000"
 		  },
 		  "version_info": {
-			"min_compat_version": 0,
 			"orig_version": 2,
 			"version": 2
 		  }
@@ -469,7 +468,6 @@ pub trait OwnerRpc {
 						"offset": "d202964900000000d302964900000000d402964900000000d502964900000000"
 					},
 					"version_info": {
-						"min_compat_version": 0,
 						"orig_version": 2,
 						"version": 2
 					}
@@ -533,7 +531,6 @@ pub trait OwnerRpc {
 						"offset": "d202964900000000d302964900000000d402964900000000d502964900000000"
 					},
 					"version_info": {
-						"min_compat_version": 0,
 						"orig_version": 2,
 						"version": 2
 					}
@@ -617,7 +614,6 @@ pub trait OwnerRpc {
 					"offset": "d202964900000000d302964900000000d402964900000000d502964900000000"
 				},
 				"version_info": {
-					"min_compat_version": 0,
 					"orig_version": 2,
 					"version": 2
 				}
@@ -686,7 +682,6 @@ pub trait OwnerRpc {
 					"offset": "d202964900000000d302964900000000d402964900000000d502964900000000"
 				},
 				"version_info": {
-				"min_compat_version": 0,
 				"orig_version": 2,
 				"version": 2
 				}
@@ -725,8 +720,7 @@ pub trait OwnerRpc {
 		{
 			"version_info": {
 				"version": 2,
-				"orig_version": 2,
-				"min_compat_version": 0
+				"orig_version": 2
 			},
 			"num_participants": 2,
 			"id": "0436430c-2b02-624c-2032-570501212b00",
@@ -860,7 +854,6 @@ pub trait OwnerRpc {
 					"offset": "d202964900000000d302964900000000d402964900000000d502964900000000"
 				},
 				"version_info": {
-					"min_compat_version": 0,
 					"orig_version": 2,
 					"version": 2
 				}
@@ -1119,7 +1112,6 @@ pub trait OwnerRpc {
 					"offset": "d202964900000000d302964900000000d402964900000000d502964900000000"
 				},
 				"version_info": {
-				"min_compat_version": 0,
 				"orig_version": 2,
 				"version": 2
 				}

--- a/libwallet/Cargo.toml
+++ b/libwallet/Cargo.toml
@@ -22,6 +22,8 @@ log = "0.4"
 uuid = { version = "0.7", features = ["serde", "v4"] }
 chrono = { version = "0.4.4", features = ["serde"] }
 lazy_static = "1"
+strum = "0.15"
+strum_macros = "0.15"
 
 grin_wallet_util = { path = "../util", version = "1.1.0-beta.3" }
 

--- a/libwallet/src/api_impl/foreign.rs
+++ b/libwallet/src/api_impl/foreign.rs
@@ -13,13 +13,15 @@
 // limitations under the License.
 
 //! Generic implementation of owner API functions
+use strum::IntoEnumIterator;
 
 use crate::grin_keychain::Keychain;
 use crate::internal::{tx, updater};
 use crate::{
-	slate_versions, BlockFees, CbData, Error, ErrorKind, NodeClient, Slate, TxLogEntryType,
+	BlockFees, CbData, Error, ErrorKind, NodeClient, Slate, TxLogEntryType,
 	VersionInfo, WalletBackend,
 };
+use crate::slate_versions::SlateVersion;
 
 const FOREIGN_API_VERSION: u16 = 2;
 const USER_MESSAGE_MAX_LEN: usize = 256;
@@ -28,7 +30,7 @@ const USER_MESSAGE_MAX_LEN: usize = 256;
 pub fn check_version() -> VersionInfo {
 	VersionInfo {
 		foreign_api_version: FOREIGN_API_VERSION,
-		default_slate_version: slate_versions::CURRENT_SLATE_VERSION,
+		supported_slate_versions: SlateVersion::iter().collect(),
 	}
 }
 

--- a/libwallet/src/api_impl/foreign.rs
+++ b/libwallet/src/api_impl/foreign.rs
@@ -17,11 +17,11 @@ use strum::IntoEnumIterator;
 
 use crate::grin_keychain::Keychain;
 use crate::internal::{tx, updater};
-use crate::{
-	BlockFees, CbData, Error, ErrorKind, NodeClient, Slate, TxLogEntryType,
-	VersionInfo, WalletBackend,
-};
 use crate::slate_versions::SlateVersion;
+use crate::{
+	BlockFees, CbData, Error, ErrorKind, NodeClient, Slate, TxLogEntryType, VersionInfo,
+	WalletBackend,
+};
 
 const FOREIGN_API_VERSION: u16 = 2;
 const USER_MESSAGE_MAX_LEN: usize = 256;

--- a/libwallet/src/api_impl/types.rs
+++ b/libwallet/src/api_impl/types.rs
@@ -18,8 +18,8 @@ use crate::grin_core::core::{Output, TxKernel};
 use crate::grin_core::libtx::secp_ser;
 use crate::grin_keychain::Identifier;
 use crate::grin_util::secp::pedersen;
-use crate::types::OutputData;
 use crate::slate_versions::SlateVersion;
+use crate::types::OutputData;
 
 /// Send TX API Args
 // TODO: This is here to ensure the legacy V1 API remains intact

--- a/libwallet/src/api_impl/types.rs
+++ b/libwallet/src/api_impl/types.rs
@@ -19,6 +19,7 @@ use crate::grin_core::libtx::secp_ser;
 use crate::grin_keychain::Identifier;
 use crate::grin_util::secp::pedersen;
 use crate::types::OutputData;
+use crate::slate_versions::SlateVersion;
 
 /// Send TX API Args
 // TODO: This is here to ensure the legacy V1 API remains intact
@@ -218,5 +219,5 @@ pub struct VersionInfo {
 	/// API version
 	pub foreign_api_version: u16,
 	/// Slate version
-	pub default_slate_version: u16,
+	pub supported_slate_versions: Vec<SlateVersion>,
 }

--- a/libwallet/src/lib.rs
+++ b/libwallet/src/lib.rs
@@ -39,6 +39,10 @@ extern crate log;
 #[macro_use]
 extern crate lazy_static;
 
+extern crate strum;
+#[macro_use]
+extern crate strum_macros;
+
 pub mod api_impl;
 mod error;
 mod internal;

--- a/libwallet/src/slate.rs
+++ b/libwallet/src/slate.rs
@@ -185,8 +185,6 @@ pub struct VersionCompatInfo {
 	pub version: u16,
 	/// Original version this slate was converted from
 	pub orig_version: u16,
-	/// Minimum version this slate is compatible with
-	pub min_compat_version: u16,
 }
 
 /// Helper just to facilitate serialization
@@ -240,7 +238,6 @@ impl Slate {
 			version_info: VersionCompatInfo {
 				version: CURRENT_SLATE_VERSION,
 				orig_version: CURRENT_SLATE_VERSION,
-				min_compat_version: 0,
 			},
 		}
 	}
@@ -816,15 +813,12 @@ impl From<&VersionCompatInfo> for VersionCompatInfoV2 {
 		let VersionCompatInfo {
 			version,
 			orig_version,
-			min_compat_version,
 		} = data;
 		let version = *version;
 		let orig_version = *orig_version;
-		let min_compat_version = *min_compat_version;
 		VersionCompatInfoV2 {
 			version,
 			orig_version,
-			min_compat_version,
 		}
 	}
 }
@@ -969,15 +963,12 @@ impl From<&VersionCompatInfoV2> for VersionCompatInfo {
 		let VersionCompatInfoV2 {
 			version,
 			orig_version,
-			min_compat_version,
 		} = data;
 		let version = *version;
 		let orig_version = *orig_version;
-		let min_compat_version = *min_compat_version;
 		VersionCompatInfo {
 			version,
 			orig_version,
-			min_compat_version,
 		}
 	}
 }

--- a/libwallet/src/slate_versions/mod.rs
+++ b/libwallet/src/slate_versions/mod.rs
@@ -30,7 +30,7 @@ pub mod v2;
 pub const CURRENT_SLATE_VERSION: u16 = 2;
 
 /// Existing versions of the slate
-#[derive(Debug, PartialEq, PartialOrd, Eq, Ord)]
+#[derive(EnumIter, Serialize, Deserialize, Clone, Debug, PartialEq, PartialOrd, Eq, Ord)]
 pub enum SlateVersion {
 	/// V0
 	V0,

--- a/libwallet/src/slate_versions/v2.rs
+++ b/libwallet/src/slate_versions/v2.rs
@@ -33,7 +33,6 @@
 //! * VersionCompatInfo struct created with fields and added to beginning of struct
 //!    version: u16
 //!    orig_verion: u16,
-//!    min_compat_version: u16
 
 use crate::grin_core::core::transaction::{KernelFeatures, OutputFeatures};
 use crate::grin_core::libtx::secp_ser;
@@ -84,8 +83,6 @@ pub struct VersionCompatInfoV2 {
 	pub version: u16,
 	/// Original version this slate was converted from
 	pub orig_version: u16,
-	/// Minimum version this slate is compatible with
-	pub min_compat_version: u16,
 }
 
 #[derive(Serialize, Deserialize, Debug, Clone)]
@@ -338,13 +335,11 @@ impl From<SlateV1> for SlateV2 {
 		} = slate;
 		let tx = TransactionV2::from(tx);
 		let version = 2;
-		let min_compat_version = 0;
 		let orig_version = orig_version as u16;
 		let participant_data = map_vec!(participant_data, |data| ParticipantDataV2::from(data));
 		let version_info = VersionCompatInfoV2 {
 			version,
 			orig_version,
-			min_compat_version,
 		};
 		SlateV2 {
 			num_participants,


### PR DESCRIPTION
1) This removes `default_slate_version` from the structure returned from the foreign api's `check_version`, and instead returns an enumeration of slate versions supported. This is implemented in such a way as to ensure it can't be forgotten about, i.e. it will return the list directly from the variants in the internal SlateVersions enum.

In thinking about slate versioning a bit more, this approach to how the `check_version` function should behave seems more natural to me. A caller can query which versions are supported and report the exact issue if it can't negotiate a match.

2) Also removes the `min_compat_version` from the slate, as on further thinking I'm not sure how it would be needed or why it would be used.