### PR TITLE
Fix typos in subcommand descriptions

### DIFF
--- a/src/bin/grin-wallet.yml
+++ b/src/bin/grin-wallet.yml
@@ -162,7 +162,7 @@ subcommands:
             short: f
             long: fluff
   - invoice:
-      about: Initialize an invoice transction.
+      about: Initialize an invoice transaction.
       args:
         - amount:
             help: Number of coins to invoice  with optional fraction, e.g. 12.423
@@ -262,7 +262,7 @@ subcommands:
             short: f
             long: fluff
   - cancel:
-      about: Cancels an previously created transaction, freeing previously locked outputs for use again
+      about: Cancels a previously created transaction, freeing previously locked outputs for use again
       args:
         - id:
             help: The ID of the transaction to cancel


### PR DESCRIPTION
I did not test this locally. I did grep the project for the typos and it's the only place I've found them. You're free to close this if it's not acceptable without testing it