### PR TITLE
API Lifecycle Implementation, Pt. 1

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -581,16 +581,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 [[package]]
 name = "grin_api"
 version = "2.0.1-beta.1"
+source = "git+https://github.com/mimblewimble/grin#ea023387bfa4f1493cc57f120205a09251468e60"
 dependencies = [
  "failure 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)",
  "failure_derive 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)",
  "futures 0.1.28 (registry+https://github.com/rust-lang/crates.io-index)",
- "grin_chain 2.0.1-beta.1",
- "grin_core 2.0.1-beta.1",
- "grin_p2p 2.0.1-beta.1",
- "grin_pool 2.0.1-beta.1",
- "grin_store 2.0.1-beta.1",
- "grin_util 2.0.1-beta.1",
+ "grin_chain 2.0.1-beta.1 (git+https://github.com/mimblewimble/grin)",
+ "grin_core 2.0.1-beta.1 (git+https://github.com/mimblewimble/grin)",
+ "grin_p2p 2.0.1-beta.1 (git+https://github.com/mimblewimble/grin)",
+ "grin_pool 2.0.1-beta.1 (git+https://github.com/mimblewimble/grin)",
+ "grin_store 2.0.1-beta.1 (git+https://github.com/mimblewimble/grin)",
+ "grin_util 2.0.1-beta.1 (git+https://github.com/mimblewimble/grin)",
  "http 0.1.18 (registry+https://github.com/rust-lang/crates.io-index)",
  "hyper 0.12.19 (registry+https://github.com/rust-lang/crates.io-index)",
  "hyper-rustls 0.14.0 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -612,6 +613,7 @@ dependencies = [
 [[package]]
 name = "grin_chain"
 version = "2.0.1-beta.1"
+source = "git+https://github.com/mimblewimble/grin#ea023387bfa4f1493cc57f120205a09251468e60"
 dependencies = [
  "bitflags 1.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "byteorder 1.3.2 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -619,10 +621,10 @@ dependencies = [
  "croaring 0.3.9 (registry+https://github.com/rust-lang/crates.io-index)",
  "failure 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)",
  "failure_derive 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)",
- "grin_core 2.0.1-beta.1",
- "grin_keychain 2.0.1-beta.1",
- "grin_store 2.0.1-beta.1",
- "grin_util 2.0.1-beta.1",
+ "grin_core 2.0.1-beta.1 (git+https://github.com/mimblewimble/grin)",
+ "grin_keychain 2.0.1-beta.1 (git+https://github.com/mimblewimble/grin)",
+ "grin_store 2.0.1-beta.1 (git+https://github.com/mimblewimble/grin)",
+ "grin_util 2.0.1-beta.1 (git+https://github.com/mimblewimble/grin)",
  "lazy_static 1.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "log 0.4.8 (registry+https://github.com/rust-lang/crates.io-index)",
  "lru-cache 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -634,6 +636,7 @@ dependencies = [
 [[package]]
 name = "grin_core"
 version = "2.0.1-beta.1"
+source = "git+https://github.com/mimblewimble/grin#ea023387bfa4f1493cc57f120205a09251468e60"
 dependencies = [
  "blake2-rfc 0.2.18 (registry+https://github.com/rust-lang/crates.io-index)",
  "byteorder 1.3.2 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -642,8 +645,8 @@ dependencies = [
  "enum_primitive 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "failure 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)",
  "failure_derive 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)",
- "grin_keychain 2.0.1-beta.1",
- "grin_util 2.0.1-beta.1",
+ "grin_keychain 2.0.1-beta.1 (git+https://github.com/mimblewimble/grin)",
+ "grin_util 2.0.1-beta.1 (git+https://github.com/mimblewimble/grin)",
  "lazy_static 1.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "log 0.4.8 (registry+https://github.com/rust-lang/crates.io-index)",
  "lru-cache 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -660,11 +663,12 @@ dependencies = [
 [[package]]
 name = "grin_keychain"
 version = "2.0.1-beta.1"
+source = "git+https://github.com/mimblewimble/grin#ea023387bfa4f1493cc57f120205a09251468e60"
 dependencies = [
  "blake2-rfc 0.2.18 (registry+https://github.com/rust-lang/crates.io-index)",
  "byteorder 1.3.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "digest 0.7.6 (registry+https://github.com/rust-lang/crates.io-index)",
- "grin_util 2.0.1-beta.1",
+ "grin_util 2.0.1-beta.1 (git+https://github.com/mimblewimble/grin)",
  "hmac 0.6.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "lazy_static 1.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "log 0.4.8 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -682,15 +686,16 @@ dependencies = [
 [[package]]
 name = "grin_p2p"
 version = "2.0.1-beta.1"
+source = "git+https://github.com/mimblewimble/grin#ea023387bfa4f1493cc57f120205a09251468e60"
 dependencies = [
  "bitflags 1.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "bytes 0.4.12 (registry+https://github.com/rust-lang/crates.io-index)",
  "chrono 0.4.7 (registry+https://github.com/rust-lang/crates.io-index)",
  "enum_primitive 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "grin_chain 2.0.1-beta.1",
- "grin_core 2.0.1-beta.1",
- "grin_store 2.0.1-beta.1",
- "grin_util 2.0.1-beta.1",
+ "grin_chain 2.0.1-beta.1 (git+https://github.com/mimblewimble/grin)",
+ "grin_core 2.0.1-beta.1 (git+https://github.com/mimblewimble/grin)",
+ "grin_store 2.0.1-beta.1 (git+https://github.com/mimblewimble/grin)",
+ "grin_util 2.0.1-beta.1 (git+https://github.com/mimblewimble/grin)",
  "log 0.4.8 (registry+https://github.com/rust-lang/crates.io-index)",
  "net2 0.2.33 (registry+https://github.com/rust-lang/crates.io-index)",
  "num 0.1.42 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -703,15 +708,16 @@ dependencies = [
 [[package]]
 name = "grin_pool"
 version = "2.0.1-beta.1"
+source = "git+https://github.com/mimblewimble/grin#ea023387bfa4f1493cc57f120205a09251468e60"
 dependencies = [
  "blake2-rfc 0.2.18 (registry+https://github.com/rust-lang/crates.io-index)",
  "chrono 0.4.7 (registry+https://github.com/rust-lang/crates.io-index)",
  "failure 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)",
  "failure_derive 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)",
- "grin_core 2.0.1-beta.1",
- "grin_keychain 2.0.1-beta.1",
- "grin_store 2.0.1-beta.1",
- "grin_util 2.0.1-beta.1",
+ "grin_core 2.0.1-beta.1 (git+https://github.com/mimblewimble/grin)",
+ "grin_keychain 2.0.1-beta.1 (git+https://github.com/mimblewimble/grin)",
+ "grin_store 2.0.1-beta.1 (git+https://github.com/mimblewimble/grin)",
+ "grin_util 2.0.1-beta.1 (git+https://github.com/mimblewimble/grin)",
  "log 0.4.8 (registry+https://github.com/rust-lang/crates.io-index)",
  "rand 0.6.5 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde 1.0.98 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -736,14 +742,15 @@ dependencies = [
 [[package]]
 name = "grin_store"
 version = "2.0.1-beta.1"
+source = "git+https://github.com/mimblewimble/grin#ea023387bfa4f1493cc57f120205a09251468e60"
 dependencies = [
  "byteorder 1.3.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "croaring 0.3.9 (registry+https://github.com/rust-lang/crates.io-index)",
  "env_logger 0.5.13 (registry+https://github.com/rust-lang/crates.io-index)",
  "failure 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)",
  "failure_derive 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)",
- "grin_core 2.0.1-beta.1",
- "grin_util 2.0.1-beta.1",
+ "grin_core 2.0.1-beta.1 (git+https://github.com/mimblewimble/grin)",
+ "grin_util 2.0.1-beta.1 (git+https://github.com/mimblewimble/grin)",
  "libc 0.2.60 (registry+https://github.com/rust-lang/crates.io-index)",
  "lmdb-zero 0.4.4 (registry+https://github.com/rust-lang/crates.io-index)",
  "log 0.4.8 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -756,6 +763,7 @@ dependencies = [
 [[package]]
 name = "grin_util"
 version = "2.0.1-beta.1"
+source = "git+https://github.com/mimblewimble/grin#ea023387bfa4f1493cc57f120205a09251468e60"
 dependencies = [
  "backtrace 0.3.34 (registry+https://github.com/rust-lang/crates.io-index)",
  "base64 0.9.3 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -918,12 +926,12 @@ name = "grin_wallet_util"
 version = "2.1.0-beta.1"
 dependencies = [
  "dirs 1.0.5 (registry+https://github.com/rust-lang/crates.io-index)",
- "grin_api 2.0.1-beta.1",
- "grin_chain 2.0.1-beta.1",
- "grin_core 2.0.1-beta.1",
- "grin_keychain 2.0.1-beta.1",
- "grin_store 2.0.1-beta.1",
- "grin_util 2.0.1-beta.1",
+ "grin_api 2.0.1-beta.1 (git+https://github.com/mimblewimble/grin)",
+ "grin_chain 2.0.1-beta.1 (git+https://github.com/mimblewimble/grin)",
+ "grin_core 2.0.1-beta.1 (git+https://github.com/mimblewimble/grin)",
+ "grin_keychain 2.0.1-beta.1 (git+https://github.com/mimblewimble/grin)",
+ "grin_store 2.0.1-beta.1 (git+https://github.com/mimblewimble/grin)",
+ "grin_util 2.0.1-beta.1 (git+https://github.com/mimblewimble/grin)",
  "pretty_assertions 0.5.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "rand 0.5.6 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde 1.0.98 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -2878,7 +2886,15 @@ dependencies = [
 "checksum getrandom 0.1.7 (registry+https://github.com/rust-lang/crates.io-index)" = "cd8e190892c840661957ba9f32dacfb3eb405e657f9f9f60485605f0bb37d6f8"
 "checksum git2 0.9.2 (registry+https://github.com/rust-lang/crates.io-index)" = "8cb400360e8a4d61b10e648285bbfa919bbf9519d0d5d5720354456f44349226"
 "checksum glob 0.2.11 (registry+https://github.com/rust-lang/crates.io-index)" = "8be18de09a56b60ed0edf84bc9df007e30040691af7acd1c41874faac5895bfb"
+"checksum grin_api 2.0.1-beta.1 (git+https://github.com/mimblewimble/grin)" = "<none>"
+"checksum grin_chain 2.0.1-beta.1 (git+https://github.com/mimblewimble/grin)" = "<none>"
+"checksum grin_core 2.0.1-beta.1 (git+https://github.com/mimblewimble/grin)" = "<none>"
+"checksum grin_keychain 2.0.1-beta.1 (git+https://github.com/mimblewimble/grin)" = "<none>"
+"checksum grin_p2p 2.0.1-beta.1 (git+https://github.com/mimblewimble/grin)" = "<none>"
+"checksum grin_pool 2.0.1-beta.1 (git+https://github.com/mimblewimble/grin)" = "<none>"
 "checksum grin_secp256k1zkp 0.7.7 (registry+https://github.com/rust-lang/crates.io-index)" = "23027a7673df2c2b20fb9589d742ff400a10a9c3e4c769a77e9fa3bd19586822"
+"checksum grin_store 2.0.1-beta.1 (git+https://github.com/mimblewimble/grin)" = "<none>"
+"checksum grin_util 2.0.1-beta.1 (git+https://github.com/mimblewimble/grin)" = "<none>"
 "checksum h2 0.1.26 (registry+https://github.com/rust-lang/crates.io-index)" = "a5b34c246847f938a410a03c5458c7fee2274436675e76d8b903c08efc29c462"
 "checksum heck 0.3.1 (registry+https://github.com/rust-lang/crates.io-index)" = "20564e78d53d2bb135c343b3f47714a56af2061f1c928fdb541dc7b9fdd94205"
 "checksum hmac 0.6.3 (registry+https://github.com/rust-lang/crates.io-index)" = "733e1b3ac906631ca01ebb577e9bb0f5e37a454032b9036b5eaea4013ed6f99a"

--- a/api/src/foreign.rs
+++ b/api/src/foreign.rs
@@ -144,7 +144,7 @@ where
 	///
 	/// // The top level wallet directory should be set manually (in the reference implementation,
 	/// // this is provided in the WalletConfig)
-	/// lc.set_wallet_directory(&wallet_config.data_file_dir);
+	/// let _ = lc.set_top_level_directory(&wallet_config.data_file_dir);
 	///
 	/// // Wallet must be opened with the password (TBD)
 	/// let pw = ZeroingString::from("wallet_password");
@@ -506,7 +506,7 @@ macro_rules! doctest_helper_setup_doc_env_foreign {
 				>,
 				>;
 		let lc = wallet.lc_provider().unwrap();
-		lc.set_wallet_directory(&wallet_config.data_file_dir);
+		let _ = lc.set_top_level_directory(&wallet_config.data_file_dir);
 		lc.open_wallet(None, pw, false, false);
 		let mut $wallet = Arc::new(Mutex::new(wallet));
 	};

--- a/api/src/foreign_rpc.rs
+++ b/api/src/foreign_rpc.rs
@@ -625,7 +625,7 @@ pub fn run_doctest_foreign(
 			>;
 	let lc = wallet1.lc_provider().unwrap();
 	let _ = lc.set_top_level_directory(&format!("{}/wallet1", test_dir));
-	lc.create_wallet(None, Some(rec_phrase_1), 32, empty_string.clone())
+	lc.create_wallet(None, Some(rec_phrase_1), 32, empty_string.clone(), false)
 		.unwrap();
 	let mask1 = lc
 		.open_wallet(None, empty_string.clone(), use_token, true)
@@ -660,7 +660,7 @@ pub fn run_doctest_foreign(
 			>;
 	let lc = wallet2.lc_provider().unwrap();
 	let _ = lc.set_top_level_directory(&format!("{}/wallet2", test_dir));
-	lc.create_wallet(None, Some(rec_phrase_2), 32, empty_string.clone())
+	lc.create_wallet(None, Some(rec_phrase_2), 32, empty_string.clone(), false)
 		.unwrap();
 	let mask2 = lc
 		.open_wallet(None, empty_string.clone(), use_token, true)

--- a/api/src/foreign_rpc.rs
+++ b/api/src/foreign_rpc.rs
@@ -624,7 +624,7 @@ pub fn run_doctest_foreign(
 				>,
 			>;
 	let lc = wallet1.lc_provider().unwrap();
-	lc.set_wallet_directory(&format!("{}/wallet1", test_dir));
+	let _ = lc.set_top_level_directory(&format!("{}/wallet1", test_dir));
 	lc.create_wallet(None, Some(rec_phrase_1), 32, empty_string.clone())
 		.unwrap();
 	let mask1 = lc
@@ -659,7 +659,7 @@ pub fn run_doctest_foreign(
 				>,
 			>;
 	let lc = wallet2.lc_provider().unwrap();
-	lc.set_wallet_directory(&format!("{}/wallet2", test_dir));
+	let _ = lc.set_top_level_directory(&format!("{}/wallet2", test_dir));
 	lc.create_wallet(None, Some(rec_phrase_2), 32, empty_string.clone())
 		.unwrap();
 	let mask2 = lc

--- a/api/src/lib.rs
+++ b/api/src/lib.rs
@@ -25,6 +25,7 @@
 use grin_wallet_util::grin_core as core;
 use grin_wallet_util::grin_keychain as keychain;
 use grin_wallet_util::grin_util as util;
+use grin_wallet_config as config;
 extern crate grin_wallet_impls as impls;
 extern crate grin_wallet_libwallet as libwallet;
 

--- a/api/src/lib.rs
+++ b/api/src/lib.rs
@@ -22,10 +22,10 @@
 #![deny(unused_mut)]
 #![warn(missing_docs)]
 
+use grin_wallet_config as config;
 use grin_wallet_util::grin_core as core;
 use grin_wallet_util::grin_keychain as keychain;
 use grin_wallet_util::grin_util as util;
-use grin_wallet_config as config;
 extern crate grin_wallet_impls as impls;
 extern crate grin_wallet_libwallet as libwallet;
 

--- a/api/src/owner.rs
+++ b/api/src/owner.rs
@@ -17,6 +17,7 @@
 use chrono::prelude::*;
 use uuid::Uuid;
 
+use crate::config::WalletConfig;
 use crate::core::core::Transaction;
 use crate::core::global;
 use crate::impls::create_sender;
@@ -27,7 +28,6 @@ use crate::libwallet::{
 	NodeHeightResult, OutputCommitMapping, Slate, TxLogEntry, WalletInfo, WalletInst,
 	WalletLCProvider,
 };
-use crate::config::WalletConfig;
 use crate::util::secp::key::SecretKey;
 use crate::util::{LoggingConfig, Mutex, ZeroingString};
 use std::sync::Arc;
@@ -1261,10 +1261,20 @@ where
 	/// Create a 'grin-wallet.toml' file in the top level directory
 	/// TODO: DOCS TBD
 
-	pub fn create_config(&self, chain_type: &global::ChainTypes, wallet_config: Option<WalletConfig>, logging_config: Option<LoggingConfig>) -> Result<(), Error> {
+	pub fn create_config(
+		&self,
+		chain_type: &global::ChainTypes,
+		wallet_config: Option<WalletConfig>,
+		logging_config: Option<LoggingConfig>,
+	) -> Result<(), Error> {
 		let mut w_lock = self.wallet_inst.lock();
 		let lc = w_lock.lc_provider()?;
-		lc.create_config(chain_type, "grin-wallet.toml", wallet_config, logging_config)
+		lc.create_config(
+			chain_type,
+			"grin-wallet.toml",
+			wallet_config,
+			logging_config,
+		)
 	}
 
 	/// Create a new wallet

--- a/api/src/owner.rs
+++ b/api/src/owner.rs
@@ -1390,7 +1390,7 @@ where
 	/// Paths in the configuration file will be updated to reflect the top level directory, so
 	/// path-related values in the optional configuration structs will be ignored.
 	///
-	/// The wallet files must not already exist, and ~The `grin-wallet.toml` file must exist 
+	/// The wallet files must not already exist, and ~The `grin-wallet.toml` file must exist
 	/// in the top level directory (can be created via a call to
 	/// [`create_config`](struct.Owner.html#method.create_config))
 	///
@@ -1575,9 +1575,9 @@ macro_rules! doctest_helper_setup_doc_env {
 		use grin_wallet_config as config;
 		use grin_wallet_impls as impls;
 		use grin_wallet_libwallet as libwallet;
+		use grin_wallet_util::grin_core;
 		use grin_wallet_util::grin_keychain as keychain;
 		use grin_wallet_util::grin_util as util;
-		use grin_wallet_util::grin_core as grin_core;
 
 		use keychain::ExtKeychain;
 		use tempfile::tempdir;

--- a/api/src/owner.rs
+++ b/api/src/owner.rs
@@ -1265,15 +1265,25 @@ where
 	/// Create a new wallet
 	/// TODO: DOCS TBD
 
-	pub fn create_wallet(&self, name: Option<&str>, mnemonic: Option<ZeroingString>,
-		mnemonic_length: u32, password: ZeroingString) -> Result<(), Error> {
+	pub fn create_wallet(
+		&self,
+		name: Option<&str>,
+		mnemonic: Option<ZeroingString>,
+		mnemonic_length: u32,
+		password: ZeroingString,
+	) -> Result<(), Error> {
 		let mut w_lock = self.wallet_inst.lock();
 		let lc = w_lock.lc_provider()?;
 		lc.create_wallet(name, mnemonic, mnemonic_length as usize, password)
 	}
 
 	/// Open a wallet, returning the token
-	pub fn open_wallet(&self, name: Option<&str>, password: ZeroingString, use_mask: bool) -> Result<Option<SecretKey>, Error> {
+	pub fn open_wallet(
+		&self,
+		name: Option<&str>,
+		password: ZeroingString,
+		use_mask: bool,
+	) -> Result<Option<SecretKey>, Error> {
 		let mut w_lock = self.wallet_inst.lock();
 		let lc = w_lock.lc_provider()?;
 		lc.open_wallet(name, password, use_mask, self.doctest_mode)

--- a/api/src/owner.rs
+++ b/api/src/owner.rs
@@ -18,6 +18,7 @@ use chrono::prelude::*;
 use uuid::Uuid;
 
 use crate::core::core::Transaction;
+use crate::core::global;
 use crate::impls::create_sender;
 use crate::keychain::{Identifier, Keychain};
 use crate::libwallet::api_impl::owner;
@@ -1231,6 +1232,36 @@ where
 		let _ = w.keychain(keychain_mask)?;
 		owner::node_height(&mut **w, keychain_mask)
 	}
+	
+	// LIFECYCLE FUNCTIONS
+
+	/// Retrieve the current wallet top-level directory
+	/// TODO: DOCS TBD
+	
+	pub fn get_top_level_directory(&self) -> Result<String, Error> {
+		let mut w_lock = self.wallet_inst.lock();
+		let lc = w_lock.lc_provider()?;
+		lc.get_top_level_directory()
+	}
+
+	/// Set the current wallet top-level directory
+	/// TODO: DOCS TBD
+	
+	pub fn set_top_level_directory(&self, dir: &str) -> Result<(), Error> {
+		let mut w_lock = self.wallet_inst.lock();
+		let lc = w_lock.lc_provider()?;
+		lc.set_top_level_directory(dir)
+	}
+
+	/// Create a 'grin-wallet.toml' file in the top level directory
+	/// TODO: DOCS TBD
+
+	pub fn create_config(&self, chain_type: &global::ChainTypes) -> Result<(), Error> {
+		let mut w_lock = self.wallet_inst.lock();
+		let lc = w_lock.lc_provider()?;
+		lc.create_config(chain_type, "grin-wallet.toml")
+	}
+
 }
 
 #[doc(hidden)]

--- a/api/src/owner.rs
+++ b/api/src/owner.rs
@@ -28,7 +28,7 @@ use crate::libwallet::{
 	WalletLCProvider,
 };
 use crate::util::secp::key::SecretKey;
-use crate::util::Mutex;
+use crate::util::{Mutex, ZeroingString};
 use std::sync::Arc;
 
 /// Main interface into all wallet API functions.
@@ -1260,6 +1260,23 @@ where
 		let mut w_lock = self.wallet_inst.lock();
 		let lc = w_lock.lc_provider()?;
 		lc.create_config(chain_type, "grin-wallet.toml")
+	}
+
+	/// Create a new wallet
+	/// TODO: DOCS TBD
+
+	pub fn create_wallet(&self, name: Option<&str>, mnemonic: Option<ZeroingString>,
+		mnemonic_length: u32, password: ZeroingString) -> Result<(), Error> {
+		let mut w_lock = self.wallet_inst.lock();
+		let lc = w_lock.lc_provider()?;
+		lc.create_wallet(name, mnemonic, mnemonic_length as usize, password)
+	}
+
+	/// Open a wallet, returning the token
+	pub fn open_wallet(&self, name: Option<&str>, password: ZeroingString, use_mask: bool) -> Result<Option<SecretKey>, Error> {
+		let mut w_lock = self.wallet_inst.lock();
+		let lc = w_lock.lc_provider()?;
+		lc.open_wallet(name, password, use_mask, self.doctest_mode)
 	}
 }
 

--- a/api/src/owner.rs
+++ b/api/src/owner.rs
@@ -1299,6 +1299,7 @@ where
 	}
 
 	/// Open a wallet, returning the token
+	/// TODO: DOCS TBD
 	pub fn open_wallet(
 		&self,
 		name: Option<&str>,
@@ -1320,6 +1321,17 @@ where
 		let mut w_lock = self.wallet_inst.lock();
 		let lc = w_lock.lc_provider()?;
 		lc.open_wallet(name, password, use_mask, self.doctest_mode)
+	}
+
+	/// Close the wallet, removing seed+token
+	/// TODO: DOCS TBD
+	pub fn close_wallet(
+		&self,
+		name: Option<&str>,
+	) -> Result<(), Error> {
+		let mut w_lock = self.wallet_inst.lock();
+		let lc = w_lock.lc_provider()?;
+		lc.close_wallet(name)
 	}
 }
 

--- a/api/src/owner.rs
+++ b/api/src/owner.rs
@@ -126,7 +126,7 @@ where
 	///
 	/// // The top level wallet directory should be set manually (in the reference implementation,
 	/// // this is provided in the WalletConfig)
-	/// lc.set_wallet_directory(&wallet_config.data_file_dir);
+	/// let _ = lc.set_top_level_directory(&wallet_config.data_file_dir);
 	///
 	/// // Wallet must be opened with the password (TBD)
 	/// let pw = ZeroingString::from("wallet_password");
@@ -1308,7 +1308,7 @@ macro_rules! doctest_helper_setup_doc_env {
 				>,
 				>;
 		let lc = wallet.lc_provider().unwrap();
-		lc.set_wallet_directory(&wallet_config.data_file_dir);
+		let _ = lc.set_top_level_directory(&wallet_config.data_file_dir);
 		lc.open_wallet(None, pw, false, false);
 		let mut $wallet = Arc::new(Mutex::new(wallet));
 	};

--- a/api/src/owner.rs
+++ b/api/src/owner.rs
@@ -29,7 +29,7 @@ use crate::libwallet::{
 	WalletLCProvider,
 };
 use crate::util::secp::key::SecretKey;
-use crate::util::{LoggingConfig, Mutex, ZeroingString};
+use crate::util::{from_hex, static_secp_instance, LoggingConfig, Mutex, ZeroingString};
 use std::sync::Arc;
 
 /// Main interface into all wallet API functions.
@@ -1289,7 +1289,7 @@ where
 	) -> Result<(), Error> {
 		let mut w_lock = self.wallet_inst.lock();
 		let lc = w_lock.lc_provider()?;
-		lc.create_wallet(name, mnemonic, mnemonic_length as usize, password)
+		lc.create_wallet(name, mnemonic, mnemonic_length as usize, password, self.doctest_mode)
 	}
 
 	/// Open a wallet, returning the token
@@ -1299,6 +1299,18 @@ where
 		password: ZeroingString,
 		use_mask: bool,
 	) -> Result<Option<SecretKey>, Error> {
+		// just return a representative string for doctest mode
+		if self.doctest_mode {
+			let secp_inst = static_secp_instance();
+			let secp = secp_inst.lock();
+			return Ok(Some(SecretKey::from_slice(
+				&secp,
+				&from_hex(
+					"d096b3cb75986b3b13f80b8f5243a9edf0af4c74ac37578c5a12cfb5b59b1868".to_owned(),
+				)
+				.unwrap(),
+			)?));
+		}
 		let mut w_lock = self.wallet_inst.lock();
 		let lc = w_lock.lc_provider()?;
 		lc.open_wallet(name, password, use_mask, self.doctest_mode)

--- a/api/src/owner.rs
+++ b/api/src/owner.rs
@@ -1289,7 +1289,13 @@ where
 	) -> Result<(), Error> {
 		let mut w_lock = self.wallet_inst.lock();
 		let lc = w_lock.lc_provider()?;
-		lc.create_wallet(name, mnemonic, mnemonic_length as usize, password, self.doctest_mode)
+		lc.create_wallet(
+			name,
+			mnemonic,
+			mnemonic_length as usize,
+			password,
+			self.doctest_mode,
+		)
 	}
 
 	/// Open a wallet, returning the token

--- a/api/src/owner.rs
+++ b/api/src/owner.rs
@@ -27,8 +27,9 @@ use crate::libwallet::{
 	NodeHeightResult, OutputCommitMapping, Slate, TxLogEntry, WalletInfo, WalletInst,
 	WalletLCProvider,
 };
+use crate::config::WalletConfig;
 use crate::util::secp::key::SecretKey;
-use crate::util::{Mutex, ZeroingString};
+use crate::util::{LoggingConfig, Mutex, ZeroingString};
 use std::sync::Arc;
 
 /// Main interface into all wallet API functions.
@@ -1241,7 +1242,11 @@ where
 	pub fn get_top_level_directory(&self) -> Result<String, Error> {
 		let mut w_lock = self.wallet_inst.lock();
 		let lc = w_lock.lc_provider()?;
-		lc.get_top_level_directory()
+		if self.doctest_mode {
+			Ok("/doctest/dir".to_owned())
+		} else {
+			lc.get_top_level_directory()
+		}
 	}
 
 	/// Set the current wallet top-level directory
@@ -1256,10 +1261,10 @@ where
 	/// Create a 'grin-wallet.toml' file in the top level directory
 	/// TODO: DOCS TBD
 
-	pub fn create_config(&self, chain_type: &global::ChainTypes) -> Result<(), Error> {
+	pub fn create_config(&self, chain_type: &global::ChainTypes, wallet_config: Option<WalletConfig>, logging_config: Option<LoggingConfig>) -> Result<(), Error> {
 		let mut w_lock = self.wallet_inst.lock();
 		let lc = w_lock.lc_provider()?;
-		lc.create_config(chain_type, "grin-wallet.toml")
+		lc.create_config(chain_type, "grin-wallet.toml", wallet_config, logging_config)
 	}
 
 	/// Create a new wallet

--- a/api/src/owner.rs
+++ b/api/src/owner.rs
@@ -1232,12 +1232,12 @@ where
 		let _ = w.keychain(keychain_mask)?;
 		owner::node_height(&mut **w, keychain_mask)
 	}
-	
+
 	// LIFECYCLE FUNCTIONS
 
 	/// Retrieve the current wallet top-level directory
 	/// TODO: DOCS TBD
-	
+
 	pub fn get_top_level_directory(&self) -> Result<String, Error> {
 		let mut w_lock = self.wallet_inst.lock();
 		let lc = w_lock.lc_provider()?;
@@ -1246,7 +1246,7 @@ where
 
 	/// Set the current wallet top-level directory
 	/// TODO: DOCS TBD
-	
+
 	pub fn set_top_level_directory(&self, dir: &str) -> Result<(), Error> {
 		let mut w_lock = self.wallet_inst.lock();
 		let lc = w_lock.lc_provider()?;
@@ -1261,7 +1261,6 @@ where
 		let lc = w_lock.lc_provider()?;
 		lc.create_config(chain_type, "grin-wallet.toml")
 	}
-
 }
 
 #[doc(hidden)]

--- a/api/src/owner.rs
+++ b/api/src/owner.rs
@@ -1325,10 +1325,7 @@ where
 
 	/// Close the wallet, removing seed+token
 	/// TODO: DOCS TBD
-	pub fn close_wallet(
-		&self,
-		name: Option<&str>,
-	) -> Result<(), Error> {
+	pub fn close_wallet(&self, name: Option<&str>) -> Result<(), Error> {
 		let mut w_lock = self.wallet_inst.lock();
 		let lc = w_lock.lc_provider()?;
 		lc.close_wallet(name)

--- a/api/src/owner_rpc.rs
+++ b/api/src/owner_rpc.rs
@@ -1414,7 +1414,7 @@ pub fn run_doctest_owner(
 			>;
 	let lc = wallet1.lc_provider().unwrap();
 	let _ = lc.set_top_level_directory(&format!("{}/wallet1", test_dir));
-	lc.create_wallet(None, Some(rec_phrase_1), 32, empty_string.clone())
+	lc.create_wallet(None, Some(rec_phrase_1), 32, empty_string.clone(), false)
 		.unwrap();
 	let mask1 = lc
 		.open_wallet(None, empty_string.clone(), use_token, true)
@@ -1449,7 +1449,7 @@ pub fn run_doctest_owner(
 			>;
 	let lc = wallet2.lc_provider().unwrap();
 	let _ = lc.set_top_level_directory(&format!("{}/wallet2", test_dir));
-	lc.create_wallet(None, Some(rec_phrase_2), 32, empty_string.clone())
+	lc.create_wallet(None, Some(rec_phrase_2), 32, empty_string.clone(), false)
 		.unwrap();
 	let mask2 = lc
 		.open_wallet(None, empty_string.clone(), use_token, true)

--- a/api/src/owner_rpc.rs
+++ b/api/src/owner_rpc.rs
@@ -1413,7 +1413,7 @@ pub fn run_doctest_owner(
 				>,
 			>;
 	let lc = wallet1.lc_provider().unwrap();
-	lc.set_wallet_directory(&format!("{}/wallet1", test_dir));
+	let _ = lc.set_top_level_directory(&format!("{}/wallet1", test_dir));
 	lc.create_wallet(None, Some(rec_phrase_1), 32, empty_string.clone())
 		.unwrap();
 	let mask1 = lc
@@ -1448,7 +1448,7 @@ pub fn run_doctest_owner(
 				>,
 			>;
 	let lc = wallet2.lc_provider().unwrap();
-	lc.set_wallet_directory(&format!("{}/wallet2", test_dir));
+	let _ = lc.set_top_level_directory(&format!("{}/wallet2", test_dir));
 	lc.create_wallet(None, Some(rec_phrase_2), 32, empty_string.clone())
 		.unwrap();
 	let mask2 = lc

--- a/api/src/owner_rpc_s.rs
+++ b/api/src/owner_rpc_s.rs
@@ -16,6 +16,7 @@
 use uuid::Uuid;
 
 use crate::core::core::Transaction;
+use crate::core::global;
 use crate::keychain::{Identifier, Keychain};
 use crate::libwallet::slate_versions::v2::TransactionV2;
 use crate::libwallet::{
@@ -1311,6 +1312,16 @@ pub trait OwnerRpcS {
 	*/
 
 	fn init_secure_api(&self, ecdh_pubkey: ECDHPubkey) -> Result<ECDHPubkey, ErrorKind>;
+
+	// LIFECYCLE FUNCTIONS
+	/// TODO: DOCS + TESTS TBD
+	fn get_top_level_directory(&self) -> Result<String, ErrorKind>;
+
+	/// TODO: DOCS + TESTS TBD
+	fn set_top_level_directory(&self, dir: String) -> Result<(), ErrorKind>;
+
+	/// TODO: DOCS + TESTS TBD
+	fn create_config(&self, chain_type: global::ChainTypes) -> Result<(), ErrorKind>;
 }
 
 impl<'a, L, C, K> OwnerRpcS for Owner<'a, L, C, K>
@@ -1520,4 +1531,20 @@ where
 			ecdh_pubkey: pub_key,
 		})
 	}
+
+	fn get_top_level_directory(&self) -> Result<String, ErrorKind>{
+		Owner::get_top_level_directory(self)
+			.map_err(|e| e.kind())
+	}
+
+	fn set_top_level_directory(&self, dir: String) -> Result<(), ErrorKind>{
+		Owner::set_top_level_directory(self, &dir)
+			.map_err(|e| e.kind())
+	}
+
+	fn create_config(&self, chain_type: global::ChainTypes) -> Result<(), ErrorKind> {
+		Owner::create_config(self, &chain_type)
+			.map_err(|e| e.kind())
+	}
 }
+

--- a/api/src/owner_rpc_s.rs
+++ b/api/src/owner_rpc_s.rs
@@ -1791,7 +1791,7 @@ where
 		})
 	}
 
-	fn close_wallet(&self, name: Option<String>) -> Result<(), ErrorKind>{
+	fn close_wallet(&self, name: Option<String>) -> Result<(), ErrorKind> {
 		let n = name.as_ref().map(|s| s.as_str());
 		Owner::close_wallet(self, n).map_err(|e| e.kind())
 	}

--- a/api/src/owner_rpc_s.rs
+++ b/api/src/owner_rpc_s.rs
@@ -1320,10 +1320,10 @@ pub trait OwnerRpcS {
 		Once the key is established, all further requests and responses are encrypted and decrypted with the
 		following parameters:
 
-    * AES-256 in GCM mode with 128-bit tags and 96 bit nonces
-    * 12 byte nonce which must be included in each request/response to use on the decrypting side
-    * Empty vector for additional data
-    * Suffix length = AES-256 GCM mode tag length = 16 bytes
+	* AES-256 in GCM mode with 128-bit tags and 96 bit nonces
+	* 12 byte nonce which must be included in each request/response to use on the decrypting side
+	* Empty vector for additional data
+	* Suffix length = AES-256 GCM mode tag length = 16 bytes
 
 		Fully-formed JSON-RPC requests (as documented) should be encrypted using these parameters, encoded
 		into base64 and included with the one-time nonce in a request for the `encrypted_request_v3` method

--- a/api/src/owner_rpc_s.rs
+++ b/api/src/owner_rpc_s.rs
@@ -1504,11 +1504,41 @@ pub trait OwnerRpcS {
 		}
 	}
 	# "#
-	# , true, 5, false, false, false);
+	# , true, 0, false, false, false);
 	```
 	*/
 
 	fn open_wallet(&self, name: Option<String>, password: String) -> Result<Token, ErrorKind>;
+
+	/**
+	Networked version of [Owner::close_wallet](struct.Owner.html#method.close_wallet).
+	```
+	# grin_wallet_api::doctest_helper_json_rpc_owner_assert_response!(
+	# r#"
+	{
+		"jsonrpc": "2.0",
+		"method": "close_wallet",
+		"params": {
+			"name": null
+		},
+		"id": 1
+	}
+	# "#
+	# ,
+	# r#"
+	{
+		"id": 1,
+		"jsonrpc": "2.0",
+		"result": {
+			"Ok": null
+		}
+	}
+	# "#
+	# , true, 0, false, false, false);
+	```
+	*/
+
+	fn close_wallet(&self, name: Option<String>) -> Result<(), ErrorKind>;
 }
 
 impl<'a, L, C, K> OwnerRpcS for Owner<'a, L, C, K>
@@ -1759,5 +1789,10 @@ where
 		Ok(Token {
 			keychain_mask: sec_key,
 		})
+	}
+
+	fn close_wallet(&self, name: Option<String>) -> Result<(), ErrorKind>{
+		let n = name.as_ref().map(|s| s.as_str());
+		Owner::close_wallet(self, n).map_err(|e| e.kind())
 	}
 }

--- a/api/src/owner_rpc_s.rs
+++ b/api/src/owner_rpc_s.rs
@@ -1375,7 +1375,64 @@ pub trait OwnerRpcS {
 
 	fn set_top_level_directory(&self, dir: String) -> Result<(), ErrorKind>;
 
-	/// TODO: DOCS + TESTS TBD
+	/**
+	Networked version of [Owner::create_config](struct.Owner.html#method.create_config).
+
+	Both the `wallet_config` and `logging_config` parameters can be `null`, the examples
+	below are for illustration. Note that the values provided for `log_file_path` and `data_file_dir`
+	will be ignored and replaced with the actual values based on the value of `get_top_level_directory`
+	```
+	# grin_wallet_api::doctest_helper_json_rpc_owner_assert_response!(
+	# r#"
+	{
+		"jsonrpc": "2.0",
+		"method": "create_config",
+		"params": {
+			"chain_type": "Mainnet",
+			"wallet_config": {
+				"chain_type": null,
+				"api_listen_interface": "127.0.0.1",
+				"api_listen_port": 3415,
+				"owner_api_listen_port": 3420,
+				"api_secret_path": null,
+				"node_api_secret_path": null,
+				"check_node_api_http_addr": "http://127.0.0.1:3413",
+				"owner_api_include_foreign": false,
+				"data_file_dir": "/path/to/data/file/dir",
+				"no_commit_cache": null,
+				"tls_certificate_file": null,
+				"tls_certificate_key": null,
+				"dark_background_color_scheme": null,
+				"keybase_notify_ttl": null
+			},
+			"logging_config": {
+				"log_to_stdout": false,
+				"stdout_log_level": "Info",
+				"log_to_file": true,
+				"file_log_level": "Debug",
+				"log_file_path": "/path/to/log/file",
+				"log_file_append": true,
+				"log_max_size": null,
+				"log_max_files": null,
+				"tui_running": null
+			}
+		},
+		"id": 1
+	}
+	# "#
+	# ,
+	# r#"
+	{
+		"id": 1,
+		"jsonrpc": "2.0",
+		"result": {
+			"Ok": null
+		}
+	}
+	# "#
+	# , true, 5, false, false, false);
+	```
+	*/
 	fn create_config(
 		&self,
 		chain_type: global::ChainTypes,
@@ -1383,7 +1440,37 @@ pub trait OwnerRpcS {
 		logging_config: Option<LoggingConfig>,
 	) -> Result<(), ErrorKind>;
 
-	/// TODO: DOCS + TESTS TBD
+	/**
+	Networked version of [Owner::create_wallet](struct.Owner.html#method.create_wallet).
+	```
+	# grin_wallet_api::doctest_helper_json_rpc_owner_assert_response!(
+	# r#"
+	{
+		"jsonrpc": "2.0",
+		"method": "create_wallet",
+		"params": {
+			"name": null,
+			"mnemonic": null,
+			"mnemonic_length": 0,
+			"password": "my_secret_password"
+		},
+		"id": 1
+	}
+	# "#
+	# ,
+	# r#"
+	{
+		"id": 1,
+		"jsonrpc": "2.0",
+		"result": {
+			"Ok": null
+		}
+	}
+	# "#
+	# , true, 0, false, false, false);
+	```
+	*/
+
 	fn create_wallet(
 		&self,
 		name: Option<String>,
@@ -1392,7 +1479,35 @@ pub trait OwnerRpcS {
 		password: String,
 	) -> Result<(), ErrorKind>;
 
-	/// TODO: DOCS + TESTS TBD
+	/**
+	Networked version of [Owner::open_wallet](struct.Owner.html#method.open_wallet).
+	```
+	# grin_wallet_api::doctest_helper_json_rpc_owner_assert_response!(
+	# r#"
+	{
+		"jsonrpc": "2.0",
+		"method": "open_wallet",
+		"params": {
+			"name": null,
+			"password": "my_secret_password"
+		},
+		"id": 1
+	}
+	# "#
+	# ,
+	# r#"
+	{
+		"id": 1,
+		"jsonrpc": "2.0",
+		"result": {
+			"Ok": "d096b3cb75986b3b13f80b8f5243a9edf0af4c74ac37578c5a12cfb5b59b1868"
+		}
+	}
+	# "#
+	# , true, 5, false, false, false);
+	```
+	*/
+
 	fn open_wallet(&self, name: Option<String>, password: String) -> Result<Token, ErrorKind>;
 }
 

--- a/api/src/owner_rpc_s.rs
+++ b/api/src/owner_rpc_s.rs
@@ -15,6 +15,7 @@
 //! JSON-RPC Stub generation for the Owner API
 use uuid::Uuid;
 
+use crate::config::WalletConfig;
 use crate::core::core::Transaction;
 use crate::core::global;
 use crate::keychain::{Identifier, Keychain};
@@ -26,7 +27,6 @@ use crate::libwallet::{
 };
 use crate::util::secp::key::{PublicKey, SecretKey};
 use crate::util::{static_secp_instance, LoggingConfig, ZeroingString};
-use crate::config::WalletConfig;
 use crate::{ECDHPubkey, Owner, Token};
 use easy_jsonrpc_mw;
 use rand::thread_rng;
@@ -1376,7 +1376,12 @@ pub trait OwnerRpcS {
 	fn set_top_level_directory(&self, dir: String) -> Result<(), ErrorKind>;
 
 	/// TODO: DOCS + TESTS TBD
-	fn create_config(&self, chain_type: global::ChainTypes, wallet_config: Option<WalletConfig>, logging_config: Option<LoggingConfig>) -> Result<(), ErrorKind>;
+	fn create_config(
+		&self,
+		chain_type: global::ChainTypes,
+		wallet_config: Option<WalletConfig>,
+		logging_config: Option<LoggingConfig>,
+	) -> Result<(), ErrorKind>;
 
 	/// TODO: DOCS + TESTS TBD
 	fn create_wallet(
@@ -1607,7 +1612,12 @@ where
 		Owner::set_top_level_directory(self, &dir).map_err(|e| e.kind())
 	}
 
-	fn create_config(&self, chain_type: global::ChainTypes, wallet_config: Option<WalletConfig>, logging_config: Option<LoggingConfig>) -> Result<(), ErrorKind> {
+	fn create_config(
+		&self,
+		chain_type: global::ChainTypes,
+		wallet_config: Option<WalletConfig>,
+		logging_config: Option<LoggingConfig>,
+	) -> Result<(), ErrorKind> {
 		Owner::create_config(self, &chain_type, wallet_config, logging_config).map_err(|e| e.kind())
 	}
 

--- a/api/src/owner_rpc_s.rs
+++ b/api/src/owner_rpc_s.rs
@@ -25,7 +25,8 @@ use crate::libwallet::{
 	WalletLCProvider,
 };
 use crate::util::secp::key::{PublicKey, SecretKey};
-use crate::util::{static_secp_instance, ZeroingString};
+use crate::util::{static_secp_instance, LoggingConfig, ZeroingString};
+use crate::config::WalletConfig;
 use crate::{ECDHPubkey, Owner, Token};
 use easy_jsonrpc_mw;
 use rand::thread_rng;
@@ -1314,14 +1315,68 @@ pub trait OwnerRpcS {
 	fn init_secure_api(&self, ecdh_pubkey: ECDHPubkey) -> Result<ECDHPubkey, ErrorKind>;
 
 	// LIFECYCLE FUNCTIONS
-	/// TODO: DOCS + TESTS TBD
+	/**
+	Networked version of [Owner::get_top_level_directory](struct.Owner.html#method.get_top_level_directory).
+
+	```
+	# grin_wallet_api::doctest_helper_json_rpc_owner_assert_response!(
+	# r#"
+	{
+		"jsonrpc": "2.0",
+		"method": "get_top_level_directory",
+		"params": {
+		},
+		"id": 1
+	}
+	# "#
+	# ,
+	# r#"
+	{
+		"id": 1,
+		"jsonrpc": "2.0",
+		"result": {
+			"Ok": "/doctest/dir"
+		}
+	}
+	# "#
+	# , true, 5, false, false, false);
+	```
+	*/
+
 	fn get_top_level_directory(&self) -> Result<String, ErrorKind>;
 
-	/// TODO: DOCS + TESTS TBD
+	/**
+	Networked version of [Owner::set_top_level_directory](struct.Owner.html#method.set_top_level_directory).
+	```
+	# grin_wallet_api::doctest_helper_json_rpc_owner_assert_response!(
+	# r#"
+	{
+		"jsonrpc": "2.0",
+		"method": "set_top_level_directory",
+		"params": {
+			"dir": "/home/wallet_user/my_wallet_dir"
+		},
+		"id": 1
+	}
+	# "#
+	# ,
+	# r#"
+	{
+		"id": 1,
+		"jsonrpc": "2.0",
+		"result": {
+			"Ok": null
+		}
+	}
+	# "#
+	# , true, 5, false, false, false);
+	```
+	*/
+
 	fn set_top_level_directory(&self, dir: String) -> Result<(), ErrorKind>;
 
 	/// TODO: DOCS + TESTS TBD
-	fn create_config(&self, chain_type: global::ChainTypes) -> Result<(), ErrorKind>;
+	fn create_config(&self, chain_type: global::ChainTypes, wallet_config: Option<WalletConfig>, logging_config: Option<LoggingConfig>) -> Result<(), ErrorKind>;
 
 	/// TODO: DOCS + TESTS TBD
 	fn create_wallet(
@@ -1552,8 +1607,8 @@ where
 		Owner::set_top_level_directory(self, &dir).map_err(|e| e.kind())
 	}
 
-	fn create_config(&self, chain_type: global::ChainTypes) -> Result<(), ErrorKind> {
-		Owner::create_config(self, &chain_type).map_err(|e| e.kind())
+	fn create_config(&self, chain_type: global::ChainTypes, wallet_config: Option<WalletConfig>, logging_config: Option<LoggingConfig>) -> Result<(), ErrorKind> {
+		Owner::create_config(self, &chain_type, wallet_config, logging_config).map_err(|e| e.kind())
 	}
 
 	fn create_wallet(

--- a/api/src/owner_rpc_s.rs
+++ b/api/src/owner_rpc_s.rs
@@ -1324,8 +1324,13 @@ pub trait OwnerRpcS {
 	fn create_config(&self, chain_type: global::ChainTypes) -> Result<(), ErrorKind>;
 
 	/// TODO: DOCS + TESTS TBD
-	fn create_wallet(&self, name: Option<String>, mnemonic: Option<String>,
-		mnemonic_length: u32, password: String) -> Result<(), ErrorKind>;
+	fn create_wallet(
+		&self,
+		name: Option<String>,
+		mnemonic: Option<String>,
+		mnemonic_length: u32,
+		password: String,
+	) -> Result<(), ErrorKind>;
 
 	/// TODO: DOCS + TESTS TBD
 	fn open_wallet(&self, name: Option<String>, password: String) -> Result<Token, ErrorKind>;
@@ -1551,8 +1556,13 @@ where
 		Owner::create_config(self, &chain_type).map_err(|e| e.kind())
 	}
 
-	fn create_wallet(&self, name: Option<String>, mnemonic: Option<String>,
-		mnemonic_length: u32, password: String) -> Result<(), ErrorKind>{
+	fn create_wallet(
+		&self,
+		name: Option<String>,
+		mnemonic: Option<String>,
+		mnemonic_length: u32,
+		password: String,
+	) -> Result<(), ErrorKind> {
 		let n = name.as_ref().map(|s| s.as_str());
 		let m = match mnemonic {
 			Some(s) => Some(ZeroingString::from(s)),
@@ -1564,7 +1574,8 @@ where
 
 	fn open_wallet(&self, name: Option<String>, password: String) -> Result<Token, ErrorKind> {
 		let n = name.as_ref().map(|s| s.as_str());
-		let sec_key = Owner::open_wallet(self, n, ZeroingString::from(password), true).map_err(|e| e.kind())?;
+		let sec_key = Owner::open_wallet(self, n, ZeroingString::from(password), true)
+			.map_err(|e| e.kind())?;
 		Ok(Token {
 			keychain_mask: sec_key,
 		})

--- a/api/src/owner_rpc_s.rs
+++ b/api/src/owner_rpc_s.rs
@@ -1532,19 +1532,15 @@ where
 		})
 	}
 
-	fn get_top_level_directory(&self) -> Result<String, ErrorKind>{
-		Owner::get_top_level_directory(self)
-			.map_err(|e| e.kind())
+	fn get_top_level_directory(&self) -> Result<String, ErrorKind> {
+		Owner::get_top_level_directory(self).map_err(|e| e.kind())
 	}
 
-	fn set_top_level_directory(&self, dir: String) -> Result<(), ErrorKind>{
-		Owner::set_top_level_directory(self, &dir)
-			.map_err(|e| e.kind())
+	fn set_top_level_directory(&self, dir: String) -> Result<(), ErrorKind> {
+		Owner::set_top_level_directory(self, &dir).map_err(|e| e.kind())
 	}
 
 	fn create_config(&self, chain_type: global::ChainTypes) -> Result<(), ErrorKind> {
-		Owner::create_config(self, &chain_type)
-			.map_err(|e| e.kind())
+		Owner::create_config(self, &chain_type).map_err(|e| e.kind())
 	}
 }
-

--- a/api/src/owner_rpc_s.rs
+++ b/api/src/owner_rpc_s.rs
@@ -1310,8 +1310,8 @@ pub trait OwnerRpcS {
 	fn node_height(&self, token: Token) -> Result<NodeHeightResult, ErrorKind>;
 
 	/**
-	   Initializes the secure JSON-RPC API. This function must be called and a shared key
-		 established before any other OwnerAPI JSON-RPC function can be called.
+		Initializes the secure JSON-RPC API. This function must be called and a shared key
+		established before any other OwnerAPI JSON-RPC function can be called.
 
 		The shared key will be derived using ECDH with the provided public key on the secp256k1 curve. This
 		function will return its public key used in the derivation, which the caller should multiply by its
@@ -1319,11 +1319,11 @@ pub trait OwnerRpcS {
 
 		Once the key is established, all further requests and responses are encrypted and decrypted with the
 		following parameters:
-
-	* AES-256 in GCM mode with 128-bit tags and 96 bit nonces
-	* 12 byte nonce which must be included in each request/response to use on the decrypting side
-	* Empty vector for additional data
-	* Suffix length = AES-256 GCM mode tag length = 16 bytes
+		* AES-256 in GCM mode with 128-bit tags and 96 bit nonces
+		* 12 byte nonce which must be included in each request/response to use on the decrypting side
+		* Empty vector for additional data
+		* Suffix length = AES-256 GCM mode tag length = 16 bytes
+		*
 
 		Fully-formed JSON-RPC requests (as documented) should be encrypted using these parameters, encoded
 		into base64 and included with the one-time nonce in a request for the `encrypted_request_v3` method

--- a/config/src/lib.rs
+++ b/config/src/lib.rs
@@ -31,4 +31,4 @@ pub mod config;
 pub mod types;
 
 pub use crate::config::{initial_setup_wallet, GRIN_WALLET_DIR, WALLET_CONFIG_FILE_NAME};
-pub use crate::types::{ConfigError, GlobalWalletConfig, WalletConfig};
+pub use crate::types::{ConfigError, GlobalWalletConfig, GlobalWalletConfigMembers, WalletConfig};

--- a/controller/src/command.rs
+++ b/controller/src/command.rs
@@ -122,7 +122,7 @@ pub struct ListenArgs {
 
 pub fn listen<'a, L, C, K>(
 	wallet: Arc<Mutex<Box<dyn WalletInst<'static, L, C, K>>>>,
-	keychain_mask: Option<SecretKey>,
+	keychain_mask: Arc<Mutex<Option<SecretKey>>>,
 	config: &WalletConfig,
 	args: &ListenArgs,
 	g_args: &GlobalArgs,
@@ -171,9 +171,12 @@ where
 	C: NodeClient + 'static,
 	K: keychain::Keychain + 'static,
 {
+	// keychain mask needs to be a sinlge instance, in case the foreign API is
+	// also being run at the same time
+	let km = Arc::new(Mutex::new(keychain_mask));
 	let res = controller::owner_listener(
 		wallet,
-		keychain_mask,
+		km,
 		config.owner_api_listen_addr().as_str(),
 		g_args.node_api_secret.clone(),
 		g_args.tls_conf.clone(),

--- a/controller/src/command.rs
+++ b/controller/src/command.rs
@@ -74,7 +74,7 @@ where
 {
 	let mut w_lock = wallet.lock();
 	let p = w_lock.lc_provider()?;
-	p.create_config(&g_args.chain_type, WALLET_CONFIG_FILE_NAME)?;
+	p.create_config(&g_args.chain_type, WALLET_CONFIG_FILE_NAME, None, None)?;
 	p.create_wallet(
 		None,
 		args.recovery_phrase,

--- a/controller/src/command.rs
+++ b/controller/src/command.rs
@@ -80,6 +80,7 @@ where
 		args.recovery_phrase,
 		args.list_length,
 		args.password.clone(),
+		false,
 	)?;
 
 	let m = p.get_mnemonic(None, args.password)?;

--- a/controller/src/controller.rs
+++ b/controller/src/controller.rs
@@ -447,7 +447,7 @@ impl OwnerV3Helpers {
 						Some(r)
 					}
 				}
-			} 
+			}
 			retval
 		} else if val["result"]["Err"].is_string() {
 			let parsed = serde_json::from_value::<String>(val["result"]["Err"].clone());
@@ -460,17 +460,19 @@ impl OwnerV3Helpers {
 		};
 		match err_string {
 			Some(s) => {
-				return (true,
+				return (
+					true,
 					serde_json::json!({
-					"jsonrpc": "2.0",
-					"id": val["id"],
-					"error": {
-						"message": s,
-						"code": -32099
-					}
-				}))
-			},
-			None => (false, val.clone()) 
+						"jsonrpc": "2.0",
+						"id": val["id"],
+						"error": {
+							"message": s,
+							"code": -32099
+						}
+					}),
+				)
+			}
+			None => (false, val.clone()),
 		}
 	}
 }

--- a/controller/src/controller.rs
+++ b/controller/src/controller.rs
@@ -29,9 +29,9 @@ use hyper::header::HeaderValue;
 use hyper::{Body, Request, Response, StatusCode};
 use serde::{Deserialize, Serialize};
 use serde_json;
+use std::collections::HashMap;
 use std::net::SocketAddr;
 use std::sync::Arc;
-use std::collections::HashMap;
 
 use crate::apiwallet::{
 	EncryptedRequest, EncryptedResponse, EncryptionErrorResponse, Foreign,
@@ -404,12 +404,12 @@ impl OwnerV3Helpers {
 	/// convert an internal error (if exists) as proper JSON-RPC
 	pub fn check_error_response(val: &serde_json::Value) -> serde_json::Value {
 		if val["result"]["Err"].is_object() {
-			let hashed: Result<HashMap<String, String>, serde_json::Error>
-				= serde_json::from_value(val["result"]["Err"].clone());
+			let hashed: Result<HashMap<String, String>, serde_json::Error> =
+				serde_json::from_value(val["result"]["Err"].clone());
 			let message = match hashed {
 				Err(_) => {
 					return val.clone();
-				},
+				}
 				Ok(h) => {
 					let mut retval = "".to_owned();
 					for (k, v) in h.iter() {
@@ -429,7 +429,6 @@ impl OwnerV3Helpers {
 		} else {
 			val.clone()
 		}
-		
 	}
 }
 
@@ -476,9 +475,13 @@ where
 			match owner_api_s.handle_request(val) {
 				MaybeReply::Reply(mut r) => {
 					let mut unencrypted_intercept = r.clone();
-					unencrypted_intercept = OwnerV3Helpers::check_error_response(&unencrypted_intercept);
+					unencrypted_intercept =
+						OwnerV3Helpers::check_error_response(&unencrypted_intercept);
 					if was_encrypted {
-						let res = OwnerV3Helpers::encrypt_response(encrypted_req_id, &unencrypted_intercept);
+						let res = OwnerV3Helpers::encrypt_response(
+							encrypted_req_id,
+							&unencrypted_intercept,
+						);
 						r = match res {
 							Ok(v) => v,
 							Err(v) => return ok(v),

--- a/controller/src/controller.rs
+++ b/controller/src/controller.rs
@@ -336,7 +336,9 @@ impl OwnerV3Helpers {
 
 	/// If incoming is an encrypted request, check there is a shared key,
 	/// Otherwise return an error value
-	pub fn check_encryption_started(key: Arc<Mutex<Option<SecretKey>>>) -> Result<(), serde_json::Value> {
+	pub fn check_encryption_started(
+		key: Arc<Mutex<Option<SecretKey>>>,
+	) -> Result<(), serde_json::Value> {
 		match OwnerV3Helpers::encryption_enabled(key) {
 			true => Ok(()),
 			false => Err(EncryptionErrorResponse::new(
@@ -349,7 +351,11 @@ impl OwnerV3Helpers {
 	}
 
 	/// Update the statically held owner API shared key
-	pub fn update_owner_api_shared_key(key: Arc<Mutex<Option<SecretKey>>>, val: &serde_json::Value, new_key: Option<SecretKey>) {
+	pub fn update_owner_api_shared_key(
+		key: Arc<Mutex<Option<SecretKey>>>,
+		val: &serde_json::Value,
+		new_key: Option<SecretKey>,
+	) {
 		if let Some(_) = val["result"]["Ok"].as_str() {
 			let mut share_key_ref = key.lock();
 			*share_key_ref = new_key;
@@ -407,7 +413,8 @@ impl OwnerV3Helpers {
 		// check for string first. This ensures that error messages
 		// that are just strings aren't given weird formatting
 		if val["result"]["Err"].is_object() {
-			let hashed: Result<HashMap<String, String>, serde_json::Error> = serde_json::from_value(val["result"]["Err"].clone());
+			let hashed: Result<HashMap<String, String>, serde_json::Error> =
+				serde_json::from_value(val["result"]["Err"].clone());
 			match hashed {
 				Err(e) => {
 					debug!("Can't cast value to Hashmap<String> {}", e);
@@ -417,14 +424,17 @@ impl OwnerV3Helpers {
 					for (k, v) in h.iter() {
 						retval = format!("{}: {}", k, v);
 					}
-					return (true, serde_json::json!({
-						"jsonrpc": "2.0",
-						"id": val["id"],
-						"error": {
-							"message": retval,
-							"code": -32099
-						}
-					}));
+					return (
+						true,
+						serde_json::json!({
+							"jsonrpc": "2.0",
+							"id": val["id"],
+							"error": {
+								"message": retval,
+								"code": -32099
+							}
+						}),
+					);
 				}
 			}
 			// Otherwise, see if error message is a map that needs
@@ -441,16 +451,19 @@ impl OwnerV3Helpers {
 					for (k, v) in h.iter() {
 						retval = format!("{}: {}", k, v);
 					}
-					return (true, serde_json::json!({
-						"jsonrpc": "2.0",
-						"id": val["id"],
-						"error": {
-							"message": retval,
-							"code": -32099
-						}
-					}));
+					return (
+						true,
+						serde_json::json!({
+							"jsonrpc": "2.0",
+							"id": val["id"],
+							"error": {
+								"message": retval,
+								"code": -32099
+							}
+						}),
+					);
 				}
-			} 
+			}
 		} else {
 			(false, val.clone())
 		}

--- a/controller/tests/common/mod.rs
+++ b/controller/tests/common/mod.rs
@@ -122,7 +122,7 @@ pub fn create_local_wallet(
 		>;
 	let lc = wallet.lc_provider().unwrap();
 	let _ = lc.set_top_level_directory(&format!("{}/{}", test_dir, name));
-	lc.create_wallet(None, mnemonic, 32, ZeroingString::from(""))
+	lc.create_wallet(None, mnemonic, 32, ZeroingString::from(""), false)
 		.unwrap();
 	let mask = lc
 		.open_wallet(None, ZeroingString::from(""), create_mask, false)

--- a/controller/tests/common/mod.rs
+++ b/controller/tests/common/mod.rs
@@ -121,7 +121,7 @@ pub fn create_local_wallet(
 			>,
 		>;
 	let lc = wallet.lc_provider().unwrap();
-	lc.set_wallet_directory(&format!("{}/{}", test_dir, name));
+	let _ = lc.set_top_level_directory(&format!("{}/{}", test_dir, name));
 	lc.create_wallet(None, mnemonic, 32, ZeroingString::from(""))
 		.unwrap();
 	let mask = lc
@@ -160,7 +160,7 @@ pub fn open_local_wallet(
 			>,
 		>;
 	let lc = wallet.lc_provider().unwrap();
-	lc.set_wallet_directory(&format!("{}/{}", test_dir, name));
+	let _ = lc.set_top_level_directory(&format!("{}/{}", test_dir, name));
 	let mask = lc
 		.open_wallet(None, ZeroingString::from(""), create_mask, false)
 		.unwrap();

--- a/impls/src/adapters/keybase.rs
+++ b/impls/src/adapters/keybase.rs
@@ -367,7 +367,7 @@ impl SlateReceiver for KeybaseAllChannels {
 				>,
 			>;
 		let lc = wallet.lc_provider().unwrap();
-		lc.set_wallet_directory(&config.data_file_dir);
+		lc.set_top_level_directory(&config.data_file_dir)?;
 		let mask = lc.open_wallet(None, passphrase, true, false)?;
 		let wallet_inst = lc.wallet_inst()?;
 		wallet_inst.set_parent_key_id_by_name(account)?;

--- a/impls/src/lifecycle/default.rs
+++ b/impls/src/lifecycle/default.rs
@@ -14,16 +14,18 @@
 
 //! Default wallet lifecycle provider
 
-use crate::config::{config, WalletConfig, GlobalWalletConfig, GlobalWalletConfigMembers, GRIN_WALLET_DIR};
+use crate::config::{
+	config, GlobalWalletConfig, GlobalWalletConfigMembers, WalletConfig, GRIN_WALLET_DIR,
+};
 use crate::core::global;
 use crate::keychain::Keychain;
 use crate::libwallet::{Error, ErrorKind, NodeClient, WalletBackend, WalletLCProvider};
 use crate::lifecycle::seed::WalletSeed;
 use crate::util::secp::key::SecretKey;
 use crate::util::ZeroingString;
-use grin_wallet_util::grin_util::LoggingConfig;
 use crate::LMDBBackend;
 use failure::ResultExt;
+use grin_wallet_util::grin_util::LoggingConfig;
 use std::fs;
 use std::path::PathBuf;
 
@@ -66,31 +68,30 @@ where
 		Ok(self.data_dir.to_owned())
 	}
 
-	fn create_config(&self, chain_type: &global::ChainTypes, file_name: &str, wallet_config: Option<WalletConfig>, logging_config: Option<LoggingConfig>) -> Result<(), Error> {
+	fn create_config(
+		&self,
+		chain_type: &global::ChainTypes,
+		file_name: &str,
+		wallet_config: Option<WalletConfig>,
+		logging_config: Option<LoggingConfig>,
+	) -> Result<(), Error> {
 		let mut default_config = GlobalWalletConfig::for_chain(chain_type);
 		let logging = match logging_config {
 			Some(l) => Some(l),
-			None => {
-				match default_config.members.as_ref() {
-					Some(m) => m.clone().logging.clone(),
-					None => None,
-				}
-			}
+			None => match default_config.members.as_ref() {
+				Some(m) => m.clone().logging.clone(),
+				None => None,
+			},
 		};
 		let wallet = match wallet_config {
 			Some(w) => w,
-			None => {
-				match default_config.members {
-					Some(m) => m.wallet,
-					None => WalletConfig::default(),
-				}
-			}
+			None => match default_config.members {
+				Some(m) => m.wallet,
+				None => WalletConfig::default(),
+			},
 		};
-		default_config = GlobalWalletConfig  {
-			members: Some(GlobalWalletConfigMembers {
-				wallet,
-				logging,
-			}),
+		default_config = GlobalWalletConfig {
+			members: Some(GlobalWalletConfigMembers { wallet, logging }),
 			..default_config
 		};
 		let mut config_file_name = PathBuf::from(self.data_dir.clone());

--- a/impls/src/lifecycle/default.rs
+++ b/impls/src/lifecycle/default.rs
@@ -93,7 +93,7 @@ where
 		if config_file_name.exists() {
 			return Ok(());
 		}
-		
+
 		let mut abs_path = std::env::current_dir()?;
 		abs_path.push(self.data_dir.clone());
 

--- a/impls/src/lifecycle/default.rs
+++ b/impls/src/lifecycle/default.rs
@@ -157,14 +157,17 @@ where
 		mnemonic: Option<ZeroingString>,
 		mnemonic_length: usize,
 		password: ZeroingString,
+		test_mode: bool,
 	) -> Result<(), Error> {
 		let mut data_dir_name = PathBuf::from(self.data_dir.clone());
 		data_dir_name.push(GRIN_WALLET_DIR);
 		let data_dir_name = data_dir_name.to_str().unwrap();
 		let exists = WalletSeed::seed_file_exists(&data_dir_name);
-		if let Ok(true) = exists {
-			let msg = format!("Wallet seed already exists at: {}", data_dir_name);
-			return Err(ErrorKind::WalletSeedExists(msg))?;
+		if !test_mode {
+			if let Ok(true) = exists {
+				let msg = format!("Wallet seed already exists at: {}", data_dir_name);
+				return Err(ErrorKind::WalletSeedExists(msg))?;
+			}
 		}
 		let _ = WalletSeed::init_file(&data_dir_name, mnemonic_length, mnemonic, password);
 		info!("Wallet seed file created");

--- a/impls/src/lifecycle/default.rs
+++ b/impls/src/lifecycle/default.rs
@@ -23,8 +23,8 @@ use crate::util::secp::key::SecretKey;
 use crate::util::ZeroingString;
 use crate::LMDBBackend;
 use failure::ResultExt;
-use std::path::PathBuf;
 use std::fs;
+use std::path::PathBuf;
 
 pub struct DefaultLCProvider<'a, C, K>
 where

--- a/impls/src/lifecycle/default.rs
+++ b/impls/src/lifecycle/default.rs
@@ -93,8 +93,11 @@ where
 		if config_file_name.exists() {
 			return Ok(());
 		}
+		
+		let mut abs_path = std::env::current_dir()?;
+		abs_path.push(self.data_dir.clone());
 
-		default_config.update_paths(&PathBuf::from(self.data_dir.clone()));
+		default_config.update_paths(&PathBuf::from(abs_path));
 		let res = default_config.write_to_file(config_file_name.to_str().unwrap());
 		if let Err(e) = res {
 			let msg = format!(
@@ -131,6 +134,11 @@ where
 		let mut data_dir_name = PathBuf::from(self.data_dir.clone());
 		data_dir_name.push(GRIN_WALLET_DIR);
 		let data_dir_name = data_dir_name.to_str().unwrap();
+		let exists = WalletSeed::seed_file_exists(&data_dir_name);
+		if let Ok(true) = exists {
+			let msg = format!("Wallet seed already exists at: {}", data_dir_name);
+			return Err(ErrorKind::WalletSeedExists(msg))?;
+		}
 		let _ = WalletSeed::init_file(&data_dir_name, mnemonic_length, mnemonic, password);
 		info!("Wallet seed file created");
 		let _wallet: LMDBBackend<'a, C, K> =

--- a/impls/src/lifecycle/seed.rs
+++ b/impls/src/lifecycle/seed.rs
@@ -86,7 +86,7 @@ impl WalletSeed {
 
 	pub fn seed_file_exists(data_file_dir: &str) -> Result<bool, Error> {
 		let seed_file_path = &format!("{}{}{}", data_file_dir, MAIN_SEPARATOR, SEED_FILE,);
-		println!("Seed file path: {}", seed_file_path);
+		debug!("Seed file path: {}", seed_file_path);
 		if Path::new(seed_file_path).exists() {
 			Ok(true)
 		} else {
@@ -123,9 +123,9 @@ impl WalletSeed {
 		password: util::ZeroingString,
 	) -> Result<(), Error> {
 		let seed_file_path = &format!("{}{}{}", data_file_dir, MAIN_SEPARATOR, SEED_FILE,);
-		println!("data file dir: {}", data_file_dir);
+		debug!("data file dir: {}", data_file_dir);
 		if let Ok(true) = WalletSeed::seed_file_exists(data_file_dir) {
-			println!("seed file exists");
+			debug!("seed file exists");
 			WalletSeed::backup_seed(data_file_dir)?;
 		}
 		if !Path::new(&data_file_dir).exists() {
@@ -157,7 +157,11 @@ impl WalletSeed {
 		let seed_file_path = &format!("{}{}{}", data_file_dir, MAIN_SEPARATOR, SEED_FILE,);
 
 		warn!("Generating wallet seed file at: {}", seed_file_path);
-		let _ = WalletSeed::seed_file_exists(data_file_dir)?;
+		let exists = WalletSeed::seed_file_exists(data_file_dir)?;
+		if exists {
+			let msg = format!("Wallet seed already exists at: {}", data_file_dir);
+			return Err(ErrorKind::WalletSeedExists(msg))?;
+		}
 
 		let seed = match recovery_phrase {
 			Some(p) => WalletSeed::from_mnemonic(p)?,

--- a/libwallet/Cargo.toml
+++ b/libwallet/Cargo.toml
@@ -26,6 +26,4 @@ strum = "0.15"
 strum_macros = "0.15"
 
 grin_wallet_util = { path = "../util", version = "2.1.0-beta.1" }
-
-[dev-dependencies]
 grin_wallet_config = { path = "../config", version = "2.1.0-beta.1" }

--- a/libwallet/src/api_impl/owner.rs
+++ b/libwallet/src/api_impl/owner.rs
@@ -274,6 +274,7 @@ where
 	// recieve the transaction back
 	{
 		let mut batch = w.batch(keychain_mask)?;
+		println!("Saving private context: {:?}", slate.id.as_bytes());
 		batch.save_private_context(slate.id.as_bytes(), 1, &context)?;
 		batch.commit()?;
 	}

--- a/libwallet/src/error.rs
+++ b/libwallet/src/error.rs
@@ -126,8 +126,8 @@ pub enum ErrorKind {
 	DuplicateTransactionId,
 
 	/// Wallet seed already exists
-	#[fail(display = "Wallet seed exists error")]
-	WalletSeedExists,
+	#[fail(display = "Wallet seed exists error: {}", _0)]
+	WalletSeedExists(String),
 
 	/// Wallet seed doesn't exist
 	#[fail(display = "Wallet seed doesn't exist error")]

--- a/libwallet/src/lib.rs
+++ b/libwallet/src/lib.rs
@@ -22,11 +22,11 @@
 #![deny(unused_mut)]
 #![warn(missing_docs)]
 
+use grin_wallet_config as config;
 use grin_wallet_util::grin_core;
 use grin_wallet_util::grin_keychain;
 use grin_wallet_util::grin_store;
 use grin_wallet_util::grin_util;
-use grin_wallet_config as config;
 
 use blake2_rfc as blake2;
 

--- a/libwallet/src/lib.rs
+++ b/libwallet/src/lib.rs
@@ -26,6 +26,7 @@ use grin_wallet_util::grin_core;
 use grin_wallet_util::grin_keychain;
 use grin_wallet_util::grin_store;
 use grin_wallet_util::grin_util;
+use grin_wallet_config as config;
 
 use blake2_rfc as blake2;
 

--- a/libwallet/src/slate_versions/mod.rs
+++ b/libwallet/src/slate_versions/mod.rs
@@ -37,7 +37,7 @@ pub enum SlateVersion {
 	V2,
 }
 
-#[derive(Serialize, Deserialize)]
+#[derive(Debug, Serialize, Deserialize)]
 #[serde(untagged)]
 /// Versions are ordered newest to oldest so serde attempts to
 /// deserialize newer versions first, then falls back to older versions.

--- a/libwallet/src/types.rs
+++ b/libwallet/src/types.rs
@@ -15,6 +15,7 @@
 //! Types and traits that should be provided by a wallet
 //! implementation
 
+use crate::config::WalletConfig;
 use crate::error::{Error, ErrorKind};
 use crate::grin_core::core::hash::Hash;
 use crate::grin_core::core::{Output, Transaction, TxKernel};
@@ -23,8 +24,7 @@ use crate::grin_core::{global, ser};
 use crate::grin_keychain::{Identifier, Keychain};
 use crate::grin_util::secp::key::{PublicKey, SecretKey};
 use crate::grin_util::secp::{self, pedersen, Secp256k1};
-use crate::grin_util::{ZeroingString, LoggingConfig};
-use crate::config::WalletConfig;
+use crate::grin_util::{LoggingConfig, ZeroingString};
 use crate::slate::ParticipantMessages;
 use chrono::prelude::*;
 use failure::ResultExt;
@@ -60,7 +60,13 @@ where
 	fn get_top_level_directory(&self) -> Result<String, Error>;
 
 	/// Output a grin-wallet.toml file into the current top-level system wallet directory
-	fn create_config(&self, chain_type: &global::ChainTypes, file_name: &str, wallet_config: Option<WalletConfig>, logging_config: Option<LoggingConfig>) -> Result<(), Error>;
+	fn create_config(
+		&self,
+		chain_type: &global::ChainTypes,
+		file_name: &str,
+		wallet_config: Option<WalletConfig>,
+		logging_config: Option<LoggingConfig>,
+	) -> Result<(), Error>;
 
 	///
 	fn create_wallet(

--- a/libwallet/src/types.rs
+++ b/libwallet/src/types.rs
@@ -75,6 +75,7 @@ where
 		mnemonic: Option<ZeroingString>,
 		mnemonic_length: usize,
 		password: ZeroingString,
+		test_mode: bool,
 	) -> Result<(), Error>;
 
 	///

--- a/libwallet/src/types.rs
+++ b/libwallet/src/types.rs
@@ -52,7 +52,11 @@ where
 {
 	/// Sets the top level system wallet directory
 	/// default is assumed to be ~/.grin/main/wallet_data (or floonet equivalent)
-	fn set_wallet_directory(&mut self, dir: &str);
+	fn set_top_level_directory(&mut self, dir: &str) -> Result<(), Error>;
+
+	/// Sets the top level system wallet directory
+	/// default is assumed to be ~/.grin/main/wallet_data (or floonet equivalent)
+	fn get_top_level_directory(&self) -> Result<String, Error>;
 
 	/// Output a grin-wallet.toml file into the current top-level system wallet directory
 	fn create_config(&self, chain_type: &global::ChainTypes, file_name: &str) -> Result<(), Error>;

--- a/libwallet/src/types.rs
+++ b/libwallet/src/types.rs
@@ -23,7 +23,8 @@ use crate::grin_core::{global, ser};
 use crate::grin_keychain::{Identifier, Keychain};
 use crate::grin_util::secp::key::{PublicKey, SecretKey};
 use crate::grin_util::secp::{self, pedersen, Secp256k1};
-use crate::grin_util::ZeroingString;
+use crate::grin_util::{ZeroingString, LoggingConfig};
+use crate::config::WalletConfig;
 use crate::slate::ParticipantMessages;
 use chrono::prelude::*;
 use failure::ResultExt;
@@ -59,7 +60,7 @@ where
 	fn get_top_level_directory(&self) -> Result<String, Error>;
 
 	/// Output a grin-wallet.toml file into the current top-level system wallet directory
-	fn create_config(&self, chain_type: &global::ChainTypes, file_name: &str) -> Result<(), Error>;
+	fn create_config(&self, chain_type: &global::ChainTypes, file_name: &str, wallet_config: Option<WalletConfig>, logging_config: Option<LoggingConfig>) -> Result<(), Error>;
 
 	///
 	fn create_wallet(

--- a/src/bin/grin-wallet.rs
+++ b/src/bin/grin-wallet.rs
@@ -23,10 +23,10 @@ use crate::core::global;
 use crate::util::init_logger;
 use clap::App;
 use grin_wallet_config as config;
+use grin_wallet_impls::HTTPNodeClient;
 use grin_wallet_util::grin_core as core;
 use grin_wallet_util::grin_util as util;
 use std::env;
-use grin_wallet_impls::HTTPNodeClient;
 
 use grin_wallet::cmd;
 

--- a/src/bin/grin-wallet.rs
+++ b/src/bin/grin-wallet.rs
@@ -26,6 +26,7 @@ use grin_wallet_config as config;
 use grin_wallet_util::grin_core as core;
 use grin_wallet_util::grin_util as util;
 use std::env;
+use grin_wallet_impls::HTTPNodeClient;
 
 use grin_wallet::cmd;
 
@@ -123,5 +124,8 @@ fn real_main() -> i32 {
 			.clone(),
 	);
 
-	cmd::wallet_command(&args, config)
+	let wallet_config = config.clone().members.unwrap().wallet;
+	let node_client = HTTPNodeClient::new(&wallet_config.check_node_api_http_addr, None);
+
+	cmd::wallet_command(&args, config, node_client)
 }

--- a/src/bin/grin-wallet.yml
+++ b/src/bin/grin-wallet.yml
@@ -76,6 +76,10 @@ subcommands:
             short: l
             long: port
             takes_value: true
+        - run_foreign:
+            help: Also run the Foreign API
+            long: run_foreign
+            takes_value: false
   - send:
       about: Builds a transaction to send coins and sends to the specified listener directly
       args:

--- a/src/bin/grin-wallet.yml
+++ b/src/bin/grin-wallet.yml
@@ -168,7 +168,7 @@ subcommands:
             short: f
             long: fluff
   - invoice:
-      about: Initialize an invoice transction.
+      about: Initialize an invoice transaction.
       args:
         - amount:
             help: Number of coins to invoice  with optional fraction, e.g. 12.423
@@ -268,7 +268,7 @@ subcommands:
             short: f
             long: fluff
   - cancel:
-      about: Cancels an previously created transaction, freeing previously locked outputs for use again
+      about: Cancels a previously created transaction, freeing previously locked outputs for use again
       args:
         - id:
             help: The ID of the transaction to cancel

--- a/src/cmd/wallet.rs
+++ b/src/cmd/wallet.rs
@@ -15,7 +15,6 @@
 use crate::cmd::wallet_args;
 use crate::config::GlobalWalletConfig;
 use clap::ArgMatches;
-use grin_wallet_impls::HTTPNodeClient;
 use grin_wallet_libwallet::NodeClient;
 use semver::Version;
 use std::thread;
@@ -23,12 +22,15 @@ use std::time::Duration;
 
 const MIN_COMPAT_NODE_VERSION: &str = "2.0.0-beta.1";
 
-pub fn wallet_command(wallet_args: &ArgMatches<'_>, config: GlobalWalletConfig) -> i32 {
+pub fn wallet_command<C>(wallet_args: &ArgMatches<'_>, config: GlobalWalletConfig, mut node_client: C) -> i32 
+where 
+	C: NodeClient + 'static,
+{
 	// just get defaults from the global config
 	let wallet_config = config.members.unwrap().wallet;
 
 	// Check the node version info, and exit with report if we're not compatible
-	let mut node_client = HTTPNodeClient::new(&wallet_config.check_node_api_http_addr, None);
+	//let mut node_client = HTTPNodeClient::new(&wallet_config.check_node_api_http_addr, None);
 	let global_wallet_args = wallet_args::parse_global_args(&wallet_config, &wallet_args)
 		.expect("Can't read configuration file");
 	node_client.set_node_api_secret(global_wallet_args.node_api_secret.clone());

--- a/src/cmd/wallet.rs
+++ b/src/cmd/wallet.rs
@@ -22,8 +22,12 @@ use std::time::Duration;
 
 const MIN_COMPAT_NODE_VERSION: &str = "2.0.0-beta.1";
 
-pub fn wallet_command<C>(wallet_args: &ArgMatches<'_>, config: GlobalWalletConfig, mut node_client: C) -> i32 
-where 
+pub fn wallet_command<C>(
+	wallet_args: &ArgMatches<'_>,
+	config: GlobalWalletConfig,
+	mut node_client: C,
+) -> i32
+where
 	C: NodeClient + 'static,
 {
 	// just get defaults from the global config

--- a/src/cmd/wallet.rs
+++ b/src/cmd/wallet.rs
@@ -57,7 +57,7 @@ where
 	}
 	// ... if node isn't available, allow offline functions
 
-	let res = wallet_args::wallet_command(wallet_args, wallet_config, node_client, false);
+	let res = wallet_args::wallet_command(wallet_args, wallet_config, node_client, false, |_|{});
 
 	// we need to give log output a chance to catch up before exiting
 	thread::sleep(Duration::from_millis(100));

--- a/src/cmd/wallet.rs
+++ b/src/cmd/wallet.rs
@@ -57,7 +57,7 @@ where
 	}
 	// ... if node isn't available, allow offline functions
 
-	let res = wallet_args::wallet_command(wallet_args, wallet_config, node_client, false, |_|{});
+	let res = wallet_args::wallet_command(wallet_args, wallet_config, node_client, false, |_| {});
 
 	// we need to give log output a chance to catch up before exiting
 	thread::sleep(Duration::from_millis(100));

--- a/src/cmd/wallet_args.rs
+++ b/src/cmd/wallet_args.rs
@@ -761,14 +761,16 @@ pub fn parse_cancel_args(args: &ArgMatches) -> Result<command::CancelArgs, Parse
 	})
 }
 
-pub fn wallet_command<C>(
+pub fn wallet_command<C, F>(
 	wallet_args: &ArgMatches,
 	mut wallet_config: WalletConfig,
 	mut node_client: C,
 	test_mode: bool,
+	//wallet_inst_cb: F
 ) -> Result<String, Error>
 where
 	C: NodeClient + 'static + Clone,
+	//F: FnOnce(&mut Arc<Mutex<Box<dyn WalletInst<'a, L, C, L
 {
 	if let Some(t) = wallet_config.chain_type.clone() {
 		core::global::set_mining_mode(t);

--- a/src/cmd/wallet_args.rs
+++ b/src/cmd/wallet_args.rs
@@ -827,7 +827,7 @@ where
 			let mut wallet_lock = wallet.lock();
 			let lc = wallet_lock.lc_provider().unwrap();
 			open_wallet = lc.wallet_exists(None)?;
-		},
+		}
 		_ => {}
 	}
 
@@ -846,8 +846,8 @@ where
 				wallet_inst.set_parent_key_id_by_name(account)?;
 			}
 			mask
-		},
-		false => None
+		}
+		false => None,
 	};
 
 	let km = (&keychain_mask).as_ref();

--- a/src/cmd/wallet_args.rs
+++ b/src/cmd/wallet_args.rs
@@ -766,11 +766,24 @@ pub fn wallet_command<C, F>(
 	mut wallet_config: WalletConfig,
 	mut node_client: C,
 	test_mode: bool,
-	wallet_inst_cb: F
+	wallet_inst_cb: F,
 ) -> Result<String, Error>
 where
 	C: NodeClient + 'static + Clone,
-	F: FnOnce(Arc<Mutex<Box<dyn WalletInst<'static, DefaultLCProvider<'static, C, keychain::ExtKeychain>, C, keychain::ExtKeychain>>>>),
+	F: FnOnce(
+		Arc<
+			Mutex<
+				Box<
+					dyn WalletInst<
+						'static,
+						DefaultLCProvider<'static, C, keychain::ExtKeychain>,
+						C,
+						keychain::ExtKeychain,
+					>,
+				>,
+			>,
+		>,
+	),
 {
 	if let Some(t) = wallet_config.chain_type.clone() {
 		core::global::set_mining_mode(t);
@@ -819,7 +832,7 @@ where
 		let _ = lc.set_top_level_directory(&wallet_config.data_file_dir);
 	}
 
-	// provide wallet instance back to the caller (handy for testing with 
+	// provide wallet instance back to the caller (handy for testing with
 	// local wallet proxy, etc)
 	wallet_inst_cb(wallet.clone());
 

--- a/src/cmd/wallet_args.rs
+++ b/src/cmd/wallet_args.rs
@@ -766,11 +766,11 @@ pub fn wallet_command<C, F>(
 	mut wallet_config: WalletConfig,
 	mut node_client: C,
 	test_mode: bool,
-	//wallet_inst_cb: F
+	wallet_inst_cb: F
 ) -> Result<String, Error>
 where
 	C: NodeClient + 'static + Clone,
-	//F: FnOnce(&mut Arc<Mutex<Box<dyn WalletInst<'a, L, C, L
+	F: FnOnce(Arc<Mutex<Box<dyn WalletInst<'static, DefaultLCProvider<'static, C, keychain::ExtKeychain>, C, keychain::ExtKeychain>>>>),
 {
 	if let Some(t) = wallet_config.chain_type.clone() {
 		core::global::set_mining_mode(t);
@@ -818,6 +818,10 @@ where
 		let lc = wallet_lock.lc_provider().unwrap();
 		let _ = lc.set_top_level_directory(&wallet_config.data_file_dir);
 	}
+
+	// provide wallet instance back to the caller (handy for testing with 
+	// local wallet proxy, etc)
+	wallet_inst_cb(wallet.clone());
 
 	// don't open wallet for certain lifecycle commands
 	let mut open_wallet = true;

--- a/src/cmd/wallet_args.rs
+++ b/src/cmd/wallet_args.rs
@@ -959,7 +959,7 @@ where
 			command::check_repair(wallet, km, a)
 		}
 		_ => {
-			let msg = format!("Unknown wallet command, use 'grin help wallet' for details");
+			let msg = format!("Unknown wallet command, use 'grin-wallet help' for details");
 			return Err(ErrorKind::ArgumentError(msg).into());
 		}
 	};

--- a/src/cmd/wallet_args.rs
+++ b/src/cmd/wallet_args.rs
@@ -895,7 +895,13 @@ where
 		("listen", Some(args)) => {
 			let mut c = wallet_config.clone();
 			let a = arg_parse!(parse_listen_args(&mut c, &args));
-			command::listen(wallet, Arc::new(Mutex::new(keychain_mask)), &c, &a, &global_wallet_args.clone())
+			command::listen(
+				wallet,
+				Arc::new(Mutex::new(keychain_mask)),
+				&c,
+				&a,
+				&global_wallet_args.clone(),
+			)
 		}
 		("owner_api", Some(args)) => {
 			let mut c = wallet_config.clone();

--- a/src/cmd/wallet_args.rs
+++ b/src/cmd/wallet_args.rs
@@ -403,6 +403,9 @@ pub fn parse_owner_api_args(
 	if let Some(port) = args.value_of("port") {
 		config.owner_api_listen_port = Some(port.parse().unwrap());
 	}
+	if args.is_present("run_foreign") {
+		config.owner_api_include_foreign = Some(true);
+	}
 	Ok(())
 }
 
@@ -892,7 +895,7 @@ where
 		("listen", Some(args)) => {
 			let mut c = wallet_config.clone();
 			let a = arg_parse!(parse_listen_args(&mut c, &args));
-			command::listen(wallet, keychain_mask, &c, &a, &global_wallet_args.clone())
+			command::listen(wallet, Arc::new(Mutex::new(keychain_mask)), &c, &a, &global_wallet_args.clone())
 		}
 		("owner_api", Some(args)) => {
 			let mut c = wallet_config.clone();

--- a/tests/common/mod.rs
+++ b/tests/common/mod.rs
@@ -149,6 +149,7 @@ pub fn config_command_wallet(
 }
 
 /// Handles setup and detection of paths for wallet
+#[allow(dead_code)]
 pub fn initial_setup_wallet(dir_name: &str, wallet_name: &str) -> WalletConfig {
 	let mut current_dir;
 	current_dir = env::current_dir().unwrap_or_else(|e| {
@@ -185,6 +186,7 @@ fn get_wallet_subcommand<'a>(
 }
 //
 // Helper to create an instance of the LMDB wallet
+#[allow(dead_code)]
 pub fn instantiate_wallet(
 	mut wallet_config: WalletConfig,
 	node_client: LocalWalletClient,
@@ -226,7 +228,7 @@ pub fn instantiate_wallet(
 		top_level_wallet_dir.pop();
 		wallet_config.data_file_dir = top_level_wallet_dir.to_str().unwrap().into();
 	}
-	lc.set_wallet_directory(&wallet_config.data_file_dir);
+	let _ = lc.set_top_level_directory(&wallet_config.data_file_dir);
 	let keychain_mask = lc
 		.open_wallet(None, ZeroingString::from(passphrase), true, false)
 		.unwrap();
@@ -235,6 +237,7 @@ pub fn instantiate_wallet(
 	Ok((Arc::new(Mutex::new(wallet)), keychain_mask))
 }
 
+#[allow(dead_code)]
 pub fn execute_command(
 	app: &App,
 	test_dir: &str,
@@ -359,6 +362,7 @@ where
 			code: res["error"]["code"].as_i64().unwrap() as i32,
 		}));
 	}
+	println!("RES: {:?}", res);
 	let res = easy_jsonrpc::Response::from_json_response(res).unwrap();
 	let res = res
 		.outputs
@@ -368,14 +372,21 @@ where
 		.unwrap();
 
 	if res["Err"] != json!(null) {
+		println!("RES[ERR]: {:?}", res);
 		Ok(Err(WalletAPIReturnError {
 			message: res["Err"].as_str().unwrap().to_owned(),
 			code: res_val["error"]["code"].as_i64().unwrap() as i32,
 		}))
 	} else {
 		// deserialize result into expected type
-		let value: OUT = serde_json::from_value(res["Ok"].clone()).unwrap();
-		Ok(Ok(value))
+		let ok_val = serde_json::from_value(res["Ok"].clone());
+		if let Ok(v) = ok_val {
+			let value: OUT = v;
+			Ok(Ok(value))
+		} else {
+			let value: OUT = serde_json::from_value(json!("Null")).unwrap();
+			Ok(Ok(value))
+		}
 	}
 }
 

--- a/tests/common/mod.rs
+++ b/tests/common/mod.rs
@@ -362,7 +362,6 @@ where
 			code: res["error"]["code"].as_i64().unwrap() as i32,
 		}));
 	}
-	println!("RES: {:?}", res);
 	let res = easy_jsonrpc::Response::from_json_response(res).unwrap();
 	let res = res
 		.outputs
@@ -372,7 +371,6 @@ where
 		.unwrap();
 
 	if res["Err"] != json!(null) {
-		println!("RES[ERR]: {:?}", res);
 		Ok(Err(WalletAPIReturnError {
 			message: res["Err"].as_str().unwrap().to_owned(),
 			code: res_val["error"]["code"].as_i64().unwrap() as i32,

--- a/tests/common/mod.rs
+++ b/tests/common/mod.rs
@@ -27,7 +27,7 @@ use util::{Mutex, ZeroingString};
 use grin_wallet_api::{EncryptedRequest, EncryptedResponse};
 use grin_wallet_config::{GlobalWalletConfig, WalletConfig, GRIN_WALLET_DIR};
 use grin_wallet_impls::{DefaultLCProvider, DefaultWalletImpl};
-use grin_wallet_libwallet::{WalletInfo, WalletInst, NodeClient};
+use grin_wallet_libwallet::{NodeClient, WalletInfo, WalletInst};
 use grin_wallet_util::grin_core::global::{self, ChainTypes};
 use grin_wallet_util::grin_keychain::ExtKeychain;
 use grin_wallet_util::grin_util::{from_hex, static_secp_instance};
@@ -250,7 +250,7 @@ pub fn execute_command(
 	let mut config = initial_setup_wallet(test_dir, wallet_name);
 	//unset chain type so it doesn't get reset
 	config.chain_type = None;
-	wallet_args::wallet_command(&args, config.clone(), client.clone(), true, |_|{})
+	wallet_args::wallet_command(&args, config.clone(), client.clone(), true, |_| {})
 }
 
 // as above, but without necessarily setting up the wallet
@@ -261,11 +261,24 @@ pub fn execute_command_no_setup<C, F>(
 	wallet_name: &str,
 	client: &C,
 	arg_vec: Vec<&str>,
-  f: F
-) -> Result<String, grin_wallet_controller::Error> 
+	f: F,
+) -> Result<String, grin_wallet_controller::Error>
 where
 	C: NodeClient + 'static + Clone,
-	F: FnOnce(Arc<Mutex<Box<dyn WalletInst<'static, DefaultLCProvider<'static, C, ExtKeychain>, C, ExtKeychain>>>>),
+	F: FnOnce(
+		Arc<
+			Mutex<
+				Box<
+					dyn WalletInst<
+						'static,
+						DefaultLCProvider<'static, C, ExtKeychain>,
+						C,
+						ExtKeychain,
+					>,
+				>,
+			>,
+		>,
+	),
 {
 	let args = app.clone().get_matches_from(arg_vec);
 	let _ = get_wallet_subcommand(test_dir, wallet_name, args.clone());

--- a/tests/common/mod.rs
+++ b/tests/common/mod.rs
@@ -404,7 +404,7 @@ where
 			Ok(v) => {
 				let value: OUT = v;
 				Ok(Ok(value))
-			},
+			}
 			Err(e) => {
 				println!("Error deserializing: {:?}", e);
 				let value: OUT = serde_json::from_value(json!("Null")).unwrap();

--- a/tests/common/mod.rs
+++ b/tests/common/mod.rs
@@ -388,7 +388,7 @@ where
 		.clone()
 		.unwrap();
 
-	println!("RES: {}", res_val);
+	//println!("RES: {}", res);
 	if res["Err"] != json!(null) {
 		Ok(Err(WalletAPIReturnError {
 			message: res["Err"].as_str().unwrap().to_owned(),
@@ -396,13 +396,20 @@ where
 		}))
 	} else {
 		// deserialize result into expected type
-		let ok_val = serde_json::from_value(res["Ok"].clone());
-		if let Ok(v) = ok_val {
-			let value: OUT = v;
-			Ok(Ok(value))
-		} else {
-			let value: OUT = serde_json::from_value(json!("Null")).unwrap();
-			Ok(Ok(value))
+		let raw_value = res["Ok"].clone();
+		let raw_value_str = serde_json::to_string_pretty(&raw_value).unwrap();
+		//println!("Raw value: {}", raw_value_str);
+		let ok_val = serde_json::from_str(&raw_value_str);
+		match ok_val {
+			Ok(v) => {
+				let value: OUT = v;
+				Ok(Ok(value))
+			},
+			Err(e) => {
+				println!("Error deserializing: {:?}", e);
+				let value: OUT = serde_json::from_value(json!("Null")).unwrap();
+				Ok(Ok(value))
+			}
 		}
 	}
 }

--- a/tests/data/v2_reqs/init_send_tx.req.json
+++ b/tests/data/v2_reqs/init_send_tx.req.json
@@ -1,0 +1,19 @@
+{
+	"jsonrpc": "2.0",
+	"method": "init_send_tx",
+	"params": {
+		"args": {
+			"src_acct_name": null,
+			"amount": "600000000000",
+			"minimum_confirmations": 2,
+			"max_outputs": 500,
+			"num_change_outputs": 1,
+			"selection_strategy_is_use_all": true,
+			"message": "my message",
+			"target_slate_version": null,
+			"send_args": null
+		}
+	},
+	"id": 1
+}
+

--- a/tests/data/v3_reqs/close_wallet.req.json
+++ b/tests/data/v3_reqs/close_wallet.req.json
@@ -1,0 +1,8 @@
+{
+	"jsonrpc": "2.0",
+	"method": "close_wallet",
+	"params": {
+		"name": null
+	},
+	"id": 1
+}

--- a/tests/data/v3_reqs/create_config.req.json
+++ b/tests/data/v3_reqs/create_config.req.json
@@ -2,7 +2,9 @@
 	"jsonrpc": "2.0",
 	"method": "create_config",
 	"params": {
-		"chain_type": "AutomatedTesting"
+		"chain_type": "AutomatedTesting",
+		"wallet_config": null,
+		"logging_config": null
 	},
 	"id": 1
 }

--- a/tests/data/v3_reqs/create_config.req.json
+++ b/tests/data/v3_reqs/create_config.req.json
@@ -1,0 +1,8 @@
+{
+	"jsonrpc": "2.0",
+	"method": "create_config",
+	"params": {
+		"chain_type": "AutomatedTesting"
+	},
+	"id": 1
+}

--- a/tests/data/v3_reqs/create_wallet.req.json
+++ b/tests/data/v3_reqs/create_wallet.req.json
@@ -1,8 +1,10 @@
 {
 	"jsonrpc": "2.0",
-	"method": "open_wallet",
+	"method": "create_wallet",
 	"params": {
 		"name": null,
+		"mnemonic": null,
+		"mnemonic_length": 0,
 		"password": "passwoid"
 	},
 	"id": 1

--- a/tests/data/v3_reqs/get_top_level.req.json
+++ b/tests/data/v3_reqs/get_top_level.req.json
@@ -1,0 +1,7 @@
+{
+	"jsonrpc": "2.0",
+	"method": "get_top_level_directory",
+	"params": {
+	},
+	"id": 1
+}

--- a/tests/data/v3_reqs/init_send_tx.req.json
+++ b/tests/data/v3_reqs/init_send_tx.req.json
@@ -1,0 +1,20 @@
+{
+	"jsonrpc": "2.0",
+	"method": "init_send_tx",
+	"params": {
+		"token": null,
+		"args": {
+			"src_acct_name": null,
+			"amount": "600000000000",
+			"minimum_confirmations": 2,
+			"max_outputs": 500,
+			"num_change_outputs": 1,
+			"selection_strategy_is_use_all": true,
+			"message": "my message",
+			"target_slate_version": null,
+			"send_args": null
+		}
+	},
+	"id": 1
+}
+

--- a/tests/owner_v3_init_secure.rs
+++ b/tests/owner_v3_init_secure.rs
@@ -197,7 +197,7 @@ fn owner_v3_init_secure() -> Result<(), grin_wallet_controller::Error> {
 	println!("RES 11: {:?}", res);
 	assert!(res.is_ok());
 
-	// 12) A request which triggers and API error (not an encryption error)
+	// 12) A request which triggers an API error (not an encryption error)
 	let req = serde_json::json!({
 		"jsonrpc": "2.0",
 		"id": 1,
@@ -212,6 +212,14 @@ fn owner_v3_init_secure() -> Result<(), grin_wallet_controller::Error> {
 	println!("RES 12: {:?}", res);
 	assert!(res.is_err());
 	assert_eq!(res.unwrap_err().code, -32601);
+
+	// 13) A request which triggers an internal API error (not enough funds)
+	let req = include_str!("data/v3_reqs/init_send_tx.req.json");
+	let res =
+		send_request_enc::<String>(13, 1, "http://127.0.0.1:33420/v3/owner", &req, &shared_key)?;
+	println!("RES 13: {:?}", res);
+	assert!(res.is_err());
+	assert_eq!(res.unwrap_err().code, -32099);
 
 	clean_output_dir(test_dir);
 

--- a/tests/owner_v3_lifecycle.rs
+++ b/tests/owner_v3_lifecycle.rs
@@ -30,6 +30,7 @@ use grin_wallet_impls::DefaultLCProvider;
 use grin_wallet_util::grin_keychain::ExtKeychain;
 use grin_wallet_util::grin_util::secp::key::SecretKey;
 use grin_wallet_util::grin_util::{from_hex, static_secp_instance};
+use grin_wallet_libwallet::WalletInfo;
 use serde_json;
 
 use std::fs;
@@ -44,7 +45,7 @@ use common::{
 
 #[test]
 fn owner_v3_lifecycle() -> Result<(), grin_wallet_controller::Error> {
-	let test_dir = "target/test_output/owner_v3_open";
+	let test_dir = "target/test_output/owner_v3_lifecycle";
 	setup(test_dir);
 
 	// Create a new proxy to simulate server and wallet responses
@@ -69,6 +70,13 @@ fn owner_v3_lifecycle() -> Result<(), grin_wallet_controller::Error> {
 		execute_command_no_setup(&app, test_dir, "wallet1", &client1, arg_vec.clone()).unwrap();
 	});
 	thread::sleep(Duration::from_millis(200));
+
+	// Set the wallet proxy listener running
+	thread::spawn(move || {
+		if let Err(e) = wallet_proxy.run() {
+			error!("Wallet Proxy error: {}", e);
+			}
+	});
 
 	// We have an owner API with no wallet initialized. Init the secure API
 	let sec_key_str = "e00dcc4a009e3427c6b1e1a550c538179d46f3827a13ed74c759c860761caf1e";
@@ -116,8 +124,54 @@ fn owner_v3_lifecycle() -> Result<(), grin_wallet_controller::Error> {
 	let pb = PathBuf::from(format!("{}/wallet1/grin-wallet.toml", test_dir));
 	assert!(pb.exists());
 
+	// 5) Try and perform an operation without having a wallet open
+	let req = include_str!("data/v3_reqs/retrieve_info.req.json");
+	let res =
+		send_request_enc::<String>(1, 1, "http://127.0.0.1:43420/v3/owner", &req, &shared_key)?;
+	println!("RES 5: {:?}", res);
+	assert!(res.is_err());
+
+	// 6) Create a wallet
+	let req = include_str!("data/v3_reqs/create_wallet.req.json");
+	let res =
+		send_request_enc::<String>(1, 1, "http://127.0.0.1:43420/v3/owner", &req, &shared_key)?;
+	println!("RES 6: {:?}", res);
+	assert!(res.is_ok());
+
+	// 7) Try and create a wallet when one exists
+	let req = include_str!("data/v3_reqs/create_wallet.req.json");
+	let res =
+		send_request_enc::<String>(1, 1, "http://127.0.0.1:43420/v3/owner", &req, &shared_key)?;
+	println!("RES 7: {:?}", res);
+	assert!(res.is_err());
+
+	// 8) Open the wallet
+	let req = include_str!("data/v3_reqs/open_wallet.req.json");
+	let res =
+		send_request_enc::<String>(1, 1, "http://127.0.0.1:43420/v3/owner", &req, &shared_key)?;
+	println!("RES 8: {:?}", res);
+	assert!(res.is_ok());
+	let token = res.unwrap();
+
+	// 9) Send a request with our new token
+	let req = serde_json::json!({
+		"jsonrpc": "2.0",
+		"id": 1,
+		"method": "retrieve_summary_info",
+		"params": {
+			"token": token,
+			"refresh_from_node": true,
+			"minimum_confirmations": 1
+		}
+	});
+
+	let res =
+		send_request_enc::<RetrieveSummaryInfoResp>(1, 1, "http://127.0.0.1:43420/v3/owner", &req.to_string(), &shared_key)?;
+	println!("RES 9: {:?}", res);
+	assert!(res.is_ok());
+
 	thread::sleep(Duration::from_millis(200));
-	clean_output_dir(test_dir);
+	//clean_output_dir(test_dir);
 
 	Ok(())
 }

--- a/tests/owner_v3_lifecycle.rs
+++ b/tests/owner_v3_lifecycle.rs
@@ -26,8 +26,8 @@ use clap::App;
 use std::thread;
 use std::time::Duration;
 
-use grin_wallet_libwallet::{InitTxArgs, Slate, SlateVersion, VersionedSlate};
 use grin_wallet_impls::DefaultLCProvider;
+use grin_wallet_libwallet::{InitTxArgs, Slate, SlateVersion, VersionedSlate};
 use grin_wallet_util::grin_keychain::ExtKeychain;
 use serde_json;
 
@@ -38,7 +38,9 @@ use std::sync::Arc;
 #[macro_use]
 mod common;
 use common::{
-	clean_output_dir, instantiate_wallet, initial_setup_wallet, derive_ecdh_key, execute_command, execute_command_no_setup, send_request, send_request_enc, setup, RetrieveSummaryInfoResp
+	clean_output_dir, derive_ecdh_key, execute_command, execute_command_no_setup,
+	initial_setup_wallet, instantiate_wallet, send_request, send_request_enc, setup,
+	RetrieveSummaryInfoResp,
 };
 
 #[test]
@@ -329,7 +331,7 @@ fn owner_v3_lifecycle() -> Result<(), grin_wallet_controller::Error> {
 	)?;
 	println!("RES 15: {:?}", res);
 	assert!(res.is_ok());
-	let mut slate:Slate = res.unwrap().into();
+	let mut slate: Slate = res.unwrap().into();
 
 	// give this slate over to wallet 2 manually
 	grin_wallet_controller::controller::owner_single_use(wallet2.clone(), mask2, |api, m| {
@@ -360,11 +362,8 @@ fn owner_v3_lifecycle() -> Result<(), grin_wallet_controller::Error> {
 			"slate": VersionedSlate::into_version(slate, SlateVersion::V2),
 		}
 	});
-	let res = send_request::<VersionedSlate>(
-		1,
-		"http://127.0.0.1:43420/v2/foreign",
-		&req.to_string(),
-	)?;
+	let res =
+		send_request::<VersionedSlate>(1, "http://127.0.0.1:43420/v2/foreign", &req.to_string())?;
 	println!("RES 16: {:?}", res);
 	assert!(res.is_ok());
 

--- a/tests/owner_v3_lifecycle.rs
+++ b/tests/owner_v3_lifecycle.rs
@@ -1,0 +1,133 @@
+// Copyright 2019 The Grin Developers
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#[macro_use]
+extern crate clap;
+
+#[macro_use]
+extern crate log;
+
+extern crate grin_wallet;
+
+use grin_wallet_api::ECDHPubkey;
+use grin_wallet_impls::test_framework::{self, LocalWalletClient, WalletProxy};
+
+use clap::App;
+use std::thread;
+use std::time::Duration;
+
+use grin_wallet_impls::DefaultLCProvider;
+use grin_wallet_util::grin_keychain::ExtKeychain;
+use grin_wallet_util::grin_util::secp::key::SecretKey;
+use grin_wallet_util::grin_util::{from_hex, static_secp_instance};
+use serde_json;
+
+use std::path::PathBuf;
+use std::fs;
+
+#[macro_use]
+mod common;
+use common::{
+	clean_output_dir, derive_ecdh_key, execute_command_no_setup, initial_setup_wallet, instantiate_wallet,
+	send_request, send_request_enc, setup, RetrieveSummaryInfoResp,
+};
+
+#[test]
+fn owner_v3_lifecycle() -> Result<(), grin_wallet_controller::Error> {
+	let test_dir = "target/test_output/owner_v3_open";
+	setup(test_dir);
+
+	// Create a new proxy to simulate server and wallet responses
+	let mut wallet_proxy: WalletProxy<
+		DefaultLCProvider<LocalWalletClient, ExtKeychain>,
+		LocalWalletClient,
+		ExtKeychain,
+	> = WalletProxy::new(test_dir);
+	let chain = wallet_proxy.chain.clone();
+
+	// load app yaml. If it don't exist, just say so and exit
+	let yml = load_yaml!("../src/bin/grin-wallet.yml");
+	let app = App::from_yaml(yml);
+
+	// start up the owner api with wallet created
+	let arg_vec = vec!["grin-wallet", "owner_api", "-l", "43420"];
+	// should create new wallet file
+	let client1 = LocalWalletClient::new("wallet1", wallet_proxy.tx.clone());
+	thread::spawn(move || {
+		let yml = load_yaml!("../src/bin/grin-wallet.yml");
+		let app = App::from_yaml(yml);
+		execute_command_no_setup(&app, test_dir, "wallet1", &client1, arg_vec.clone()).unwrap();
+	});
+	thread::sleep(Duration::from_millis(200));
+
+	// We have an owner API with no wallet initialized. Init the secure API
+	let sec_key_str = "e00dcc4a009e3427c6b1e1a550c538179d46f3827a13ed74c759c860761caf1e";
+	let req = include_str!("data/v3_reqs/init_secure_api.req.json");
+	let res = send_request(1, "http://127.0.0.1:43420/v3/owner", req)?;
+	println!("RES 1: {:?}", res);
+
+	assert!(res.is_ok());
+	let value: ECDHPubkey = res.unwrap();
+	let shared_key = derive_ecdh_key(sec_key_str, &value.ecdh_pubkey);
+
+	// 2) get the top level directory, should default to ~/.grin/auto
+	let req = include_str!("data/v3_reqs/get_top_level.req.json");
+	let res = send_request_enc::<String>(
+		1,
+		1,
+		"http://127.0.0.1:43420/v3/owner",
+		&req,
+		&shared_key,
+	)?;
+	println!("RES 2: {:?}", res);
+	assert!(res.is_ok());
+	assert!(res.unwrap().contains(".grin/auto"));
+
+	// 3) now set the top level directory to our test wallet dir
+	let req = serde_json::json!({
+		"jsonrpc": "2.0",
+		"id": 1,
+		"method": "set_top_level_directory",
+		"params": {
+			"dir": format!("{}/wallet1", test_dir)
+		}
+	});
+	let res = send_request_enc::<String>(
+		1,
+		1,
+		"http://127.0.0.1:43420/v3/owner",
+		&req.to_string(),
+		&shared_key,
+	)?;
+	println!("RES 3: {:?}", res);
+	assert!(res.is_ok());
+
+	// 4) create a configuration file in top level directory
+	let req = include_str!("data/v3_reqs/create_config.req.json");
+	let res = send_request_enc::<String>(
+		1,
+		1,
+		"http://127.0.0.1:43420/v3/owner",
+		&req,
+		&shared_key,
+	)?;
+	println!("RES 4: {:?}", res);
+	assert!(res.is_ok());
+	let pb = PathBuf::from(format!("{}/wallet1/grin-wallet.toml", test_dir));
+	assert!(pb.exists());
+
+	thread::sleep(Duration::from_millis(200));
+	clean_output_dir(test_dir);
+
+	Ok(())
+}

--- a/tests/owner_v3_lifecycle.rs
+++ b/tests/owner_v3_lifecycle.rs
@@ -117,7 +117,7 @@ fn owner_v3_lifecycle() -> Result<(), grin_wallet_controller::Error> {
 		send_request_enc::<String>(1, 1, "http://127.0.0.1:43420/v3/owner", &req, &shared_key)?;
 	println!("RES 2: {:?}", res);
 	assert!(res.is_ok());
-	assert!(res.unwrap().contains(".grin/auto"));
+	assert!(res.unwrap().contains("auto"));
 
 	// 3) now set the top level directory to our test wallet dir
 	let req = serde_json::json!({

--- a/tests/owner_v3_lifecycle.rs
+++ b/tests/owner_v3_lifecycle.rs
@@ -32,14 +32,14 @@ use grin_wallet_util::grin_util::secp::key::SecretKey;
 use grin_wallet_util::grin_util::{from_hex, static_secp_instance};
 use serde_json;
 
-use std::path::PathBuf;
 use std::fs;
+use std::path::PathBuf;
 
 #[macro_use]
 mod common;
 use common::{
-	clean_output_dir, derive_ecdh_key, execute_command_no_setup, initial_setup_wallet, instantiate_wallet,
-	send_request, send_request_enc, setup, RetrieveSummaryInfoResp,
+	clean_output_dir, derive_ecdh_key, execute_command_no_setup, initial_setup_wallet,
+	instantiate_wallet, send_request, send_request_enc, setup, RetrieveSummaryInfoResp,
 };
 
 #[test]
@@ -82,13 +82,8 @@ fn owner_v3_lifecycle() -> Result<(), grin_wallet_controller::Error> {
 
 	// 2) get the top level directory, should default to ~/.grin/auto
 	let req = include_str!("data/v3_reqs/get_top_level.req.json");
-	let res = send_request_enc::<String>(
-		1,
-		1,
-		"http://127.0.0.1:43420/v3/owner",
-		&req,
-		&shared_key,
-	)?;
+	let res =
+		send_request_enc::<String>(1, 1, "http://127.0.0.1:43420/v3/owner", &req, &shared_key)?;
 	println!("RES 2: {:?}", res);
 	assert!(res.is_ok());
 	assert!(res.unwrap().contains(".grin/auto"));
@@ -114,13 +109,8 @@ fn owner_v3_lifecycle() -> Result<(), grin_wallet_controller::Error> {
 
 	// 4) create a configuration file in top level directory
 	let req = include_str!("data/v3_reqs/create_config.req.json");
-	let res = send_request_enc::<String>(
-		1,
-		1,
-		"http://127.0.0.1:43420/v3/owner",
-		&req,
-		&shared_key,
-	)?;
+	let res =
+		send_request_enc::<String>(1, 1, "http://127.0.0.1:43420/v3/owner", &req, &shared_key)?;
 	println!("RES 4: {:?}", res);
 	assert!(res.is_ok());
 	let pb = PathBuf::from(format!("{}/wallet1/grin-wallet.toml", test_dir));

--- a/tests/owner_v3_lifecycle.rs
+++ b/tests/owner_v3_lifecycle.rs
@@ -27,10 +27,10 @@ use std::thread;
 use std::time::Duration;
 
 use grin_wallet_impls::DefaultLCProvider;
+use grin_wallet_libwallet::WalletInfo;
 use grin_wallet_util::grin_keychain::ExtKeychain;
 use grin_wallet_util::grin_util::secp::key::SecretKey;
 use grin_wallet_util::grin_util::{from_hex, static_secp_instance};
-use grin_wallet_libwallet::WalletInfo;
 use serde_json;
 
 use std::fs;
@@ -75,7 +75,7 @@ fn owner_v3_lifecycle() -> Result<(), grin_wallet_controller::Error> {
 	thread::spawn(move || {
 		if let Err(e) = wallet_proxy.run() {
 			error!("Wallet Proxy error: {}", e);
-			}
+		}
 	});
 
 	// We have an owner API with no wallet initialized. Init the secure API
@@ -165,8 +165,13 @@ fn owner_v3_lifecycle() -> Result<(), grin_wallet_controller::Error> {
 		}
 	});
 
-	let res =
-		send_request_enc::<RetrieveSummaryInfoResp>(1, 1, "http://127.0.0.1:43420/v3/owner", &req.to_string(), &shared_key)?;
+	let res = send_request_enc::<RetrieveSummaryInfoResp>(
+		1,
+		1,
+		"http://127.0.0.1:43420/v3/owner",
+		&req.to_string(),
+		&shared_key,
+	)?;
 	println!("RES 9: {:?}", res);
 	assert!(res.is_ok());
 

--- a/tests/owner_v3_lifecycle.rs
+++ b/tests/owner_v3_lifecycle.rs
@@ -20,12 +20,13 @@ extern crate log;
 extern crate grin_wallet;
 
 use grin_wallet_api::ECDHPubkey;
-use grin_wallet_impls::test_framework::{LocalWalletClient, WalletProxy};
+use grin_wallet_impls::test_framework::{self, LocalWalletClient, WalletProxy};
 
 use clap::App;
 use std::thread;
 use std::time::Duration;
 
+use grin_wallet_libwallet::{InitTxArgs, Slate, SlateVersion, VersionedSlate};
 use grin_wallet_impls::DefaultLCProvider;
 use grin_wallet_util::grin_keychain::ExtKeychain;
 use serde_json;
@@ -37,14 +38,16 @@ use std::sync::Arc;
 #[macro_use]
 mod common;
 use common::{
-	clean_output_dir, derive_ecdh_key, execute_command_no_setup, send_request, send_request_enc,
-	setup, RetrieveSummaryInfoResp,
+	clean_output_dir, instantiate_wallet, initial_setup_wallet, derive_ecdh_key, execute_command, execute_command_no_setup, send_request, send_request_enc, setup, RetrieveSummaryInfoResp
 };
 
 #[test]
 fn owner_v3_lifecycle() -> Result<(), grin_wallet_controller::Error> {
 	let test_dir = "target/test_output/owner_v3_lifecycle";
 	setup(test_dir);
+
+	let yml = load_yaml!("../src/bin/grin-wallet.yml");
+	let app = App::from_yaml(yml);
 
 	// Create a new proxy to simulate server and wallet responses
 	let wallet_proxy_a: Arc<
@@ -56,12 +59,29 @@ fn owner_v3_lifecycle() -> Result<(), grin_wallet_controller::Error> {
 			>,
 		>,
 	> = Arc::new(Mutex::new(WalletProxy::new(test_dir)));
-	{
-		let wallet_proxy = wallet_proxy_a.lock();
-		let _chain = wallet_proxy.chain.clone();
+	let (chain, wallet2, mask2_i) = {
+		let mut wallet_proxy = wallet_proxy_a.lock();
+		let chain = wallet_proxy.chain.clone();
+
+		// Create wallet 2 manually, which will mine a bit and insert some
+		// grins into the equation
+		let client2 = LocalWalletClient::new("wallet2", wallet_proxy.tx.clone());
+		let arg_vec = vec!["grin-wallet", "-p", "password", "init", "-h"];
+		execute_command(&app, test_dir, "wallet2", &client2, arg_vec.clone())?;
+
+		let config2 = initial_setup_wallet(test_dir, "wallet2");
+		//config2.api_listen_port = 23415;
+		let (wallet2, mask2_i) =
+			instantiate_wallet(config2.clone(), client2.clone(), "password", "default")?;
+		wallet_proxy.add_wallet(
+			"wallet2",
+			client2.get_send_instance(),
+			wallet2.clone(),
+			mask2_i.clone(),
+		);
 
 		// start up the owner api with wallet created
-		let arg_vec = vec!["grin-wallet", "owner_api", "-l", "43420"];
+		let arg_vec = vec!["grin-wallet", "owner_api", "-l", "43420", "--run_foreign"];
 		// should create new wallet file
 		let client1 = LocalWalletClient::new("wallet1", wallet_proxy.tx.clone());
 
@@ -88,9 +108,11 @@ fn owner_v3_lifecycle() -> Result<(), grin_wallet_controller::Error> {
 			)
 			.unwrap();
 		});
-	}
+		(chain, wallet2, mask2_i)
+	};
 	// give a bit for wallet to init and populate proxy with wallet via callback in thread above
 	thread::sleep(Duration::from_millis(500));
+	let mask2 = (&mask2_i).as_ref();
 	let wallet_proxy = wallet_proxy_a.clone();
 
 	// Set the wallet proxy listener running
@@ -100,6 +122,11 @@ fn owner_v3_lifecycle() -> Result<(), grin_wallet_controller::Error> {
 			error!("Wallet Proxy error: {}", e);
 		}
 	});
+
+	// mine into wallet 2 a bit
+	let bh = 10u64;
+	let _ =
+		test_framework::award_blocks_to_wallet(&chain, wallet2.clone(), mask2, bh as usize, false);
 
 	// We have an owner API with no wallet initialized. Init the secure API
 	let sec_key_str = "e00dcc4a009e3427c6b1e1a550c538179d46f3827a13ed74c759c860761caf1e";
@@ -219,6 +246,127 @@ fn owner_v3_lifecycle() -> Result<(), grin_wallet_controller::Error> {
 	)?;
 	println!("RES 10: {:?}", res);
 	assert!(res.is_err());
+
+	// 11) Close the wallet
+	let req = include_str!("data/v3_reqs/close_wallet.req.json");
+	let res =
+		send_request_enc::<String>(1, 1, "http://127.0.0.1:43420/v3/owner", &req, &shared_key)?;
+	println!("RES 11: {:?}", res);
+	assert!(res.is_ok());
+
+	// 12) Wallet is closed
+	let req = serde_json::json!({
+		"jsonrpc": "2.0",
+		"id": 1,
+		"method": "retrieve_summary_info",
+		"params": {
+			"token": token,
+			"refresh_from_node": true,
+			"minimum_confirmations": 1
+		}
+	});
+
+	let res = send_request_enc::<RetrieveSummaryInfoResp>(
+		1,
+		1,
+		"http://127.0.0.1:43420/v3/owner",
+		&req.to_string(),
+		&shared_key,
+	)?;
+	println!("RES 12: {:?}", res);
+	assert!(res.is_err());
+
+	// 13) Open the wallet again
+	let req = include_str!("data/v3_reqs/open_wallet.req.json");
+	let res =
+		send_request_enc::<String>(1, 1, "http://127.0.0.1:43420/v3/owner", &req, &shared_key)?;
+	println!("RES 13: {:?}", res);
+	assert!(res.is_ok());
+	let token = res.unwrap();
+
+	// 14) Send a request with our new token
+	let req = serde_json::json!({
+		"jsonrpc": "2.0",
+		"id": 1,
+		"method": "retrieve_summary_info",
+		"params": {
+			"token": token,
+			"refresh_from_node": true,
+			"minimum_confirmations": 1
+		}
+	});
+	let res = send_request_enc::<RetrieveSummaryInfoResp>(
+		1,
+		1,
+		"http://127.0.0.1:43420/v3/owner",
+		&req.to_string(),
+		&shared_key,
+	)?;
+	println!("RES 14: {:?}", res);
+	assert!(res.is_ok());
+
+	//15) Ask wallet 2 for some grins
+	let req = serde_json::json!({
+		"jsonrpc": "2.0",
+		"id": 1,
+		"method": "issue_invoice_tx",
+		"params": {
+			"token": token,
+			"args": {
+				"amount": "6000000000",
+				"message": "geez a block of grins",
+				"dest_acct_name": null,
+				"target_slate_version": null
+			}
+		}
+	});
+	let res = send_request_enc::<VersionedSlate>(
+		1,
+		1,
+		"http://127.0.0.1:43420/v3/owner",
+		&req.to_string(),
+		&shared_key,
+	)?;
+	println!("RES 15: {:?}", res);
+	assert!(res.is_ok());
+	let mut slate:Slate = res.unwrap().into();
+
+	// give this slate over to wallet 2 manually
+	grin_wallet_controller::controller::owner_single_use(wallet2.clone(), mask2, |api, m| {
+		let args = InitTxArgs {
+			src_acct_name: None,
+			amount: slate.amount,
+			minimum_confirmations: 1,
+			max_outputs: 500,
+			num_change_outputs: 1,
+			selection_strategy_is_use_all: false,
+			..Default::default()
+		};
+		let res = api.process_invoice_tx(m, &slate, args);
+		assert!(res.is_ok());
+		slate = res.unwrap();
+		api.tx_lock_outputs(m, &slate, 0)?;
+
+		Ok(())
+	})?;
+
+	//16) Finalize the invoice tx (to foreign api)
+	// (Tests that foreign API on same port also has its stored mask updated)
+	let req = serde_json::json!({
+		"jsonrpc": "2.0",
+		"id": 1,
+		"method": "finalize_invoice_tx",
+		"params": {
+			"slate": VersionedSlate::into_version(slate, SlateVersion::V2),
+		}
+	});
+	let res = send_request::<VersionedSlate>(
+		1,
+		"http://127.0.0.1:43420/v2/foreign",
+		&req.to_string(),
+	)?;
+	println!("RES 16: {:?}", res);
+	assert!(res.is_ok());
 
 	thread::sleep(Duration::from_millis(200));
 	clean_output_dir(test_dir);


### PR DESCRIPTION
WIP, aims to add to the V3 API:

* `set/get_top_level_directory`
* `create_config_file`
* `open_wallet`
* `close_wallet`

Also of note:

* Changes V3 API to return properly formatted JSON-RPC error responses for internal errors (instead of V2 `OK` json_rpc response containing an error string)
* Allows the wallet `owner_api` to run without a wallet or wallet configuration file being present anywhere