### PR TITLE
API Token Fixes

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -581,7 +581,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 [[package]]
 name = "grin_api"
 version = "2.0.1-beta.1"
-source = "git+https://github.com/mimblewimble/grin#ea023387bfa4f1493cc57f120205a09251468e60"
+source = "git+https://github.com/mimblewimble/grin#108b640c228b10ef41d37159316b10842c6a6c17"
 dependencies = [
  "failure 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)",
  "failure_derive 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -613,7 +613,7 @@ dependencies = [
 [[package]]
 name = "grin_chain"
 version = "2.0.1-beta.1"
-source = "git+https://github.com/mimblewimble/grin#ea023387bfa4f1493cc57f120205a09251468e60"
+source = "git+https://github.com/mimblewimble/grin#108b640c228b10ef41d37159316b10842c6a6c17"
 dependencies = [
  "bitflags 1.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "byteorder 1.3.2 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -636,7 +636,7 @@ dependencies = [
 [[package]]
 name = "grin_core"
 version = "2.0.1-beta.1"
-source = "git+https://github.com/mimblewimble/grin#ea023387bfa4f1493cc57f120205a09251468e60"
+source = "git+https://github.com/mimblewimble/grin#108b640c228b10ef41d37159316b10842c6a6c17"
 dependencies = [
  "blake2-rfc 0.2.18 (registry+https://github.com/rust-lang/crates.io-index)",
  "byteorder 1.3.2 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -663,7 +663,7 @@ dependencies = [
 [[package]]
 name = "grin_keychain"
 version = "2.0.1-beta.1"
-source = "git+https://github.com/mimblewimble/grin#ea023387bfa4f1493cc57f120205a09251468e60"
+source = "git+https://github.com/mimblewimble/grin#108b640c228b10ef41d37159316b10842c6a6c17"
 dependencies = [
  "blake2-rfc 0.2.18 (registry+https://github.com/rust-lang/crates.io-index)",
  "byteorder 1.3.2 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -686,7 +686,7 @@ dependencies = [
 [[package]]
 name = "grin_p2p"
 version = "2.0.1-beta.1"
-source = "git+https://github.com/mimblewimble/grin#ea023387bfa4f1493cc57f120205a09251468e60"
+source = "git+https://github.com/mimblewimble/grin#108b640c228b10ef41d37159316b10842c6a6c17"
 dependencies = [
  "bitflags 1.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "bytes 0.4.12 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -708,7 +708,7 @@ dependencies = [
 [[package]]
 name = "grin_pool"
 version = "2.0.1-beta.1"
-source = "git+https://github.com/mimblewimble/grin#ea023387bfa4f1493cc57f120205a09251468e60"
+source = "git+https://github.com/mimblewimble/grin#108b640c228b10ef41d37159316b10842c6a6c17"
 dependencies = [
  "blake2-rfc 0.2.18 (registry+https://github.com/rust-lang/crates.io-index)",
  "chrono 0.4.7 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -742,7 +742,7 @@ dependencies = [
 [[package]]
 name = "grin_store"
 version = "2.0.1-beta.1"
-source = "git+https://github.com/mimblewimble/grin#ea023387bfa4f1493cc57f120205a09251468e60"
+source = "git+https://github.com/mimblewimble/grin#108b640c228b10ef41d37159316b10842c6a6c17"
 dependencies = [
  "byteorder 1.3.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "croaring 0.3.9 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -763,7 +763,7 @@ dependencies = [
 [[package]]
 name = "grin_util"
 version = "2.0.1-beta.1"
-source = "git+https://github.com/mimblewimble/grin#ea023387bfa4f1493cc57f120205a09251468e60"
+source = "git+https://github.com/mimblewimble/grin#108b640c228b10ef41d37159316b10842c6a6c17"
 dependencies = [
  "backtrace 0.3.34 (registry+https://github.com/rust-lang/crates.io-index)",
  "base64 0.9.3 (registry+https://github.com/rust-lang/crates.io-index)",

--- a/config/src/config.rs
+++ b/config/src/config.rs
@@ -37,8 +37,10 @@ const WALLET_LOG_FILE_NAME: &'static str = "grin-wallet.log";
 const GRIN_HOME: &'static str = ".grin";
 /// Wallet data directory
 pub const GRIN_WALLET_DIR: &'static str = "wallet_data";
-/// API secret
+/// Node API secret
 pub const API_SECRET_FILE_NAME: &'static str = ".api_secret";
+/// Owner API secret
+pub const OWNER_API_SECRET_FILE_NAME: &'static str = ".owner_api_secret";
 
 fn get_grin_path(chain_type: &global::ChainTypes) -> Result<PathBuf, ConfigError> {
 	// Check if grin dir exists
@@ -98,13 +100,14 @@ pub fn check_api_secret(api_secret_path: &PathBuf) -> Result<(), ConfigError> {
 fn check_api_secret_file(
 	chain_type: &global::ChainTypes,
 	data_path: Option<PathBuf>,
+	file_name: &str,
 ) -> Result<(), ConfigError> {
 	let grin_path = match data_path {
 		Some(p) => p,
 		None => get_grin_path(chain_type)?,
 	};
 	let mut api_secret_path = grin_path.clone();
-	api_secret_path.push(API_SECRET_FILE_NAME);
+	api_secret_path.push(file_name);
 	if !api_secret_path.exists() {
 		init_api_secret(&api_secret_path)
 	} else {
@@ -117,7 +120,8 @@ pub fn initial_setup_wallet(
 	chain_type: &global::ChainTypes,
 	data_path: Option<PathBuf>,
 ) -> Result<GlobalWalletConfig, ConfigError> {
-	check_api_secret_file(chain_type, data_path.clone())?;
+	check_api_secret_file(chain_type, data_path.clone(), OWNER_API_SECRET_FILE_NAME)?;
+	check_api_secret_file(chain_type, data_path.clone(), API_SECRET_FILE_NAME)?;
 	// Use config file if current directory if it exists, .grin home otherwise
 	if let Some(p) = check_config_current_dir(WALLET_CONFIG_FILE_NAME) {
 		GlobalWalletConfig::new(p.to_str().unwrap())
@@ -237,7 +241,7 @@ impl GlobalWalletConfig {
 		self.members.as_mut().unwrap().wallet.data_file_dir =
 			wallet_path.to_str().unwrap().to_owned();
 		let mut secret_path = wallet_home.clone();
-		secret_path.push(API_SECRET_FILE_NAME);
+		secret_path.push(OWNER_API_SECRET_FILE_NAME);
 		self.members.as_mut().unwrap().wallet.api_secret_path =
 			Some(secret_path.to_str().unwrap().to_owned());
 		let mut node_secret_path = wallet_home.clone();

--- a/config/src/types.rs
+++ b/config/src/types.rs
@@ -65,7 +65,7 @@ impl Default for WalletConfig {
 			api_listen_interface: "127.0.0.1".to_string(),
 			api_listen_port: 3415,
 			owner_api_listen_port: Some(WalletConfig::default_owner_api_listen_port()),
-			api_secret_path: Some(".api_secret".to_string()),
+			api_secret_path: Some(".owner_api_secret".to_string()),
 			node_api_secret_path: Some(".api_secret".to_string()),
 			check_node_api_http_addr: "http://127.0.0.1:3413".to_string(),
 			owner_api_include_foreign: Some(false),

--- a/controller/src/command.rs
+++ b/controller/src/command.rs
@@ -45,6 +45,7 @@ fn show_recovery_phrase(phrase: ZeroingString) {
 #[derive(Clone)]
 pub struct GlobalArgs {
 	pub account: String,
+	pub api_secret: Option<String>,
 	pub node_api_secret: Option<String>,
 	pub show_spent: bool,
 	pub chain_type: global::ChainTypes,
@@ -178,7 +179,7 @@ where
 		wallet,
 		km,
 		config.owner_api_listen_addr().as_str(),
-		g_args.node_api_secret.clone(),
+		g_args.api_secret.clone(),
 		g_args.tls_conf.clone(),
 		config.owner_api_include_foreign.clone(),
 	);

--- a/controller/src/controller.rs
+++ b/controller/src/controller.rs
@@ -137,6 +137,7 @@ where
 		let basic_auth_middleware = Arc::new(BasicAuthMiddleware::new(
 			api_basic_auth,
 			&GRIN_OWNER_BASIC_REALM,
+			Some("/v2/foreign".into()),
 		));
 		router.add_middleware(basic_auth_middleware);
 	}

--- a/impls/src/backends/lmdb.rs
+++ b/impls/src/backends/lmdb.rs
@@ -296,7 +296,7 @@ where
 			Some(i) => to_key_u64(OUTPUT_PREFIX, &mut id.to_bytes().to_vec(), *i),
 			None => to_key(OUTPUT_PREFIX, &mut id.to_bytes().to_vec()),
 		};
-		option_to_not_found(self.db.get_ser(&key), &format!("Key Id: {}", id)).map_err(|e| e.into())
+		option_to_not_found(self.db.get_ser(&key), ||{format!("Key Id: {}", id)}).map_err(|e| e.into())
 	}
 
 	fn iter<'a>(&'a self) -> Box<dyn Iterator<Item = OutputData> + 'a> {
@@ -328,7 +328,7 @@ where
 
 		let mut ctx: Context = option_to_not_found(
 			self.db.get_ser(&ctx_key),
-			&format!("Slate id: {:x?}", slate_id.to_vec()),
+			||{format!("Slate id: {:x?}", slate_id.to_vec())},
 		)?;
 
 		for i in 0..SECRET_KEY_SIZE {
@@ -487,7 +487,7 @@ where
 		};
 		option_to_not_found(
 			self.db.borrow().as_ref().unwrap().get_ser(&key),
-			&format!("Key ID: {}", id),
+			||{format!("Key ID: {}", id)},
 		)
 		.map_err(|e| e.into())
 	}

--- a/impls/src/backends/lmdb.rs
+++ b/impls/src/backends/lmdb.rs
@@ -296,7 +296,8 @@ where
 			Some(i) => to_key_u64(OUTPUT_PREFIX, &mut id.to_bytes().to_vec(), *i),
 			None => to_key(OUTPUT_PREFIX, &mut id.to_bytes().to_vec()),
 		};
-		option_to_not_found(self.db.get_ser(&key), ||{format!("Key Id: {}", id)}).map_err(|e| e.into())
+		option_to_not_found(self.db.get_ser(&key), || format!("Key Id: {}", id))
+			.map_err(|e| e.into())
 	}
 
 	fn iter<'a>(&'a self) -> Box<dyn Iterator<Item = OutputData> + 'a> {
@@ -326,10 +327,9 @@ where
 		let (blind_xor_key, nonce_xor_key) =
 			private_ctx_xor_keys(&self.keychain(keychain_mask)?, slate_id)?;
 
-		let mut ctx: Context = option_to_not_found(
-			self.db.get_ser(&ctx_key),
-			||{format!("Slate id: {:x?}", slate_id.to_vec())},
-		)?;
+		let mut ctx: Context = option_to_not_found(self.db.get_ser(&ctx_key), || {
+			format!("Slate id: {:x?}", slate_id.to_vec())
+		})?;
 
 		for i in 0..SECRET_KEY_SIZE {
 			ctx.sec_key.0[i] = ctx.sec_key.0[i] ^ blind_xor_key[i];
@@ -485,10 +485,9 @@ where
 			Some(i) => to_key_u64(OUTPUT_PREFIX, &mut id.to_bytes().to_vec(), *i),
 			None => to_key(OUTPUT_PREFIX, &mut id.to_bytes().to_vec()),
 		};
-		option_to_not_found(
-			self.db.borrow().as_ref().unwrap().get_ser(&key),
-			||{format!("Key ID: {}", id)},
-		)
+		option_to_not_found(self.db.borrow().as_ref().unwrap().get_ser(&key), || {
+			format!("Key ID: {}", id)
+		})
 		.map_err(|e| e.into())
 	}
 

--- a/src/cmd/wallet_args.rs
+++ b/src/cmd/wallet_args.rs
@@ -265,6 +265,7 @@ pub fn parse_global_args(
 	if args.is_present("show_spent") {
 		show_spent = true;
 	}
+	let api_secret = get_first_line(config.api_secret_path.clone());
 	let node_api_secret = get_first_line(config.node_api_secret_path.clone());
 	let password = match args.value_of("pass") {
 		None => None,
@@ -297,6 +298,7 @@ pub fn parse_global_args(
 		account: account.to_owned(),
 		show_spent: show_spent,
 		chain_type: chain_type,
+		api_secret: api_secret,
 		node_api_secret: node_api_secret,
 		password: password,
 		tls_conf: tls_conf,


### PR DESCRIPTION
* Splits API token into an explicit owner api token and node_api token, ensures they operate independently of each other
* When owner API and foreign API are run on the same port, drop the authentication requirement for the foreign API (requires https://github.com/mimblewimble/grin/pull/3037)
* Also updates `option_to_not_found` function calls to latest form on grin master

Addresses all known outstanding Auth issues: #183, #203, #93 

On release, users may have to re-organize their API tokens, this needs to be clearly stated in release notes along with instructions. Notes are:

* Upon wallet creation, the wallet now creates 2 files in the wallet directory: `.api_secret` and `.owner_api_secret`
* `.api_secret` is the secret shared with the node for wallet to node communication. Previous versions used this file for both node communication and Owner API authentication. This file should now only be used for the node secret and users should update files/paths in `grin-wallet.toml` accordingly
* `.owner_api_secret` is now used only to authenticate the Owner API.
* In `grin-wallet.toml`, `api_secret_path` corresponds to the Owner API secret file (`.owner_api_secret by default), while `node_api_secret_path` corresponds to the node secret file (`.api_secret` by default)
* When running the owner and foreign apis on the same port via the `owner_api_include_foreign` option in `grin-wallet.toml`, the foreign API no longer requires the Owner API authentication secret.