### PR TITLE
Introduce VersionedCoinbase to add api stability around build_coinbase

### DIFF
--- a/libwallet/src/api_impl/types.rs
+++ b/libwallet/src/api_impl/types.rs
@@ -14,7 +14,6 @@
 
 //! Types specific to the wallet api, mostly argument serialization
 
-use crate::grin_core::core::{Output, TxKernel};
 use crate::grin_core::libtx::secp_ser;
 use crate::grin_keychain::Identifier;
 use crate::grin_util::secp::pedersen;
@@ -177,17 +176,6 @@ impl BlockFees {
 	pub fn key_id(&self) -> Option<Identifier> {
 		self.key_id.clone()
 	}
-}
-
-/// Response to build a coinbase output.
-#[derive(Serialize, Deserialize, Debug, Clone)]
-pub struct CbData {
-	/// Output
-	pub output: Output,
-	/// Kernel
-	pub kernel: TxKernel,
-	/// Key Id
-	pub key_id: Option<Identifier>,
 }
 
 /// Map Outputdata to commits

--- a/libwallet/src/lib.rs
+++ b/libwallet/src/lib.rs
@@ -53,15 +53,16 @@ mod types;
 pub use crate::error::{Error, ErrorKind};
 pub use crate::slate::{ParticipantData, ParticipantMessageData, Slate};
 pub use crate::slate_versions::{
-	SlateVersion, VersionedSlate, CURRENT_SLATE_VERSION, GRIN_BLOCK_HEADER_VERSION,
+	SlateVersion, VersionedCoinbase, VersionedSlate, CURRENT_SLATE_VERSION,
+	GRIN_BLOCK_HEADER_VERSION,
 };
 pub use api_impl::types::{
-	BlockFees, CbData, InitTxArgs, InitTxSendArgs, IssueInvoiceTxArgs, NodeHeightResult,
+	BlockFees, InitTxArgs, InitTxSendArgs, IssueInvoiceTxArgs, NodeHeightResult,
 	OutputCommitMapping, SendTXArgs, VersionInfo,
 };
 pub use internal::restore::{check_repair, restore};
 pub use types::{
-	AcctPathMapping, BlockIdentifier, Context, NodeClient, NodeVersionInfo, OutputData,
+	AcctPathMapping, BlockIdentifier, CbData, Context, NodeClient, NodeVersionInfo, OutputData,
 	OutputStatus, TxLogEntry, TxLogEntryType, TxWrapper, WalletBackend, WalletInfo, WalletInst,
 	WalletLCProvider, WalletOutputBatch,
 };

--- a/libwallet/src/slate.rs
+++ b/libwallet/src/slate.rs
@@ -39,10 +39,11 @@ use std::sync::Arc;
 use uuid::Uuid;
 
 use crate::slate_versions::v2::{
-	InputV2, OutputV2, ParticipantDataV2, SlateV2, TransactionBodyV2, TransactionV2, TxKernelV2,
-	VersionCompatInfoV2,
+	CoinbaseV2, InputV2, OutputV2, ParticipantDataV2, SlateV2, TransactionBodyV2, TransactionV2,
+	TxKernelV2, VersionCompatInfoV2,
 };
 use crate::slate_versions::{CURRENT_SLATE_VERSION, GRIN_BLOCK_HEADER_VERSION};
+use crate::types::CbData;
 
 /// Public data for each participant in the slate
 #[derive(Serialize, Deserialize, Debug, Clone)]
@@ -707,6 +708,17 @@ impl SlateVersionProbe {
 				Some(_) => 1,
 				None => 0,
 			},
+		}
+	}
+}
+
+// Coinbase data to versioned.
+impl From<CbData> for CoinbaseV2 {
+	fn from(cb: CbData) -> CoinbaseV2 {
+		CoinbaseV2 {
+			output: OutputV2::from(&cb.output),
+			kernel: TxKernelV2::from(&cb.kernel),
+			key_id: cb.key_id,
 		}
 	}
 }

--- a/libwallet/src/slate_versions/mod.rs
+++ b/libwallet/src/slate_versions/mod.rs
@@ -18,7 +18,8 @@
 //! remains for future needs
 
 use crate::slate::Slate;
-use crate::slate_versions::v2::SlateV2;
+use crate::slate_versions::v2::{CoinbaseV2, SlateV2};
+use crate::types::CbData;
 
 #[allow(missing_docs)]
 pub mod v2;
@@ -82,6 +83,24 @@ impl From<VersionedSlate> for Slate {
 				  let s = SlateV2::from(s);
 				  Slate::from(s)
 			  }*/
+		}
+	}
+}
+
+#[derive(Deserialize, Serialize)]
+#[serde(untagged)]
+/// Versions are ordered newest to oldest so serde attempts to
+/// deserialize newer versions first, then falls back to older versions.
+pub enum VersionedCoinbase {
+	/// Current supported coinbase version.
+	V2(CoinbaseV2),
+}
+
+impl VersionedCoinbase {
+	/// convert this coinbase data to a specific versioned representation for the json api.
+	pub fn into_version(cb: CbData, version: SlateVersion) -> VersionedCoinbase {
+		match version {
+			SlateVersion::V2 => VersionedCoinbase::V2(cb.into()),
 		}
 	}
 }

--- a/libwallet/src/slate_versions/v2.rs
+++ b/libwallet/src/slate_versions/v2.rs
@@ -37,7 +37,7 @@
 
 use crate::grin_core::core::transaction::OutputFeatures;
 use crate::grin_core::libtx::secp_ser;
-use crate::grin_keychain::BlindingFactor;
+use crate::grin_keychain::{BlindingFactor, Identifier};
 use crate::grin_util::secp;
 use crate::grin_util::secp::key::PublicKey;
 use crate::grin_util::secp::pedersen::{Commitment, RangeProof};
@@ -183,4 +183,15 @@ pub struct TxKernelV2 {
 	/// the transaction fee.
 	#[serde(with = "secp_ser::sig_serde")]
 	pub excess_sig: secp::Signature,
+}
+
+/// A mining node requests new coinbase via the foreign api every time a new candidate block is built.
+#[derive(Serialize, Deserialize, Debug, Clone)]
+pub struct CoinbaseV2 {
+	/// Output
+	pub output: OutputV2,
+	/// Kernel
+	pub kernel: TxKernelV2,
+	/// Key Id
+	pub key_id: Option<Identifier>,
 }

--- a/libwallet/src/types.rs
+++ b/libwallet/src/types.rs
@@ -17,7 +17,7 @@
 
 use crate::error::{Error, ErrorKind};
 use crate::grin_core::core::hash::Hash;
-use crate::grin_core::core::Transaction;
+use crate::grin_core::core::{Output, Transaction, TxKernel};
 use crate::grin_core::libtx::{aggsig, secp_ser};
 use crate::grin_core::{global, ser};
 use crate::grin_keychain::{Identifier, Keychain};
@@ -808,4 +808,17 @@ impl ser::Readable for AcctPathMapping {
 pub struct TxWrapper {
 	/// hex representation of transaction
 	pub tx_hex: String,
+}
+
+/// Wrapper for reward output and kernel used when building a coinbase for a mining node.
+/// Note: Not serializable, must be converted to necesssary "versioned" representation
+/// before serializing to json to ensure compatibility with mining node.
+#[derive(Debug, Clone)]
+pub struct CbData {
+	/// Output
+	pub output: Output,
+	/// Kernel
+	pub kernel: TxKernel,
+	/// Key Id
+	pub key_id: Option<Identifier>,
 }


### PR DESCRIPTION
This PR introduces a `VersionedCoinbase`, following the same approach as the existing `VersionedSlate`.

We have a `build_coinbase` api call on the foreign api that is used by a mining node to generate a new coinbase reward (output + kernel) when building a candidate block for mining.

It is important this api continues to work even if we make internal changes to the core output and kernel impls.

The `build_coinbase` api endpoint now returns a `VersionedCoinbase` (currently uses `V2`) and this maintains full backward compatibility with the existing node and wallet.

This api endpoint is a little tricky and easy to miss because it works in the opposite direction to everything else. This is accessed `node->wallet` when generating candidate blocks for mining.

This PR should add some additional robustness to ensure old nodes can mine using a newer wallet and vice-versa.

Related - #129 

TODO - 

- [x] local testing of mining nodes and wallets to confirm we can still mine successfully in various old/new combinations...

