### PR TITLE
Derive --version output dynamically from cargo package version

### DIFF
--- a/src/bin/grin-wallet.rs
+++ b/src/bin/grin-wallet.rs
@@ -67,7 +67,9 @@ fn main() {
 
 fn real_main() -> i32 {
 	let yml = load_yaml!("grin-wallet.yml");
-	let args = App::from_yaml(yml).get_matches();
+	let args = App::from_yaml(yml)
+		.version(built_info::PKG_VERSION)
+		.get_matches();
 
 	let chain_type = if args.is_present("floonet") {
 		global::ChainTypes::Floonet

--- a/src/bin/grin-wallet.yml
+++ b/src/bin/grin-wallet.yml
@@ -1,5 +1,4 @@
 name: grin-wallet
-version: "2.0.0-beta.2"
 about: Reference Grin Wallet
 author: The Grin Team
 


### PR DESCRIPTION
The version reported by `grin-wallet --version` is currently set manually in `grin-wallet.yml`, which means it can easily be missed on release. Small fix to ensure this output comes from the cargo package version instead.