### PR TITLE
filter feature for txs/outputs command

### DIFF
--- a/controller/src/command.rs
+++ b/controller/src/command.rs
@@ -36,7 +36,9 @@ use crate::impls::{
 	LMDBBackend, NullWalletCommAdapter,
 };
 use crate::impls::{HTTPNodeClient, WalletSeed};
-use crate::libwallet::{InitTxArgs, IssueInvoiceTxArgs, NodeClient, OutputStatus, TxLogEntryType, WalletInst};
+use crate::libwallet::{
+	InitTxArgs, IssueInvoiceTxArgs, NodeClient, OutputStatus, TxLogEntryType, WalletInst,
+};
 use crate::{controller, display};
 
 /// Arguments common to all wallet commands
@@ -254,7 +256,8 @@ pub fn send(
 						minimum_confirmations: args.minimum_confirmations,
 						max_outputs: args.max_outputs as u32,
 						num_change_outputs: args.change_outputs as u32,
-						selection_strategy_is_use_all: strategy == "all",						estimate_only: Some(true),
+						selection_strategy_is_use_all: strategy == "all",
+						estimate_only: Some(true),
 						..Default::default()
 					};
 					let slate = api.init_send_tx(init_args).unwrap();

--- a/controller/src/display.rs
+++ b/controller/src/display.rs
@@ -58,6 +58,7 @@ pub fn outputs(
 		bMG->"Tx"
 	]);
 
+	let len = outputs.len();
 	for m in outputs {
 		let commit = format!("{}", util::to_hex(m.commit.as_ref().to_vec()));
 		let index = match m.output.mmr_index {
@@ -111,6 +112,7 @@ pub fn outputs(
 	table.set_format(*prettytable::format::consts::FORMAT_NO_COLSEP);
 	table.printstd();
 	println!();
+	println!("total displayed outputs: {}", len);
 
 	if !validated {
 		println!(
@@ -252,6 +254,7 @@ pub fn txs(
 	table.set_format(*prettytable::format::consts::FORMAT_NO_COLSEP);
 	table.printstd();
 	println!();
+	println!("total displayed txs: {}", txs.len());
 
 	if !validated && include_status {
 		println!(

--- a/controller/src/lib.rs
+++ b/controller/src/lib.rs
@@ -21,6 +21,8 @@ extern crate prettytable;
 extern crate log;
 #[macro_use]
 extern crate lazy_static;
+extern crate chrono;
+
 use failure;
 use grin_wallet_api as apiwallet;
 use grin_wallet_config as config;
@@ -37,3 +39,4 @@ pub mod display;
 mod error;
 
 pub use crate::error::{Error, ErrorKind};
+pub use chrono::NaiveDateTime as DateTime;

--- a/controller/src/lib.rs
+++ b/controller/src/lib.rs
@@ -39,4 +39,4 @@ pub mod display;
 mod error;
 
 pub use crate::error::{Error, ErrorKind};
-pub use chrono::NaiveDateTime as NaiveDateTime;
+pub use chrono::NaiveDateTime;

--- a/controller/src/lib.rs
+++ b/controller/src/lib.rs
@@ -39,4 +39,4 @@ pub mod display;
 mod error;
 
 pub use crate::error::{Error, ErrorKind};
-pub use chrono::NaiveDateTime as DateTime;
+pub use chrono::NaiveDateTime as NaiveDateTime;

--- a/src/bin/cmd/wallet_args.rs
+++ b/src/bin/cmd/wallet_args.rs
@@ -22,7 +22,9 @@ use grin_wallet_config::WalletConfig;
 use grin_wallet_controller::command;
 use grin_wallet_controller::{Error, ErrorKind, NaiveDateTime};
 use grin_wallet_impls::{instantiate_wallet, WalletSeed};
-use grin_wallet_libwallet::{IssueInvoiceTxArgs, NodeClient, OutputStatus, TxLogEntryType,WalletInst};
+use grin_wallet_libwallet::{
+	IssueInvoiceTxArgs, NodeClient, OutputStatus, TxLogEntryType, WalletInst,
+};
 use grin_wallet_util::grin_core as core;
 use grin_wallet_util::grin_keychain as keychain;
 use linefeed::terminal::Signal;

--- a/src/bin/cmd/wallet_args.rs
+++ b/src/bin/cmd/wallet_args.rs
@@ -20,9 +20,11 @@ use clap::ArgMatches;
 use failure::Fail;
 use grin_wallet_config::WalletConfig;
 use grin_wallet_controller::command;
-use grin_wallet_controller::{NaiveDateTime, Error, ErrorKind};
+use grin_wallet_controller::{Error, ErrorKind, NaiveDateTime};
 use grin_wallet_impls::{instantiate_wallet, FileWalletCommAdapter, WalletSeed};
-use grin_wallet_libwallet::{IssueInvoiceTxArgs, NodeClient, OutputStatus, Slate, TxLogEntryType, WalletInst};
+use grin_wallet_libwallet::{
+	IssueInvoiceTxArgs, NodeClient, OutputStatus, Slate, TxLogEntryType, WalletInst,
+};
 use grin_wallet_util::grin_core as core;
 use grin_wallet_util::grin_core::core::amount_to_hr_string;
 use grin_wallet_util::grin_keychain as keychain;
@@ -931,10 +933,10 @@ pub fn wallet_command(
 		("outputs", Some(args)) => {
 			let a = arg_parse!(parse_outputs_args(&args));
 			command::outputs(
-			inst_wallet(),
-			&global_wallet_args,
-			a,
-			wallet_config.dark_background_color_scheme.unwrap_or(true),
+				inst_wallet(),
+				&global_wallet_args,
+				a,
+				wallet_config.dark_background_color_scheme.unwrap_or(true),
 			)
 		}
 		("txs", Some(args)) => {

--- a/src/bin/cmd/wallet_tests.rs
+++ b/src/bin/cmd/wallet_tests.rs
@@ -567,9 +567,9 @@ mod wallet_tests {
 			"password",
 			"txs",
 			"-s",
-			"'2019-01-15 00:00:00'",
+			"2019-01-15 00:00:00",
 			"-e",
-			"'2020-01-25 00:00:00'",
+			"2020-01-25 00:00:00",
 		];
 		execute_command(&app, test_dir, "wallet2", &client2, arg_vec)?;
 

--- a/src/bin/cmd/wallet_tests.rs
+++ b/src/bin/cmd/wallet_tests.rs
@@ -561,7 +561,16 @@ mod wallet_tests {
 		let arg_vec = vec!["grin-wallet", "-p", "password", "txs", "-t", "rx"];
 		execute_command(&app, test_dir, "wallet2", &client2, arg_vec)?;
 
-		let arg_vec = vec!["grin-wallet", "-p", "password", "txs", "-s", "'2019-01-15 00:00:00'", "-e", "'2020-01-25 00:00:00'"];
+		let arg_vec = vec![
+			"grin-wallet",
+			"-p",
+			"password",
+			"txs",
+			"-s",
+			"'2019-01-15 00:00:00'",
+			"-e",
+			"'2020-01-25 00:00:00'",
+		];
 		execute_command(&app, test_dir, "wallet2", &client2, arg_vec)?;
 
 		let arg_vec = vec!["grin-wallet", "-p", "password", "outputs", "-l", "10"];

--- a/src/bin/cmd/wallet_tests.rs
+++ b/src/bin/cmd/wallet_tests.rs
@@ -551,8 +551,26 @@ mod wallet_tests {
 
 		let arg_vec = vec!["grin-wallet", "-p", "password", "txs"];
 		execute_command(&app, test_dir, "wallet2", &client2, arg_vec)?;
-
 		let arg_vec = vec!["grin-wallet", "-p", "password", "outputs"];
+		execute_command(&app, test_dir, "wallet2", &client2, arg_vec)?;
+
+		// txs and outputs filter feature
+		let arg_vec = vec!["grin-wallet", "-p", "password", "txs", "-l", "10"];
+		execute_command(&app, test_dir, "wallet2", &client2, arg_vec)?;
+
+		let arg_vec = vec!["grin-wallet", "-p", "password", "txs", "-t", "rx"];
+		execute_command(&app, test_dir, "wallet2", &client2, arg_vec)?;
+
+		let arg_vec = vec!["grin-wallet", "-p", "password", "txs", "-s", "'2019-01-15 00:00:00'", "-e", "'2020-01-25 00:00:00'"];
+		execute_command(&app, test_dir, "wallet2", &client2, arg_vec)?;
+
+		let arg_vec = vec!["grin-wallet", "-p", "password", "outputs", "-l", "10"];
+		execute_command(&app, test_dir, "wallet2", &client2, arg_vec)?;
+
+		let arg_vec = vec!["grin-wallet", "-p", "password", "outputs", "-m", "0.1"];
+		execute_command(&app, test_dir, "wallet2", &client2, arg_vec)?;
+
+		let arg_vec = vec!["grin-wallet", "-p", "password", "outputs", "-s", "unspent"];
 		execute_command(&app, test_dir, "wallet2", &client2, arg_vec)?;
 
 		// let logging finish

--- a/src/bin/grin-wallet.yml
+++ b/src/bin/grin-wallet.yml
@@ -248,7 +248,7 @@ subcommands:
             short: l
             long: limit
             takes_value: true
-   - txs:
+  - txs:
       about: Display transaction information
       args:
         - id:

--- a/src/bin/grin-wallet.yml
+++ b/src/bin/grin-wallet.yml
@@ -231,14 +231,50 @@ subcommands:
             long: input
             takes_value: true
   - outputs:
-      about: Raw wallet output info (list of outputs)
-  - txs:
+      about: Raw wallet self owned output info (list of outputs)
+      args:
+        - minvalue:
+            help: Filter outputs by minimum value
+            short: m
+            long: minvalue
+            takes_value: true
+        - status:
+            help: Filter outputs by status (unconfirmed/unspent/locked/spent)
+            short: s
+            long: status
+            takes_value: true
+        - limit:
+            help: Limit the maximum display lines (show the latest ones)
+            short: l
+            long: limit
+            takes_value: true
+   - txs:
       about: Display transaction information
       args:
         - id:
             help: If specified, display transaction with given Id and all associated Inputs/Outputs
             short: i
             long: id
+            takes_value: true
+        - type:
+            help: Filter txs by tx type (coinbase/rx/tx/rxc/txc, means Coinbase/Received/Sent/ReceivedCanceled/SentCanceled)
+            short: t
+            long: type
+            takes_value: true
+        - startdate:
+            help: Filter txs by creation date from 'startdate' to 'enddate', with format '1970-01-01 00:00:00'
+            short: s
+            long: startdate
+            takes_value: true
+        - enddate:
+            help: Filter txs by creation date from 'startdate' to 'enddate', with format '1970-01-01 00:00:00'
+            short: e
+            long: enddate
+            takes_value: true
+        - limit:
+            help: Limit the maximum display lines (show the latest ones)
+            short: l
+            long: limit
             takes_value: true
   - repost:
       about: Reposts a stored, completed but unconfirmed transaction to the chain, or dumps it to a file


### PR DESCRIPTION
In production environment, when there're thousands of outputs and txs, the wallet command output will always show all the outputs or txs, which has too many outputs and not easy to read.

This PR give an enhancement to filter the display.

For `outputs`, we can query by
- a minimum output value
- and/or an `OutputStatus` (unconfirmed/unspent/locked/spent)
- and/or limit the total display lines

```
  - outputs:
      about: Raw wallet output info (list of outputs)
      args:
        - minvalue:
            help: Filter outputs by minimum value
            short: m
            long: minvalue
            takes_value: true
        - status:
            help: Filter outputs by status
            short: s
            long: status
            takes_value: true
        - limit:
            help: Limit the maximum display lines (show the latest ones)
            short: l
            long: limit
            takes_value: true
```
For example:
```
$ ./target/release/grin-wallet --floonet outputs -m 10.0 -s unspent -l 10
...
total displayed outputs: 10
```

For `txs`, we can query by
-  tx type (i.e. `coinbase/rx/tx/rxc/txc`  for coinbase/received/sent/ReceivedCanceled/SentCanceled)
- and/or tx creation date from and to
- and/or limit the total display lines

```
  - txs:
      about: Display transaction information
      args:
        - id:
            help: If specified, display transaction with given Id and all associated Inputs/Outputs
            short: i
            long: id
            takes_value: true
        - type:
            help: Filter txs by tx type (Coinbase/rx/tx/rxc/txc, means Received/Sent/ReceivedCanceled/SentCanceled)
            short: t
            long: type
            takes_value: true
        - startdate:
            help: Filter txs by creation date from 'startdate' to 'enddate', with format '1970-01-01 00:00:00'
            short: s
            long: startdate
            takes_value: true
        - enddate:
            help: Filter txs by creation date from 'startdate' to 'enddate', with format '1970-01-01 00:00:00'
            short: e
            long: enddate
            takes_value: true
        - limit:
            help: Limit the maximum display lines (show the latest ones)
            short: l
            long: limit
            takes_value: true
```
For example:
```
$ ./target/release/grin-wallet --floonet txs -l 50 -s "2019-05-02 00:00:00" -e "2019-05-04 00:00:00" -t tx

...

total displayed txs: 2
```
