### PR TITLE
Read version info from server, react accordingly

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -68,7 +68,7 @@ version = "0.2.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "libc 0.2.58 (registry+https://github.com/rust-lang/crates.io-index)",
- "termion 1.5.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "termion 1.5.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "winapi 0.3.7 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
@@ -103,7 +103,7 @@ name = "base64"
 version = "0.9.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "byteorder 1.3.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "byteorder 1.3.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "safemem 0.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
@@ -122,7 +122,7 @@ dependencies = [
  "peeking_take_while 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "proc-macro2 0.3.5 (registry+https://github.com/rust-lang/crates.io-index)",
  "quote 0.5.2 (registry+https://github.com/rust-lang/crates.io-index)",
- "regex 1.1.6 (registry+https://github.com/rust-lang/crates.io-index)",
+ "regex 1.1.7 (registry+https://github.com/rust-lang/crates.io-index)",
  "which 1.0.5 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
@@ -166,13 +166,13 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
 name = "built"
-version = "0.3.0"
+version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "git2 0.7.5 (registry+https://github.com/rust-lang/crates.io-index)",
+ "chrono 0.4.6 (registry+https://github.com/rust-lang/crates.io-index)",
+ "git2 0.9.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "semver 0.9.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "time 0.1.42 (registry+https://github.com/rust-lang/crates.io-index)",
- "toml 0.4.10 (registry+https://github.com/rust-lang/crates.io-index)",
+ "toml 0.5.1 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -182,7 +182,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
 name = "byteorder"
-version = "1.3.1"
+version = "1.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
@@ -190,7 +190,7 @@ name = "bytes"
 version = "0.4.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "byteorder 1.3.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "byteorder 1.3.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "iovec 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
@@ -349,7 +349,7 @@ name = "csv"
 version = "0.15.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "byteorder 1.3.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "byteorder 1.3.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "memchr 1.0.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "rustc-serialize 0.3.24 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
@@ -419,7 +419,7 @@ dependencies = [
  "heck 0.3.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "proc-macro2 0.4.30 (registry+https://github.com/rust-lang/crates.io-index)",
  "quote 0.6.12 (registry+https://github.com/rust-lang/crates.io-index)",
- "syn 0.15.34 (registry+https://github.com/rust-lang/crates.io-index)",
+ "syn 0.15.36 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -443,7 +443,7 @@ dependencies = [
  "atty 0.2.11 (registry+https://github.com/rust-lang/crates.io-index)",
  "humantime 1.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "log 0.4.6 (registry+https://github.com/rust-lang/crates.io-index)",
- "regex 1.1.6 (registry+https://github.com/rust-lang/crates.io-index)",
+ "regex 1.1.7 (registry+https://github.com/rust-lang/crates.io-index)",
  "termcolor 1.0.5 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
@@ -463,7 +463,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "proc-macro2 0.4.30 (registry+https://github.com/rust-lang/crates.io-index)",
  "quote 0.6.12 (registry+https://github.com/rust-lang/crates.io-index)",
- "syn 0.15.34 (registry+https://github.com/rust-lang/crates.io-index)",
+ "syn 0.15.36 (registry+https://github.com/rust-lang/crates.io-index)",
  "synstructure 0.10.2 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
@@ -518,7 +518,7 @@ version = "0.1.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "futures 0.1.27 (registry+https://github.com/rust-lang/crates.io-index)",
- "num_cpus 1.10.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "num_cpus 1.10.1 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -536,12 +536,12 @@ dependencies = [
 
 [[package]]
 name = "git2"
-version = "0.7.5"
+version = "0.9.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "bitflags 1.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "libc 0.2.58 (registry+https://github.com/rust-lang/crates.io-index)",
- "libgit2-sys 0.7.11 (registry+https://github.com/rust-lang/crates.io-index)",
+ "libgit2-sys 0.8.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "log 0.4.6 (registry+https://github.com/rust-lang/crates.io-index)",
  "url 1.7.2 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
@@ -554,7 +554,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 [[package]]
 name = "grin_api"
 version = "2.0.0-beta.1"
-source = "git+https://github.com/mimblewimble/grin?branch=milestone/2.0.0#e3f30644146ed71039b3e6a53371d8b0688e923d"
+source = "git+https://github.com/mimblewimble/grin?branch=milestone/2.0.0#c2153fada237dc0cfea900bb451552ff20a728c1"
 dependencies = [
  "failure 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)",
  "failure_derive 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -570,7 +570,7 @@ dependencies = [
  "hyper-rustls 0.14.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "lazy_static 1.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "log 0.4.6 (registry+https://github.com/rust-lang/crates.io-index)",
- "regex 1.1.6 (registry+https://github.com/rust-lang/crates.io-index)",
+ "regex 1.1.7 (registry+https://github.com/rust-lang/crates.io-index)",
  "ring 0.13.5 (registry+https://github.com/rust-lang/crates.io-index)",
  "rustls 0.13.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde 1.0.92 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -586,10 +586,10 @@ dependencies = [
 [[package]]
 name = "grin_chain"
 version = "2.0.0-beta.1"
-source = "git+https://github.com/mimblewimble/grin?branch=milestone/2.0.0#e3f30644146ed71039b3e6a53371d8b0688e923d"
+source = "git+https://github.com/mimblewimble/grin?branch=milestone/2.0.0#c2153fada237dc0cfea900bb451552ff20a728c1"
 dependencies = [
  "bitflags 1.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "byteorder 1.3.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "byteorder 1.3.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "chrono 0.4.6 (registry+https://github.com/rust-lang/crates.io-index)",
  "croaring 0.3.9 (registry+https://github.com/rust-lang/crates.io-index)",
  "failure 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -601,7 +601,7 @@ dependencies = [
  "lazy_static 1.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "log 0.4.6 (registry+https://github.com/rust-lang/crates.io-index)",
  "lru-cache 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)",
- "regex 1.1.6 (registry+https://github.com/rust-lang/crates.io-index)",
+ "regex 1.1.7 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde 1.0.92 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde_derive 1.0.92 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
@@ -609,10 +609,10 @@ dependencies = [
 [[package]]
 name = "grin_core"
 version = "2.0.0-beta.1"
-source = "git+https://github.com/mimblewimble/grin?branch=milestone/2.0.0#e3f30644146ed71039b3e6a53371d8b0688e923d"
+source = "git+https://github.com/mimblewimble/grin?branch=milestone/2.0.0#c2153fada237dc0cfea900bb451552ff20a728c1"
 dependencies = [
  "blake2-rfc 0.2.18 (registry+https://github.com/rust-lang/crates.io-index)",
- "byteorder 1.3.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "byteorder 1.3.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "chrono 0.4.6 (registry+https://github.com/rust-lang/crates.io-index)",
  "croaring 0.3.9 (registry+https://github.com/rust-lang/crates.io-index)",
  "enum_primitive 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -636,10 +636,10 @@ dependencies = [
 [[package]]
 name = "grin_keychain"
 version = "2.0.0-beta.1"
-source = "git+https://github.com/mimblewimble/grin?branch=milestone/2.0.0#e3f30644146ed71039b3e6a53371d8b0688e923d"
+source = "git+https://github.com/mimblewimble/grin?branch=milestone/2.0.0#c2153fada237dc0cfea900bb451552ff20a728c1"
 dependencies = [
  "blake2-rfc 0.2.18 (registry+https://github.com/rust-lang/crates.io-index)",
- "byteorder 1.3.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "byteorder 1.3.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "digest 0.7.6 (registry+https://github.com/rust-lang/crates.io-index)",
  "grin_util 2.0.0-beta.1 (git+https://github.com/mimblewimble/grin?branch=milestone/2.0.0)",
  "hmac 0.6.3 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -659,7 +659,7 @@ dependencies = [
 [[package]]
 name = "grin_p2p"
 version = "2.0.0-beta.1"
-source = "git+https://github.com/mimblewimble/grin?branch=milestone/2.0.0#e3f30644146ed71039b3e6a53371d8b0688e923d"
+source = "git+https://github.com/mimblewimble/grin?branch=milestone/2.0.0#c2153fada237dc0cfea900bb451552ff20a728c1"
 dependencies = [
  "bitflags 1.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "bytes 0.4.12 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -681,7 +681,7 @@ dependencies = [
 [[package]]
 name = "grin_pool"
 version = "2.0.0-beta.1"
-source = "git+https://github.com/mimblewimble/grin?branch=milestone/2.0.0#e3f30644146ed71039b3e6a53371d8b0688e923d"
+source = "git+https://github.com/mimblewimble/grin?branch=milestone/2.0.0#c2153fada237dc0cfea900bb451552ff20a728c1"
 dependencies = [
  "blake2-rfc 0.2.18 (registry+https://github.com/rust-lang/crates.io-index)",
  "chrono 0.4.6 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -715,9 +715,9 @@ dependencies = [
 [[package]]
 name = "grin_store"
 version = "2.0.0-beta.1"
-source = "git+https://github.com/mimblewimble/grin?branch=milestone/2.0.0#e3f30644146ed71039b3e6a53371d8b0688e923d"
+source = "git+https://github.com/mimblewimble/grin?branch=milestone/2.0.0#c2153fada237dc0cfea900bb451552ff20a728c1"
 dependencies = [
- "byteorder 1.3.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "byteorder 1.3.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "croaring 0.3.9 (registry+https://github.com/rust-lang/crates.io-index)",
  "env_logger 0.5.13 (registry+https://github.com/rust-lang/crates.io-index)",
  "failure 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -736,11 +736,11 @@ dependencies = [
 [[package]]
 name = "grin_util"
 version = "2.0.0-beta.1"
-source = "git+https://github.com/mimblewimble/grin?branch=milestone/2.0.0#e3f30644146ed71039b3e6a53371d8b0688e923d"
+source = "git+https://github.com/mimblewimble/grin?branch=milestone/2.0.0#c2153fada237dc0cfea900bb451552ff20a728c1"
 dependencies = [
  "backtrace 0.3.30 (registry+https://github.com/rust-lang/crates.io-index)",
  "base64 0.9.3 (registry+https://github.com/rust-lang/crates.io-index)",
- "byteorder 1.3.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "byteorder 1.3.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "grin_secp256k1zkp 0.7.6 (registry+https://github.com/rust-lang/crates.io-index)",
  "lazy_static 1.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "log 0.4.6 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -749,7 +749,7 @@ dependencies = [
  "rand 0.6.5 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde 1.0.92 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde_derive 1.0.92 (registry+https://github.com/rust-lang/crates.io-index)",
- "walkdir 2.2.7 (registry+https://github.com/rust-lang/crates.io-index)",
+ "walkdir 2.2.8 (registry+https://github.com/rust-lang/crates.io-index)",
  "zeroize 0.5.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "zip 0.4.2 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
@@ -758,7 +758,7 @@ dependencies = [
 name = "grin_wallet"
 version = "2.0.0-beta.1"
 dependencies = [
- "built 0.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "built 0.3.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "clap 2.33.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "ctrlc 3.1.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "failure 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -773,6 +773,7 @@ dependencies = [
  "log 0.4.6 (registry+https://github.com/rust-lang/crates.io-index)",
  "prettytable-rs 0.7.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "rpassword 2.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "semver 0.9.0 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -905,7 +906,7 @@ name = "h2"
 version = "0.1.23"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "byteorder 1.3.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "byteorder 1.3.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "bytes 0.4.12 (registry+https://github.com/rust-lang/crates.io-index)",
  "fnv 1.0.6 (registry+https://github.com/rust-lang/crates.io-index)",
  "futures 0.1.27 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -1063,7 +1064,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
 name = "libgit2-sys"
-version = "0.7.11"
+version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "cc 1.0.37 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -1380,10 +1381,10 @@ version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "num-bigint 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)",
- "num-complex 0.2.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "num-complex 0.2.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "num-integer 0.1.41 (registry+https://github.com/rust-lang/crates.io-index)",
  "num-iter 0.1.39 (registry+https://github.com/rust-lang/crates.io-index)",
- "num-rational 0.2.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "num-rational 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "num-traits 0.2.8 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
@@ -1418,9 +1419,10 @@ dependencies = [
 
 [[package]]
 name = "num-complex"
-version = "0.2.1"
+version = "0.2.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
+ "autocfg 0.1.4 (registry+https://github.com/rust-lang/crates.io-index)",
  "num-traits 0.2.8 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
@@ -1456,9 +1458,10 @@ dependencies = [
 
 [[package]]
 name = "num-rational"
-version = "0.2.1"
+version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
+ "autocfg 0.1.4 (registry+https://github.com/rust-lang/crates.io-index)",
  "num-bigint 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "num-integer 0.1.41 (registry+https://github.com/rust-lang/crates.io-index)",
  "num-traits 0.2.8 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -1482,7 +1485,7 @@ dependencies = [
 
 [[package]]
 name = "num_cpus"
-version = "1.10.0"
+version = "1.10.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "libc 0.2.58 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -1540,7 +1543,7 @@ dependencies = [
  "libc 0.2.58 (registry+https://github.com/rust-lang/crates.io-index)",
  "rand 0.5.6 (registry+https://github.com/rust-lang/crates.io-index)",
  "rustc_version 0.2.3 (registry+https://github.com/rust-lang/crates.io-index)",
- "smallvec 0.6.9 (registry+https://github.com/rust-lang/crates.io-index)",
+ "smallvec 0.6.10 (registry+https://github.com/rust-lang/crates.io-index)",
  "winapi 0.3.7 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
@@ -1552,7 +1555,7 @@ dependencies = [
  "libc 0.2.58 (registry+https://github.com/rust-lang/crates.io-index)",
  "rand 0.6.5 (registry+https://github.com/rust-lang/crates.io-index)",
  "rustc_version 0.2.3 (registry+https://github.com/rust-lang/crates.io-index)",
- "smallvec 0.6.9 (registry+https://github.com/rust-lang/crates.io-index)",
+ "smallvec 0.6.10 (registry+https://github.com/rust-lang/crates.io-index)",
  "winapi 0.3.7 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
@@ -1562,7 +1565,7 @@ version = "0.2.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "base64 0.9.3 (registry+https://github.com/rust-lang/crates.io-index)",
- "byteorder 1.3.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "byteorder 1.3.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "constant_time_eq 0.1.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "crypto-mac 0.6.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "generic-array 0.9.0 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -1847,19 +1850,19 @@ dependencies = [
 
 [[package]]
 name = "regex"
-version = "1.1.6"
+version = "1.1.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "aho-corasick 0.7.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "memchr 2.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "regex-syntax 0.6.6 (registry+https://github.com/rust-lang/crates.io-index)",
+ "regex-syntax 0.6.7 (registry+https://github.com/rust-lang/crates.io-index)",
  "thread_local 0.3.6 (registry+https://github.com/rust-lang/crates.io-index)",
- "utf8-ranges 1.0.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "utf8-ranges 1.0.3 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
 name = "regex-syntax"
-version = "0.6.6"
+version = "0.6.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "ucd-util 0.1.3 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -1867,7 +1870,7 @@ dependencies = [
 
 [[package]]
 name = "remove_dir_all"
-version = "0.5.1"
+version = "0.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "winapi 0.3.7 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -2027,7 +2030,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "proc-macro2 0.4.30 (registry+https://github.com/rust-lang/crates.io-index)",
  "quote 0.6.12 (registry+https://github.com/rust-lang/crates.io-index)",
- "syn 0.15.34 (registry+https://github.com/rust-lang/crates.io-index)",
+ "syn 0.15.36 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -2077,12 +2080,12 @@ name = "smallstr"
 version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "smallvec 0.6.9 (registry+https://github.com/rust-lang/crates.io-index)",
+ "smallvec 0.6.10 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
 name = "smallvec"
-version = "0.6.9"
+version = "0.6.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
@@ -2116,7 +2119,7 @@ dependencies = [
  "heck 0.3.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "proc-macro2 0.4.30 (registry+https://github.com/rust-lang/crates.io-index)",
  "quote 0.6.12 (registry+https://github.com/rust-lang/crates.io-index)",
- "syn 0.15.34 (registry+https://github.com/rust-lang/crates.io-index)",
+ "syn 0.15.36 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -2126,7 +2129,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
 name = "syn"
-version = "0.15.34"
+version = "0.15.36"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "proc-macro2 0.4.30 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -2141,7 +2144,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "proc-macro2 0.4.30 (registry+https://github.com/rust-lang/crates.io-index)",
  "quote 0.6.12 (registry+https://github.com/rust-lang/crates.io-index)",
- "syn 0.15.34 (registry+https://github.com/rust-lang/crates.io-index)",
+ "syn 0.15.36 (registry+https://github.com/rust-lang/crates.io-index)",
  "unicode-xid 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
@@ -2154,7 +2157,7 @@ dependencies = [
  "libc 0.2.58 (registry+https://github.com/rust-lang/crates.io-index)",
  "rand 0.6.5 (registry+https://github.com/rust-lang/crates.io-index)",
  "redox_syscall 0.1.54 (registry+https://github.com/rust-lang/crates.io-index)",
- "remove_dir_all 0.5.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "remove_dir_all 0.5.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "winapi 0.3.7 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
@@ -2163,7 +2166,7 @@ name = "term"
 version = "0.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "byteorder 1.3.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "byteorder 1.3.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "dirs 1.0.5 (registry+https://github.com/rust-lang/crates.io-index)",
  "winapi 0.3.7 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
@@ -2189,7 +2192,7 @@ dependencies = [
 
 [[package]]
 name = "termion"
-version = "1.5.2"
+version = "1.5.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "libc 0.2.58 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -2331,7 +2334,7 @@ dependencies = [
  "lazy_static 1.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "log 0.4.6 (registry+https://github.com/rust-lang/crates.io-index)",
  "mio 0.6.19 (registry+https://github.com/rust-lang/crates.io-index)",
- "num_cpus 1.10.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "num_cpus 1.10.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "parking_lot 0.7.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "slab 0.4.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "tokio-executor 0.1.7 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -2400,7 +2403,7 @@ dependencies = [
  "crossbeam-utils 0.6.5 (registry+https://github.com/rust-lang/crates.io-index)",
  "futures 0.1.27 (registry+https://github.com/rust-lang/crates.io-index)",
  "log 0.4.6 (registry+https://github.com/rust-lang/crates.io-index)",
- "num_cpus 1.10.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "num_cpus 1.10.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "rand 0.6.5 (registry+https://github.com/rust-lang/crates.io-index)",
  "slab 0.4.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "tokio-executor 0.1.7 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -2457,6 +2460,14 @@ dependencies = [
 ]
 
 [[package]]
+name = "toml"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "serde 1.0.92 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
 name = "traitobject"
 version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2497,7 +2508,7 @@ name = "unicode-normalization"
 version = "0.1.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "smallvec 0.6.9 (registry+https://github.com/rust-lang/crates.io-index)",
+ "smallvec 0.6.10 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -2540,7 +2551,7 @@ dependencies = [
 
 [[package]]
 name = "utf8-ranges"
-version = "1.0.2"
+version = "1.0.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
@@ -2584,7 +2595,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
 name = "walkdir"
-version = "2.2.7"
+version = "2.2.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "same-file 1.0.4 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -2716,7 +2727,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "proc-macro2 0.4.30 (registry+https://github.com/rust-lang/crates.io-index)",
  "quote 0.6.12 (registry+https://github.com/rust-lang/crates.io-index)",
- "syn 0.15.34 (registry+https://github.com/rust-lang/crates.io-index)",
+ "syn 0.15.36 (registry+https://github.com/rust-lang/crates.io-index)",
  "synstructure 0.10.2 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
@@ -2752,9 +2763,9 @@ dependencies = [
 "checksum blake2-rfc 0.2.18 (registry+https://github.com/rust-lang/crates.io-index)" = "5d6d530bdd2d52966a6d03b7a964add7ae1a288d25214066fd4b600f0f796400"
 "checksum block-buffer 0.3.3 (registry+https://github.com/rust-lang/crates.io-index)" = "a076c298b9ecdb530ed9d967e74a6027d6a7478924520acddcddc24c1c8ab3ab"
 "checksum build_const 0.2.1 (registry+https://github.com/rust-lang/crates.io-index)" = "39092a32794787acd8525ee150305ff051b0aa6cc2abaf193924f5ab05425f39"
-"checksum built 0.3.0 (registry+https://github.com/rust-lang/crates.io-index)" = "61f5aae2fa15b68fbcf0cbab64e659a55d10e9bacc55d3470ef77ae73030d755"
+"checksum built 0.3.1 (registry+https://github.com/rust-lang/crates.io-index)" = "9e7bff98465f9ff426a6e99829629b69acb0048504584934c1fb8b5822457535"
 "checksum byte-tools 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)" = "560c32574a12a89ecd91f5e742165893f86e3ab98d21f8ea548658eb9eef5f40"
-"checksum byteorder 1.3.1 (registry+https://github.com/rust-lang/crates.io-index)" = "a019b10a2a7cdeb292db131fc8113e57ea2a908f6e7894b0c3c671893b65dbeb"
+"checksum byteorder 1.3.2 (registry+https://github.com/rust-lang/crates.io-index)" = "a7c3dd8985a7111efc5c80b44e23ecdd8c007de8ade3b96595387e812b957cf5"
 "checksum bytes 0.4.12 (registry+https://github.com/rust-lang/crates.io-index)" = "206fdffcfa2df7cbe15601ef46c813fce0965eb3286db6b56c583b814b51c81c"
 "checksum cc 1.0.37 (registry+https://github.com/rust-lang/crates.io-index)" = "39f75544d7bbaf57560d2168f28fd649ff9c76153874db88bdbdfd839b1a7e7d"
 "checksum cexpr 0.2.3 (registry+https://github.com/rust-lang/crates.io-index)" = "42aac45e9567d97474a834efdee3081b3c942b2205be932092f53354ce503d6c"
@@ -2797,7 +2808,7 @@ dependencies = [
 "checksum futures-cpupool 0.1.8 (registry+https://github.com/rust-lang/crates.io-index)" = "ab90cde24b3319636588d0c35fe03b1333857621051837ed769faefb4c2162e4"
 "checksum gcc 0.3.55 (registry+https://github.com/rust-lang/crates.io-index)" = "8f5f3913fa0bfe7ee1fd8248b6b9f42a5af4b9d65ec2dd2c3c26132b950ecfc2"
 "checksum generic-array 0.9.0 (registry+https://github.com/rust-lang/crates.io-index)" = "ef25c5683767570c2bbd7deba372926a55eaae9982d7726ee2a1050239d45b9d"
-"checksum git2 0.7.5 (registry+https://github.com/rust-lang/crates.io-index)" = "591f8be1674b421644b6c030969520bc3fa12114d2eb467471982ed3e9584e71"
+"checksum git2 0.9.1 (registry+https://github.com/rust-lang/crates.io-index)" = "924b2e7d2986e625dcad89e8a429a7b3adee3c3d71e585f4a66c4f7e78715e31"
 "checksum glob 0.2.11 (registry+https://github.com/rust-lang/crates.io-index)" = "8be18de09a56b60ed0edf84bc9df007e30040691af7acd1c41874faac5895bfb"
 "checksum grin_api 2.0.0-beta.1 (git+https://github.com/mimblewimble/grin?branch=milestone/2.0.0)" = "<none>"
 "checksum grin_chain 2.0.0-beta.1 (git+https://github.com/mimblewimble/grin?branch=milestone/2.0.0)" = "<none>"
@@ -2824,7 +2835,7 @@ dependencies = [
 "checksum kernel32-sys 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)" = "7507624b29483431c0ba2d82aece8ca6cdba9382bff4ddd0f7490560c056098d"
 "checksum lazy_static 1.3.0 (registry+https://github.com/rust-lang/crates.io-index)" = "bc5729f27f159ddd61f4df6228e827e86643d4d3e7c32183cb30a1c08f604a14"
 "checksum libc 0.2.58 (registry+https://github.com/rust-lang/crates.io-index)" = "6281b86796ba5e4366000be6e9e18bf35580adf9e63fbe2294aadb587613a319"
-"checksum libgit2-sys 0.7.11 (registry+https://github.com/rust-lang/crates.io-index)" = "48441cb35dc255da8ae72825689a95368bf510659ae1ad55dc4aa88cb1789bf1"
+"checksum libgit2-sys 0.8.0 (registry+https://github.com/rust-lang/crates.io-index)" = "3cdc869f847995243b84e2f10226fe70afdd9f989c6fc4500d1ff53dd21cf43b"
 "checksum liblmdb-sys 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)" = "feed38a3a580f60bf61aaa067b0ff4123395966839adeaf67258a9e50c4d2e49"
 "checksum libloading 0.5.1 (registry+https://github.com/rust-lang/crates.io-index)" = "a5692f82b51823e27c4118b3e5c0d98aee9be90633ebc71ad12afef380b50219"
 "checksum libz-sys 1.0.25 (registry+https://github.com/rust-lang/crates.io-index)" = "2eb5e43362e38e2bca2fd5f5134c4d4564a23a5c28e9b95411652021a8675ebe"
@@ -2860,14 +2871,14 @@ dependencies = [
 "checksum num-bigint 0.1.44 (registry+https://github.com/rust-lang/crates.io-index)" = "e63899ad0da84ce718c14936262a41cee2c79c981fc0a0e7c7beb47d5a07e8c1"
 "checksum num-bigint 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)" = "57450397855d951f1a41305e54851b1a7b8f5d2e349543a02a2effe25459f718"
 "checksum num-complex 0.1.43 (registry+https://github.com/rust-lang/crates.io-index)" = "b288631d7878aaf59442cffd36910ea604ecd7745c36054328595114001c9656"
-"checksum num-complex 0.2.1 (registry+https://github.com/rust-lang/crates.io-index)" = "107b9be86cd2481930688277b675b0114578227f034674726605b8a482d8baf8"
+"checksum num-complex 0.2.3 (registry+https://github.com/rust-lang/crates.io-index)" = "fcb0cf31fb3ff77e6d2a6ebd6800df7fdcd106f2ad89113c9130bcd07f93dffc"
 "checksum num-integer 0.1.41 (registry+https://github.com/rust-lang/crates.io-index)" = "b85e541ef8255f6cf42bbfe4ef361305c6c135d10919ecc26126c4e5ae94bc09"
 "checksum num-iter 0.1.39 (registry+https://github.com/rust-lang/crates.io-index)" = "76bd5272412d173d6bf9afdf98db8612bbabc9a7a830b7bfc9c188911716132e"
 "checksum num-rational 0.1.42 (registry+https://github.com/rust-lang/crates.io-index)" = "ee314c74bd753fc86b4780aa9475da469155f3848473a261d2d18e35245a784e"
-"checksum num-rational 0.2.1 (registry+https://github.com/rust-lang/crates.io-index)" = "4e96f040177bb3da242b5b1ecf3f54b5d5af3efbbfb18608977a5d2767b22f10"
+"checksum num-rational 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)" = "f2885278d5fe2adc2f75ced642d52d879bffaceb5a2e0b1d4309ffdfb239b454"
 "checksum num-traits 0.1.43 (registry+https://github.com/rust-lang/crates.io-index)" = "92e5113e9fd4cc14ded8e499429f396a20f98c772a47cc8622a736e1ec843c31"
 "checksum num-traits 0.2.8 (registry+https://github.com/rust-lang/crates.io-index)" = "6ba9a427cfca2be13aa6f6403b0b7e7368fe982bfa16fccc450ce74c46cd9b32"
-"checksum num_cpus 1.10.0 (registry+https://github.com/rust-lang/crates.io-index)" = "1a23f0ed30a54abaa0c7e83b1d2d87ada7c3c23078d1d87815af3e3b6385fbba"
+"checksum num_cpus 1.10.1 (registry+https://github.com/rust-lang/crates.io-index)" = "bcef43580c035376c0705c42792c294b66974abbfd2789b511784023f71f3273"
 "checksum numtoa 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)" = "b8f8bdf33df195859076e54ab11ee78a1b208382d3a26ec40d142ffc1ecc49ef"
 "checksum odds 0.2.26 (registry+https://github.com/rust-lang/crates.io-index)" = "4eae0151b9dacf24fcc170d9995e511669a082856a91f958a2fe380bfab3fb22"
 "checksum ordered-float 1.0.2 (registry+https://github.com/rust-lang/crates.io-index)" = "18869315e81473c951eb56ad5558bbc56978562d3ecfb87abb7a1e944cea4518"
@@ -2909,9 +2920,9 @@ dependencies = [
 "checksum redox_syscall 0.1.54 (registry+https://github.com/rust-lang/crates.io-index)" = "12229c14a0f65c4f1cb046a3b52047cdd9da1f4b30f8a39c5063c8bae515e252"
 "checksum redox_termios 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)" = "7e891cfe48e9100a70a3b6eb652fef28920c117d366339687bd5576160db0f76"
 "checksum redox_users 0.3.0 (registry+https://github.com/rust-lang/crates.io-index)" = "3fe5204c3a17e97dde73f285d49be585df59ed84b50a872baf416e73b62c3828"
-"checksum regex 1.1.6 (registry+https://github.com/rust-lang/crates.io-index)" = "8f0a0bcab2fd7d1d7c54fa9eae6f43eddeb9ce2e7352f8518a814a4f65d60c58"
-"checksum regex-syntax 0.6.6 (registry+https://github.com/rust-lang/crates.io-index)" = "dcfd8681eebe297b81d98498869d4aae052137651ad7b96822f09ceb690d0a96"
-"checksum remove_dir_all 0.5.1 (registry+https://github.com/rust-lang/crates.io-index)" = "3488ba1b9a2084d38645c4c08276a1752dcbf2c7130d74f1569681ad5d2799c5"
+"checksum regex 1.1.7 (registry+https://github.com/rust-lang/crates.io-index)" = "0b2f0808e7d7e4fb1cb07feb6ff2f4bc827938f24f8c2e6a3beb7370af544bdd"
+"checksum regex-syntax 0.6.7 (registry+https://github.com/rust-lang/crates.io-index)" = "9d76410686f9e3a17f06128962e0ecc5755870bb890c34820c7af7f1db2e1d48"
+"checksum remove_dir_all 0.5.2 (registry+https://github.com/rust-lang/crates.io-index)" = "4a83fa3702a688b9359eccba92d153ac33fd2e8462f9e0e3fdf155239ea7792e"
 "checksum ring 0.13.5 (registry+https://github.com/rust-lang/crates.io-index)" = "2c4db68a2e35f3497146b7e4563df7d4773a2433230c5e4b448328e31740458a"
 "checksum ripemd160 0.7.0 (registry+https://github.com/rust-lang/crates.io-index)" = "482aa56cc68aaeccdaaff1cc5a72c247da8bbad3beb174ca5741f274c22883fb"
 "checksum rpassword 2.1.0 (registry+https://github.com/rust-lang/crates.io-index)" = "d37473170aedbe66ffa3ad3726939ba677d83c646ad4fd99e5b4bc38712f45ec"
@@ -2939,20 +2950,20 @@ dependencies = [
 "checksum siphasher 0.2.3 (registry+https://github.com/rust-lang/crates.io-index)" = "0b8de496cf83d4ed58b6be86c3a275b8602f6ffe98d3024a869e124147a9a3ac"
 "checksum slab 0.4.2 (registry+https://github.com/rust-lang/crates.io-index)" = "c111b5bd5695e56cffe5129854aa230b39c93a305372fdbb2668ca2394eea9f8"
 "checksum smallstr 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)" = "6aa65bb4d5b2bbc90d36af64e29802f788aa614783fa1d0df011800ddcec6e8e"
-"checksum smallvec 0.6.9 (registry+https://github.com/rust-lang/crates.io-index)" = "c4488ae950c49d403731982257768f48fada354a5203fe81f9bb6f43ca9002be"
+"checksum smallvec 0.6.10 (registry+https://github.com/rust-lang/crates.io-index)" = "ab606a9c5e214920bb66c458cd7be8ef094f813f20fe77a54cc7dbfff220d4b7"
 "checksum stable_deref_trait 1.1.1 (registry+https://github.com/rust-lang/crates.io-index)" = "dba1a27d3efae4351c8051072d619e3ade2820635c3958d826bfea39d59b54c8"
 "checksum string 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)" = "d0bbfb8937e38e34c3444ff00afb28b0811d9554f15c5ad64d12b0308d1d1995"
 "checksum strsim 0.8.0 (registry+https://github.com/rust-lang/crates.io-index)" = "8ea5119cdb4c55b55d432abb513a0429384878c15dde60cc77b1c99de1a95a6a"
 "checksum strum 0.15.0 (registry+https://github.com/rust-lang/crates.io-index)" = "e5d1c33039533f051704951680f1adfd468fd37ac46816ded0d9ee068e60f05f"
 "checksum strum_macros 0.15.0 (registry+https://github.com/rust-lang/crates.io-index)" = "47cd23f5c7dee395a00fa20135e2ec0fffcdfa151c56182966d7a3261343432e"
 "checksum supercow 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)" = "171758edb47aa306a78dfa4ab9aeb5167405bd4e3dc2b64e88f6a84bbe98bd63"
-"checksum syn 0.15.34 (registry+https://github.com/rust-lang/crates.io-index)" = "a1393e4a97a19c01e900df2aec855a29f71cf02c402e2f443b8d2747c25c5dbe"
+"checksum syn 0.15.36 (registry+https://github.com/rust-lang/crates.io-index)" = "8b4f551a91e2e3848aeef8751d0d4eec9489b6474c720fd4c55958d8d31a430c"
 "checksum synstructure 0.10.2 (registry+https://github.com/rust-lang/crates.io-index)" = "02353edf96d6e4dc81aea2d8490a7e9db177bf8acb0e951c24940bf866cb313f"
 "checksum tempfile 3.0.8 (registry+https://github.com/rust-lang/crates.io-index)" = "7dc4738f2e68ed2855de5ac9cdbe05c9216773ecde4739b2f095002ab03a13ef"
 "checksum term 0.5.2 (registry+https://github.com/rust-lang/crates.io-index)" = "edd106a334b7657c10b7c540a0106114feadeb4dc314513e97df481d5d966f42"
 "checksum termcolor 1.0.5 (registry+https://github.com/rust-lang/crates.io-index)" = "96d6098003bde162e4277c70665bd87c326f5a0c3f3fbfb285787fa482d54e6e"
 "checksum terminfo 0.6.1 (registry+https://github.com/rust-lang/crates.io-index)" = "8e51065bafd2abe106b6036483b69d1741f4a1ec56ce8a2378de341637de689e"
-"checksum termion 1.5.2 (registry+https://github.com/rust-lang/crates.io-index)" = "dde0593aeb8d47accea5392b39350015b5eccb12c0d98044d856983d89548dea"
+"checksum termion 1.5.3 (registry+https://github.com/rust-lang/crates.io-index)" = "6a8fb22f7cde82c8220e5aeacb3258ed7ce996142c77cba193f203515e26c330"
 "checksum textwrap 0.11.0 (registry+https://github.com/rust-lang/crates.io-index)" = "d326610f408c7a4eb6f51c37c330e496b08506c9457c9d34287ecc38809fb060"
 "checksum thread-id 3.3.0 (registry+https://github.com/rust-lang/crates.io-index)" = "c7fbf4c9d56b320106cd64fd024dadfa0be7cb4706725fc44a7d7ce952d820c1"
 "checksum thread_local 0.3.6 (registry+https://github.com/rust-lang/crates.io-index)" = "c6b53e329000edc2b34dbe8545fd20e55a333362d0a321909685a19bd28c3f1b"
@@ -2975,6 +2986,7 @@ dependencies = [
 "checksum tokio-udp 0.1.3 (registry+https://github.com/rust-lang/crates.io-index)" = "66268575b80f4a4a710ef83d087fdfeeabdce9b74c797535fbac18a2cb906e92"
 "checksum tokio-uds 0.2.5 (registry+https://github.com/rust-lang/crates.io-index)" = "037ffc3ba0e12a0ab4aca92e5234e0dedeb48fddf6ccd260f1f150a36a9f2445"
 "checksum toml 0.4.10 (registry+https://github.com/rust-lang/crates.io-index)" = "758664fc71a3a69038656bee8b6be6477d2a6c315a6b81f7081f591bffa4111f"
+"checksum toml 0.5.1 (registry+https://github.com/rust-lang/crates.io-index)" = "b8c96d7873fa7ef8bdeb3a9cda3ac48389b4154f32b9803b4bc26220b677b039"
 "checksum traitobject 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)" = "efd1f82c56340fdf16f2a953d7bda4f8fdffba13d93b00844c25572110b26079"
 "checksum try-lock 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)" = "e604eb7b43c06650e854be16a2a03155743d3752dd1c943f6829e26b7a36e382"
 "checksum typemap 0.3.3 (registry+https://github.com/rust-lang/crates.io-index)" = "653be63c80a3296da5551e1bfd2cca35227e13cdd08c6668903ae2f4f77aa1f6"
@@ -2988,14 +3000,14 @@ dependencies = [
 "checksum unsafe-any 0.4.2 (registry+https://github.com/rust-lang/crates.io-index)" = "f30360d7979f5e9c6e6cea48af192ea8fab4afb3cf72597154b8f08935bc9c7f"
 "checksum untrusted 0.6.2 (registry+https://github.com/rust-lang/crates.io-index)" = "55cd1f4b4e96b46aeb8d4855db4a7a9bd96eeeb5c6a1ab54593328761642ce2f"
 "checksum url 1.7.2 (registry+https://github.com/rust-lang/crates.io-index)" = "dd4e7c0d531266369519a4aa4f399d748bd37043b00bde1e4ff1f60a120b355a"
-"checksum utf8-ranges 1.0.2 (registry+https://github.com/rust-lang/crates.io-index)" = "796f7e48bef87609f7ade7e06495a87d5cd06c7866e6a5cbfceffc558a243737"
+"checksum utf8-ranges 1.0.3 (registry+https://github.com/rust-lang/crates.io-index)" = "9d50aa7650df78abf942826607c62468ce18d9019673d4a2ebe1865dbb96ffde"
 "checksum uuid 0.6.5 (registry+https://github.com/rust-lang/crates.io-index)" = "e1436e58182935dcd9ce0add9ea0b558e8a87befe01c1a301e6020aeb0876363"
 "checksum uuid 0.7.4 (registry+https://github.com/rust-lang/crates.io-index)" = "90dbc611eb48397705a6b0f6e917da23ae517e4d127123d2cf7674206627d32a"
 "checksum vcpkg 0.2.6 (registry+https://github.com/rust-lang/crates.io-index)" = "def296d3eb3b12371b2c7d0e83bfe1403e4db2d7a0bba324a12b21c4ee13143d"
 "checksum vec_map 0.8.1 (registry+https://github.com/rust-lang/crates.io-index)" = "05c78687fb1a80548ae3250346c3db86a80a7cdd77bda190189f2d0a0987c81a"
 "checksum version_check 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)" = "914b1a6776c4c929a602fafd8bc742e06365d4bcbe48c30f9cca5824f70dc9dd"
 "checksum void 1.0.2 (registry+https://github.com/rust-lang/crates.io-index)" = "6a02e4885ed3bc0f2de90ea6dd45ebcbb66dacffe03547fadbb0eeae2770887d"
-"checksum walkdir 2.2.7 (registry+https://github.com/rust-lang/crates.io-index)" = "9d9d7ed3431229a144296213105a390676cc49c9b6a72bd19f3176c98e129fa1"
+"checksum walkdir 2.2.8 (registry+https://github.com/rust-lang/crates.io-index)" = "c7904a7e2bb3cdf0cf5e783f44204a85a37a93151738fa349f06680f59a98b45"
 "checksum want 0.0.6 (registry+https://github.com/rust-lang/crates.io-index)" = "797464475f30ddb8830cc529aaaae648d581f99e2036a928877dfde027ddf6b3"
 "checksum webpki 0.18.1 (registry+https://github.com/rust-lang/crates.io-index)" = "17d7967316d8411ca3b01821ee6c332bde138ba4363becdb492f12e514daa17f"
 "checksum webpki-roots 0.15.0 (registry+https://github.com/rust-lang/crates.io-index)" = "85d1f408918fd590908a70d36b7ac388db2edc221470333e4d6e5b598e44cabf"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -28,6 +28,7 @@ failure_derive = "0.1"
 prettytable-rs = "0.7"
 log = "0.4"
 linefeed = "0.5"
+semver = "0.9"
 
 grin_wallet_api = { path = "./api", version = "2.0.0-beta.1" }
 grin_wallet_impls = { path = "./impls", version = "2.0.0-beta.1" }

--- a/api/src/foreign.rs
+++ b/api/src/foreign.rs
@@ -16,7 +16,9 @@
 
 use crate::keychain::Keychain;
 use crate::libwallet::api_impl::foreign;
-use crate::libwallet::{BlockFees, CbData, Error, NodeClient, Slate, NodeVersionInfo, VersionInfo, WalletBackend};
+use crate::libwallet::{
+	BlockFees, CbData, Error, NodeClient, NodeVersionInfo, Slate, VersionInfo, WalletBackend,
+};
 use crate::util::Mutex;
 use std::marker::PhantomData;
 use std::sync::Arc;

--- a/api/src/foreign.rs
+++ b/api/src/foreign.rs
@@ -24,7 +24,8 @@ use std::marker::PhantomData;
 use std::sync::Arc;
 
 /// ForeignAPI Middleware Check callback
-pub type ForeignCheckMiddleware = fn(ForeignCheckMiddlewareFn, Option<NodeVersionInfo>, Option<&Slate>) -> Result<(), Error>;
+pub type ForeignCheckMiddleware =
+	fn(ForeignCheckMiddlewareFn, Option<NodeVersionInfo>, Option<&Slate>) -> Result<(), Error>;
 
 /// Middleware Identifiers for each function
 pub enum ForeignCheckMiddlewareFn {
@@ -168,7 +169,11 @@ where
 	pub fn check_version(&self) -> Result<VersionInfo, Error> {
 		if let Some(m) = self.middleware.as_ref() {
 			let mut w = self.wallet.lock();
-			m(ForeignCheckMiddlewareFn::CheckVersion, w.w2n_client().get_version_info(), None)?;
+			m(
+				ForeignCheckMiddlewareFn::CheckVersion,
+				w.w2n_client().get_version_info(),
+				None,
+			)?;
 		}
 		Ok(foreign::check_version())
 	}
@@ -226,7 +231,11 @@ where
 	pub fn build_coinbase(&self, block_fees: &BlockFees) -> Result<CbData, Error> {
 		let mut w = self.wallet.lock();
 		if let Some(m) = self.middleware.as_ref() {
-			m(ForeignCheckMiddlewareFn::BuildCoinbase, w.w2n_client().get_version_info(), None)?;
+			m(
+				ForeignCheckMiddlewareFn::BuildCoinbase,
+				w.w2n_client().get_version_info(),
+				None,
+			)?;
 		}
 		w.open_with_credentials()?;
 		let res = foreign::build_coinbase(&mut *w, block_fees, self.doctest_mode);
@@ -275,7 +284,11 @@ where
 	pub fn verify_slate_messages(&self, slate: &Slate) -> Result<(), Error> {
 		if let Some(m) = self.middleware.as_ref() {
 			let mut w = self.wallet.lock();
-			m(ForeignCheckMiddlewareFn::VerifySlateMessages, w.w2n_client().get_version_info(), Some(slate))?;
+			m(
+				ForeignCheckMiddlewareFn::VerifySlateMessages,
+				w.w2n_client().get_version_info(),
+				Some(slate),
+			)?;
 		}
 		foreign::verify_slate_messages(slate)
 	}
@@ -344,7 +357,11 @@ where
 	) -> Result<Slate, Error> {
 		let mut w = self.wallet.lock();
 		if let Some(m) = self.middleware.as_ref() {
-			m(ForeignCheckMiddlewareFn::ReceiveTx, w.w2n_client().get_version_info(), Some(slate))?;
+			m(
+				ForeignCheckMiddlewareFn::ReceiveTx,
+				w.w2n_client().get_version_info(),
+				Some(slate),
+			)?;
 		}
 		w.open_with_credentials()?;
 		let res = foreign::receive_tx(&mut *w, slate, dest_acct_name, message, self.doctest_mode);
@@ -402,7 +419,11 @@ where
 	pub fn finalize_invoice_tx(&self, slate: &Slate) -> Result<Slate, Error> {
 		let mut w = self.wallet.lock();
 		if let Some(m) = self.middleware.as_ref() {
-			m(ForeignCheckMiddlewareFn::FinalizeInvoiceTx, w.w2n_client().get_version_info(), Some(slate))?;
+			m(
+				ForeignCheckMiddlewareFn::FinalizeInvoiceTx,
+				w.w2n_client().get_version_info(),
+				Some(slate),
+			)?;
 		}
 		w.open_with_credentials()?;
 		let res = foreign::finalize_invoice_tx(&mut *w, slate);

--- a/api/src/foreign_rpc.rs
+++ b/api/src/foreign_rpc.rs
@@ -15,8 +15,8 @@
 //! JSON-RPC Stub generation for the Foreign API
 
 use crate::keychain::Keychain;
-use crate::libwallet::{
-	BlockFees, CbData, ErrorKind, InitTxArgs, IssueInvoiceTxArgs, NodeClient, Slate, VersionInfo,
+use crate::libwallet::{self,
+	BlockFees, CbData, ErrorKind, InitTxArgs, IssueInvoiceTxArgs, NodeVersionInfo, NodeClient, Slate, VersionInfo,
 	VersionedSlate, WalletBackend,
 };
 use crate::Foreign;
@@ -557,6 +557,12 @@ where
 	}
 }
 
+fn test_check_middleware(_node_version_info: Option<NodeVersionInfo>, _slate: Option<&Slate>) -> Result<(), libwallet::Error> {
+	// TODO: Implement checks
+	// return Err(ErrorKind::GenericError("Test Rejection".into()))?
+	Ok(())
+}
+
 /// helper to set up a real environment to run integrated doctests
 pub fn run_doctest_foreign(
 	request: serde_json::Value,
@@ -675,8 +681,8 @@ pub fn run_doctest_foreign(
 	}
 
 	let mut api_foreign = match init_invoice_tx {
-		false => Foreign::new(wallet1.clone()),
-		true => Foreign::new(wallet2.clone()),
+		false => Foreign::new(wallet1.clone(), Some(test_check_middleware)),
+		true => Foreign::new(wallet2.clone(), Some(test_check_middleware)),
 	};
 	api_foreign.doctest_mode = true;
 	let foreign_api = &api_foreign as &dyn ForeignRpc;

--- a/api/src/foreign_rpc.rs
+++ b/api/src/foreign_rpc.rs
@@ -19,7 +19,7 @@ use crate::libwallet::{
 	self, BlockFees, CbData, ErrorKind, InitTxArgs, IssueInvoiceTxArgs, NodeClient,
 	NodeVersionInfo, Slate, VersionInfo, VersionedSlate, WalletBackend,
 };
-use crate::Foreign;
+use crate::{Foreign, ForeignCheckMiddlewareFn};
 use easy_jsonrpc;
 
 /// Public definition used to generate Foreign jsonrpc api.
@@ -558,6 +558,7 @@ where
 }
 
 fn test_check_middleware(
+	_name: ForeignCheckMiddlewareFn,
 	_node_version_info: Option<NodeVersionInfo>,
 	_slate: Option<&Slate>,
 ) -> Result<(), libwallet::Error> {

--- a/api/src/foreign_rpc.rs
+++ b/api/src/foreign_rpc.rs
@@ -15,9 +15,9 @@
 //! JSON-RPC Stub generation for the Foreign API
 
 use crate::keychain::Keychain;
-use crate::libwallet::{self,
-	BlockFees, CbData, ErrorKind, InitTxArgs, IssueInvoiceTxArgs, NodeVersionInfo, NodeClient, Slate, VersionInfo,
-	VersionedSlate, WalletBackend,
+use crate::libwallet::{
+	self, BlockFees, CbData, ErrorKind, InitTxArgs, IssueInvoiceTxArgs, NodeClient,
+	NodeVersionInfo, Slate, VersionInfo, VersionedSlate, WalletBackend,
 };
 use crate::Foreign;
 use easy_jsonrpc;
@@ -557,7 +557,10 @@ where
 	}
 }
 
-fn test_check_middleware(_node_version_info: Option<NodeVersionInfo>, _slate: Option<&Slate>) -> Result<(), libwallet::Error> {
+fn test_check_middleware(
+	_node_version_info: Option<NodeVersionInfo>,
+	_slate: Option<&Slate>,
+) -> Result<(), libwallet::Error> {
 	// TODO: Implement checks
 	// return Err(ErrorKind::GenericError("Test Rejection".into()))?
 	Ok(())

--- a/api/src/lib.rs
+++ b/api/src/lib.rs
@@ -38,7 +38,7 @@ mod foreign;
 mod foreign_rpc;
 mod owner;
 mod owner_rpc;
-pub use crate::foreign::{Foreign, ForeignCheckMiddleware};
+pub use crate::foreign::{Foreign, ForeignCheckMiddleware, ForeignCheckMiddlewareFn};
 pub use crate::foreign_rpc::ForeignRpc;
 pub use crate::owner::Owner;
 pub use crate::owner_rpc::OwnerRpc;

--- a/api/src/lib.rs
+++ b/api/src/lib.rs
@@ -38,7 +38,7 @@ mod foreign;
 mod foreign_rpc;
 mod owner;
 mod owner_rpc;
-pub use crate::foreign::Foreign;
+pub use crate::foreign::{Foreign, ForeignCheckMiddleware};
 pub use crate::foreign_rpc::ForeignRpc;
 pub use crate::owner::Owner;
 pub use crate::owner_rpc::OwnerRpc;

--- a/api/src/owner_rpc.rs
+++ b/api/src/owner_rpc.rs
@@ -391,7 +391,7 @@ pub trait OwnerRpc {
 		  "version_info": {
 				"orig_version": 2,
 				"version": 2,
-				"block_header_version": 2
+				"block_header_version": 1
 		  }
 		}
 	  }
@@ -471,7 +471,7 @@ pub trait OwnerRpc {
 					"version_info": {
 						"orig_version": 2,
 						"version": 2,
-						"block_header_version": 2
+						"block_header_version": 1
 					}
 				}
 			}

--- a/controller/src/controller.rs
+++ b/controller/src/controller.rs
@@ -57,6 +57,7 @@ fn check_middleware(
 			}
 			if let Some(s) = slate {
 				if s.version_info.version < CURRENT_SLATE_VERSION
+					|| (bhv == 1 && s.version_info.block_header_version != 1)
 					|| (bhv > 1 && s.version_info.block_header_version < GRIN_BLOCK_HEADER_VERSION)
 				{
 					Err(ErrorKind::Compatibility(

--- a/controller/src/controller.rs
+++ b/controller/src/controller.rs
@@ -16,8 +16,10 @@
 //! invocations) as needed.
 use crate::api::{self, ApiServer, BasicAuthMiddleware, ResponseFuture, Router, TLSConfig};
 use crate::keychain::Keychain;
-use crate::libwallet::{Error, ErrorKind, NodeClient, NodeVersionInfo, Slate, WalletBackend,
-CURRENT_SLATE_VERSION, GRIN_BLOCK_HEADER_VERSION};
+use crate::libwallet::{
+	Error, ErrorKind, NodeClient, NodeVersionInfo, Slate, WalletBackend, CURRENT_SLATE_VERSION,
+	GRIN_BLOCK_HEADER_VERSION,
+};
 use crate::util::to_base64;
 use crate::util::Mutex;
 use failure::ResultExt;
@@ -31,7 +33,7 @@ use std::marker::PhantomData;
 use std::net::SocketAddr;
 use std::sync::Arc;
 
-use crate::apiwallet::{Foreign, ForeignRpc, ForeignCheckMiddlewareFn, Owner, OwnerRpc};
+use crate::apiwallet::{Foreign, ForeignCheckMiddlewareFn, ForeignRpc, Owner, OwnerRpc};
 use easy_jsonrpc;
 use easy_jsonrpc::{Handler, MaybeReply};
 
@@ -54,10 +56,14 @@ fn check_middleware(
 				bhv = n.block_header_version;
 			}
 			if let Some(s) = slate {
-				if s.version_info.version < CURRENT_SLATE_VERSION ||
-					(bhv > 1 && s.version_info.block_header_version < GRIN_BLOCK_HEADER_VERSION) {
-					Err(ErrorKind::Compatibility("Incoming Slate is not compatible with this wallet. \
-					Please upgrade the node or use a different one.".into()))?;
+				if s.version_info.version < CURRENT_SLATE_VERSION
+					|| (bhv > 1 && s.version_info.block_header_version < GRIN_BLOCK_HEADER_VERSION)
+				{
+					Err(ErrorKind::Compatibility(
+						"Incoming Slate is not compatible with this wallet. \
+						 Please upgrade the node or use a different one."
+							.into(),
+					))?;
 				}
 			}
 			Ok(())

--- a/controller/src/controller.rs
+++ b/controller/src/controller.rs
@@ -16,7 +16,7 @@
 //! invocations) as needed.
 use crate::api::{self, ApiServer, BasicAuthMiddleware, ResponseFuture, Router, TLSConfig};
 use crate::keychain::Keychain;
-use crate::libwallet::{Error, ErrorKind, NodeClient, WalletBackend, Slate, NodeVersionInfo};
+use crate::libwallet::{Error, ErrorKind, NodeClient, NodeVersionInfo, Slate, WalletBackend};
 use crate::util::to_base64;
 use crate::util::Mutex;
 use failure::ResultExt;
@@ -39,7 +39,10 @@ lazy_static! {
 		HeaderValue::from_str("Basic realm=GrinOwnerAPI").unwrap();
 }
 
-fn check_middleware(_node_version_info: Option<NodeVersionInfo>, _slate: Option<&Slate>) -> Result<(), Error> {
+fn check_middleware(
+	_node_version_info: Option<NodeVersionInfo>,
+	_slate: Option<&Slate>,
+) -> Result<(), Error> {
 	// TODO: Implement checks
 	Ok(())
 }

--- a/impls/src/node_clients/http.rs
+++ b/impls/src/node_clients/http.rs
@@ -70,24 +70,25 @@ impl NodeClient for HTTPNodeClient {
 			return Some(v.clone());
 		}
 		let url = format!("{}/v1/version", self.node_url());
-		let mut retval = match api::client::get::<NodeVersionInfo>(url.as_str(), self.node_api_secret()) {
-			Ok(n) => n,
-			Err(e) => {
-			// If node isn't available, allow offline functions
-			// unfortunately have to parse string due to error structure
-				let err_string = format!("{}", e);
-				if err_string.contains("404") {
-					return Some(NodeVersionInfo {
-						node_version: "1.0.0".into(),
-						block_header_version: 1,
-						verified: Some(false),
-					});
-				} else {
-					error!("Unable to contact Node to get version info: {}", e);
-					return None
+		let mut retval =
+			match api::client::get::<NodeVersionInfo>(url.as_str(), self.node_api_secret()) {
+				Ok(n) => n,
+				Err(e) => {
+					// If node isn't available, allow offline functions
+					// unfortunately have to parse string due to error structure
+					let err_string = format!("{}", e);
+					if err_string.contains("404") {
+						return Some(NodeVersionInfo {
+							node_version: "1.0.0".into(),
+							block_header_version: 1,
+							verified: Some(false),
+						});
+					} else {
+						error!("Unable to contact Node to get version info: {}", e);
+						return None;
+					}
 				}
-			}
-		};
+			};
 		retval.verified = Some(true);
 		self.node_version_info = Some(retval.clone());
 		Some(retval)

--- a/impls/src/node_clients/http.rs
+++ b/impls/src/node_clients/http.rs
@@ -30,6 +30,7 @@ use crate::util::secp::pedersen;
 pub struct HTTPNodeClient {
 	node_url: String,
 	node_api_secret: Option<String>,
+	node_version_info: Option<NodeVersionInfo>,
 }
 
 impl HTTPNodeClient {
@@ -38,6 +39,7 @@ impl HTTPNodeClient {
 		HTTPNodeClient {
 			node_url: node_url.to_owned(),
 			node_api_secret: node_api_secret,
+			node_version_info: None,
 		}
 	}
 
@@ -63,16 +65,32 @@ impl NodeClient for HTTPNodeClient {
 		self.node_api_secret = node_api_secret;
 	}
 
-	fn get_version_info(&self) -> Result<NodeVersionInfo, libwallet::Error> {
-		let url = format!("{}/v1/version", self.node_url());
-		match api::client::get::<NodeVersionInfo>(url.as_str(), self.node_api_secret()) {
-			Ok(n) => Ok(n),
-			Err(e) => {
-				let report = format!("Getting version info from node: {}", e);
-				error!("Unable to get version info from Node: {}", e);
-				Err(libwallet::ErrorKind::ClientCallback(report).into())
-			}
+	fn get_version_info(&mut self) -> Option<NodeVersionInfo> {
+		if let Some(v) = self.node_version_info.as_ref() {
+			return Some(v.clone());
 		}
+		let url = format!("{}/v1/version", self.node_url());
+		let mut retval = match api::client::get::<NodeVersionInfo>(url.as_str(), self.node_api_secret()) {
+			Ok(n) => n,
+			Err(e) => {
+			// If node isn't available, allow offline functions
+			// unfortunately have to parse string due to error structure
+				let err_string = format!("{}", e);
+				if err_string.contains("404") {
+					return Some(NodeVersionInfo {
+						node_version: "1.0.0".into(),
+						block_header_version: 1,
+						verified: Some(false),
+					});
+				} else {
+					error!("Unable to contact Node to get version info: {}", e);
+					return None
+				}
+			}
+		};
+		retval.verified = Some(true);
+		self.node_version_info = Some(retval.clone());
+		Some(retval)
 	}
 
 	/// Posts a transaction to a grin node

--- a/impls/src/node_clients/http.rs
+++ b/impls/src/node_clients/http.rs
@@ -63,9 +63,9 @@ impl NodeClient for HTTPNodeClient {
 		self.node_api_secret = node_api_secret;
 	}
 
-	fn get_version_info(&self) -> Result<NodeVersionInfo, libwallet::Error>{
+	fn get_version_info(&self) -> Result<NodeVersionInfo, libwallet::Error> {
 		let url = format!("{}/v1/version", self.node_url());
-		match api::client::get::<NodeVersionInfo>(url.as_str(), self.node_api_secret()){
+		match api::client::get::<NodeVersionInfo>(url.as_str(), self.node_api_secret()) {
 			Ok(n) => Ok(n),
 			Err(e) => {
 				let report = format!("Getting version info from node: {}", e);

--- a/impls/src/test_framework/testclient.rs
+++ b/impls/src/test_framework/testclient.rs
@@ -402,8 +402,8 @@ impl NodeClient for LocalWalletClient {
 	}
 	fn set_node_url(&mut self, _node_url: &str) {}
 	fn set_node_api_secret(&mut self, _node_api_secret: Option<String>) {}
-	fn get_version_info(&self) -> Result<NodeVersionInfo, libwallet::Error> {
-		unimplemented!()
+	fn get_version_info(&mut self) -> Option<NodeVersionInfo> {
+		None
 	}
 	/// Posts a transaction to a grin node
 	/// In this case it will create a new block with award rewarded to

--- a/impls/src/test_framework/testclient.rs
+++ b/impls/src/test_framework/testclient.rs
@@ -26,7 +26,7 @@ use crate::core::global::{set_mining_mode, ChainTypes};
 use crate::core::{pow, ser};
 use crate::keychain::Keychain;
 use crate::libwallet::api_impl::foreign;
-use crate::libwallet::{NodeClient, Slate, TxWrapper, WalletInst};
+use crate::libwallet::{NodeClient, NodeVersionInfo, Slate, TxWrapper, WalletInst};
 use crate::util;
 use crate::util::secp::pedersen;
 use crate::util::secp::pedersen::Commitment;
@@ -402,6 +402,9 @@ impl NodeClient for LocalWalletClient {
 	}
 	fn set_node_url(&mut self, _node_url: &str) {}
 	fn set_node_api_secret(&mut self, _node_api_secret: Option<String>) {}
+	fn get_version_info(&self) -> Result<NodeVersionInfo, libwallet::Error>{
+		unimplemented!()
+	}
 	/// Posts a transaction to a grin node
 	/// In this case it will create a new block with award rewarded to
 	fn post_tx(&self, tx: &TxWrapper, _fluff: bool) -> Result<(), libwallet::Error> {

--- a/impls/src/test_framework/testclient.rs
+++ b/impls/src/test_framework/testclient.rs
@@ -402,7 +402,7 @@ impl NodeClient for LocalWalletClient {
 	}
 	fn set_node_url(&mut self, _node_url: &str) {}
 	fn set_node_api_secret(&mut self, _node_api_secret: Option<String>) {}
-	fn get_version_info(&self) -> Result<NodeVersionInfo, libwallet::Error>{
+	fn get_version_info(&self) -> Result<NodeVersionInfo, libwallet::Error> {
 		unimplemented!()
 	}
 	/// Posts a transaction to a grin node

--- a/libwallet/src/error.rs
+++ b/libwallet/src/error.rs
@@ -193,6 +193,10 @@ pub enum ErrorKind {
 	#[fail(display = "Unknown Slate Version: {}", _0)]
 	SlateVersion(u16),
 
+	/// Compatibility error between incoming slate versions and what's expected
+	#[fail(display = "Compatibility Error: {}", _0)]
+	Compatibility(String),
+
 	/// Other
 	#[fail(display = "Generic error: {}", _0)]
 	GenericError(String),

--- a/libwallet/src/internal/tx.rs
+++ b/libwallet/src/internal/tx.rs
@@ -16,10 +16,10 @@
 
 use uuid::Uuid;
 
+use crate::grin_core::consensus::valid_header_version;
+use crate::grin_core::core::HeaderVersion;
 use crate::grin_keychain::{Identifier, Keychain};
 use crate::grin_util::Mutex;
-use crate::grin_core::consensus::{valid_header_version};
-use crate::grin_core::core::{HeaderVersion};
 use crate::internal::{selection, updater};
 use crate::slate::Slate;
 use crate::types::{Context, NodeClient, TxLogEntryType, WalletBackend};

--- a/libwallet/src/internal/tx.rs
+++ b/libwallet/src/internal/tx.rs
@@ -18,6 +18,8 @@ use uuid::Uuid;
 
 use crate::grin_keychain::{Identifier, Keychain};
 use crate::grin_util::Mutex;
+use crate::grin_core::consensus::{valid_header_version};
+use crate::grin_core::core::{HeaderVersion};
 use crate::internal::{selection, updater};
 use crate::slate::Slate;
 use crate::types::{Context, NodeClient, TxLogEntryType, WalletBackend};
@@ -53,6 +55,10 @@ where
 	}
 	slate.amount = amount;
 	slate.height = current_height;
+
+	if valid_header_version(current_height, HeaderVersion(1)) {
+		slate.version_info.block_header_version = 1;
+	}
 
 	// Set the lock_height explicitly to 0 here.
 	// This will generate a Plain kernel (rather than a HeightLocked kernel).

--- a/libwallet/src/lib.rs
+++ b/libwallet/src/lib.rs
@@ -52,7 +52,9 @@ mod types;
 
 pub use crate::error::{Error, ErrorKind};
 pub use crate::slate::{ParticipantData, ParticipantMessageData, Slate};
-pub use crate::slate_versions::{CURRENT_SLATE_VERSION, GRIN_BLOCK_HEADER_VERSION, SlateVersion, VersionedSlate};
+pub use crate::slate_versions::{
+	SlateVersion, VersionedSlate, CURRENT_SLATE_VERSION, GRIN_BLOCK_HEADER_VERSION,
+};
 pub use api_impl::types::{
 	BlockFees, CbData, InitTxArgs, InitTxSendArgs, IssueInvoiceTxArgs, NodeHeightResult,
 	OutputCommitMapping, SendTXArgs, VersionInfo,

--- a/libwallet/src/lib.rs
+++ b/libwallet/src/lib.rs
@@ -52,7 +52,7 @@ mod types;
 
 pub use crate::error::{Error, ErrorKind};
 pub use crate::slate::{ParticipantData, ParticipantMessageData, Slate};
-pub use crate::slate_versions::{SlateVersion, VersionedSlate};
+pub use crate::slate_versions::{CURRENT_SLATE_VERSION, GRIN_BLOCK_HEADER_VERSION, SlateVersion, VersionedSlate};
 pub use api_impl::types::{
 	BlockFees, CbData, InitTxArgs, InitTxSendArgs, IssueInvoiceTxArgs, NodeHeightResult,
 	OutputCommitMapping, SendTXArgs, VersionInfo,

--- a/libwallet/src/lib.rs
+++ b/libwallet/src/lib.rs
@@ -59,6 +59,7 @@ pub use api_impl::types::{
 };
 pub use internal::restore::{check_repair, restore};
 pub use types::{
-	AcctPathMapping, BlockIdentifier, Context, NodeClient, NodeVersionInfo, OutputData, OutputStatus, TxLogEntry,
-	TxLogEntryType, TxWrapper, WalletBackend, WalletInfo, WalletInst, WalletOutputBatch,
+	AcctPathMapping, BlockIdentifier, Context, NodeClient, NodeVersionInfo, OutputData,
+	OutputStatus, TxLogEntry, TxLogEntryType, TxWrapper, WalletBackend, WalletInfo, WalletInst,
+	WalletOutputBatch,
 };

--- a/libwallet/src/lib.rs
+++ b/libwallet/src/lib.rs
@@ -59,6 +59,6 @@ pub use api_impl::types::{
 };
 pub use internal::restore::{check_repair, restore};
 pub use types::{
-	AcctPathMapping, BlockIdentifier, Context, NodeClient, OutputData, OutputStatus, TxLogEntry,
+	AcctPathMapping, BlockIdentifier, Context, NodeClient, NodeVersionInfo, OutputData, OutputStatus, TxLogEntry,
 	TxLogEntryType, TxWrapper, WalletBackend, WalletInfo, WalletInst, WalletOutputBatch,
 };

--- a/libwallet/src/types.rs
+++ b/libwallet/src/types.rs
@@ -221,6 +221,10 @@ pub trait NodeClient: Sync + Send + Clone {
 	/// Posts a transaction to a grin node
 	fn post_tx(&self, tx: &TxWrapper, fluff: bool) -> Result<(), Error>;
 
+	/// Returns the api version string and block header version as reported
+	/// by the node
+	fn get_version_info(&self) -> Result<NodeVersionInfo, Error>;
+
 	/// retrieves the current tip from the specified grin node
 	fn get_chain_height(&self) -> Result<u64, Error>;
 
@@ -248,6 +252,15 @@ pub trait NodeClient: Sync + Send + Clone {
 		),
 		Error,
 	>;
+}
+
+/// Node version info
+#[derive(Serialize, Deserialize, Debug, Clone, PartialEq, PartialOrd, Eq, Ord)]
+pub struct NodeVersionInfo {
+	/// Semver version string
+	pub node_version: String,
+	/// block header verson
+	pub block_header_version: u16,
 }
 
 /// Information about an output that's being tracked by the wallet. Must be

--- a/libwallet/src/types.rs
+++ b/libwallet/src/types.rs
@@ -222,8 +222,8 @@ pub trait NodeClient: Sync + Send + Clone {
 	fn post_tx(&self, tx: &TxWrapper, fluff: bool) -> Result<(), Error>;
 
 	/// Returns the api version string and block header version as reported
-	/// by the node
-	fn get_version_info(&self) -> Result<NodeVersionInfo, Error>;
+	/// by the node. Result can be cached for later use
+	fn get_version_info(&mut self) -> Option<NodeVersionInfo>;
 
 	/// retrieves the current tip from the specified grin node
 	fn get_chain_height(&self) -> Result<u64, Error>;
@@ -255,12 +255,14 @@ pub trait NodeClient: Sync + Send + Clone {
 }
 
 /// Node version info
-#[derive(Serialize, Deserialize, Debug, Clone, PartialEq, PartialOrd, Eq, Ord)]
+#[derive(Serialize, Deserialize, Debug, Clone)]
 pub struct NodeVersionInfo {
 	/// Semver version string
 	pub node_version: String,
 	/// block header verson
 	pub block_header_version: u16,
+	/// Whether this version info was successfully verified from a node
+	pub verified: Option<bool>,
 }
 
 /// Information about an output that's being tracked by the wallet. Must be

--- a/src/bin/cmd/wallet.rs
+++ b/src/bin/cmd/wallet.rs
@@ -18,12 +18,12 @@ use clap::ArgMatches;
 use grin_wallet_config::WalletConfig;
 use grin_wallet_impls::{HTTPNodeClient, WalletSeed, SEED_FILE};
 use grin_wallet_libwallet::NodeClient;
+use semver::Version;
 use std::path::PathBuf;
 use std::thread;
 use std::time::Duration;
-use semver::Version;
 
-const MIN_COMPAT_NODE_VERSION:&str = "2.0.0-beta.1";
+const MIN_COMPAT_NODE_VERSION: &str = "2.0.0-beta.1";
 // TODO: Change to 2 for HF
 const MIN_COMPAT_BLOCK_HEADER_VERSION: u16 = 1;
 
@@ -59,19 +59,22 @@ pub fn wallet_command(wallet_args: &ArgMatches<'_>, config: GlobalWalletConfig) 
 		Ok(v) => {
 			// Isn't going to happen just yet (as of 2.0.0) but keep this here for
 			// the future
-			if Version::parse(&v.node_version) < Version::parse(MIN_COMPAT_NODE_VERSION){
+			if Version::parse(&v.node_version) < Version::parse(MIN_COMPAT_NODE_VERSION) {
 				println!("Specified Grin Node (version {}) is outdated and incompatible with this wallet version", v.node_version);
 				println!("Please update the node or use a different one");
 				return 1;
 			}
 			if v.block_header_version < MIN_COMPAT_BLOCK_HEADER_VERSION {
-				println!("Node reported Block Header Version ({}) incompatible with this wallet", v.block_header_version);
+				println!(
+					"Node reported Block Header Version ({}) incompatible with this wallet",
+					v.block_header_version
+				);
 				println!("Please update the node or use a different one");
 				return 1;
 			}
-		},
+		}
 		Err(e) => {
-			// If node isn't available, allow offline functions 
+			// If node isn't available, allow offline functions
 			// unfortunately have to parse string due to error structure
 			let err_string = format!("{}", e);
 			if err_string.contains("404") {


### PR DESCRIPTION
Follow up from https://github.com/mimblewimble/grin/pull/2897 on the wallet side

* Change `v1/pool/push` endpoint call to `v1/pool/push_tx`
* Add function to read version info from node to NodeClient trait, add implementation to HttpNodeClient
* On startup, attempt to read version info from node and:
    * If can't communicate with node, continue read only
    * If node reports 404 for `v1/version` endpoint, assume node is < 2.0.0 and exit
    * If node reports version < what wallet is looking for as a minimum (currently 2.0.0-beta.1), exit with message to upgrade
    * ~~If node reports blockheader version < what wallet is looking for (currently set to 1 for testing, but should be bumped to 2 before releasing), exit with prompt to upgrade~~
