### PR TITLE
fix for base url when checking other version via foreign api

### DIFF
--- a/impls/src/adapters/http.rs
+++ b/impls/src/adapters/http.rs
@@ -36,7 +36,7 @@ impl HttpSlateSender {
 	}
 
 	/// Check version of the listening wallet
-	fn check_other_version(&self) -> Result<(), Error> {
+	fn check_other_version(&self, url: &Url) -> Result<(), Error> {
 		let req = json!({
 			"jsonrpc": "2.0",
 			"method": "check_version",
@@ -44,7 +44,7 @@ impl HttpSlateSender {
 			"params": []
 		});
 
-		let res: String = post(&self.base_url, None, &req).map_err(|e| {
+		let res: String = post(url, None, &req).map_err(|e| {
 			let mut report = format!("Performing version check (is recipient listening?): {}", e);
 			let err_string = format!("{}", e);
 			if err_string.contains("404") {
@@ -101,7 +101,7 @@ impl SlateSender for HttpSlateSender {
 			.expect("/v2/foreign is an invalid url path");
 		debug!("Posting transaction slate to {}", url);
 
-		self.check_other_version()?;
+		self.check_other_version(&url)?;
 
 		// Note: not using easy-jsonrpc as don't want the dependencies in this crate
 		let req = json!({


### PR DESCRIPTION
This resolves what looks like a bad merge at some point on master branch, most likely during post-HF branch cleanup.

The current `2.0.x` branch has the correct impl of this - 

https://github.com/mimblewimble/grin-wallet/blob/7b6d597d39a9fbc635fe6768c72370f80a2a05f8/impls/src/adapters/http.rs#L105-L108

At some point this was broken or reverted or missed on master and we are not using the correct url when hitting the foreign api to "check current version".

These changes are included in https://github.com/mimblewimble/grin-wallet/pull/206 but I'd like to get them in independently to help with testing for https://github.com/mimblewimble/grin-wallet/pull/129 "Rework kernel features support".