### PR TITLE
Provide more specific error when other wallet is outdated

### DIFF
--- a/impls/src/adapters/http.rs
+++ b/impls/src/adapters/http.rs
@@ -44,8 +44,10 @@ impl HTTPWalletCommAdapter {
 			let err_string = format!("{}", e);
 			if err_string.contains("404") {
 				// Report that the other version of the wallet is out of date
-				report = format!("Other wallet is incompatible and requires an upgrade. \
-				Please urge the other wallet owner to upgrade and try the transaction again.");
+				report = format!(
+					"Other wallet is incompatible and requires an upgrade. \
+					 Please urge the other wallet owner to upgrade and try the transaction again."
+				);
 			}
 			error!("{}", report);
 			ErrorKind::ClientCallback(report)

--- a/impls/src/adapters/http.rs
+++ b/impls/src/adapters/http.rs
@@ -40,7 +40,13 @@ impl HTTPWalletCommAdapter {
 		});
 
 		let res: String = post(url, None, &req).map_err(|e| {
-			let report = format!("Performing version check (is recipient listening?): {}", e);
+			let mut report = format!("Performing version check (is recipient listening?): {}", e);
+			let err_string = format!("{}", e);
+			if err_string.contains("404") {
+				// Report that the other version of the wallet is out of date
+				report = format!("Other wallet is incompatible and requires an upgrade. \
+				Please urge the other wallet owner to upgrade and try the transaction again.");
+			}
 			error!("{}", report);
 			ErrorKind::ClientCallback(report)
 		})?;


### PR DESCRIPTION
If older wallet is 1.0.x series (i.e. doesn't have the v2 API version function in place,) provide a more specific message.