### PR TITLE
use explicit protocol version (local is not safe)

### DIFF
--- a/impls/src/backends/lmdb.rs
+++ b/impls/src/backends/lmdb.rs
@@ -360,7 +360,7 @@ where
 			.join(filename);
 		let path_buf = Path::new(&path).to_path_buf();
 		let mut stored_tx = File::create(path_buf)?;
-		let tx_hex = util::to_hex(ser::ser_vec(tx, ser::ProtocolVersion::local()).unwrap());;
+		let tx_hex = util::to_hex(ser::ser_vec(tx, ser::ProtocolVersion(1)).unwrap());;
 		stored_tx.write_all(&tx_hex.as_bytes())?;
 		stored_tx.sync_all()?;
 		Ok(())
@@ -380,8 +380,7 @@ where
 		tx_f.read_to_string(&mut content)?;
 		let tx_bin = util::from_hex(content).unwrap();
 		Ok(Some(
-			ser::deserialize::<Transaction>(&mut &tx_bin[..], ser::ProtocolVersion::local())
-				.unwrap(),
+			ser::deserialize::<Transaction>(&mut &tx_bin[..], ser::ProtocolVersion(1)).unwrap(),
 		))
 	}
 

--- a/impls/src/test_framework/testclient.rs
+++ b/impls/src/test_framework/testclient.rs
@@ -185,10 +185,9 @@ where
 			libwallet::ErrorKind::ClientCallback("Error parsing TxWrapper: tx_bin".to_owned()),
 		)?;
 
-		let tx: Transaction = ser::deserialize(&mut &tx_bin[..], ser::ProtocolVersion::local())
-			.context(libwallet::ErrorKind::ClientCallback(
-				"Error parsing TxWrapper: tx".to_owned(),
-			))?;
+		let tx: Transaction = ser::deserialize(&mut &tx_bin[..], ser::ProtocolVersion(1)).context(
+			libwallet::ErrorKind::ClientCallback("Error parsing TxWrapper: tx".to_owned()),
+		)?;
 
 		super::award_block_to_wallet(
 			&self.chain,

--- a/libwallet/src/api_impl/owner.rs
+++ b/libwallet/src/api_impl/owner.rs
@@ -448,7 +448,7 @@ pub fn post_tx<'a, C>(client: &C, tx: &Transaction, fluff: bool) -> Result<(), E
 where
 	C: NodeClient + 'a,
 {
-	let tx_hex = grin_util::to_hex(ser::ser_vec(tx, ser::ProtocolVersion::local()).unwrap());
+	let tx_hex = grin_util::to_hex(ser::ser_vec(tx, ser::ProtocolVersion(1)).unwrap());
 	let res = client.post_tx(&TxWrapper { tx_hex: tx_hex }, fluff);
 	if let Err(e) = res {
 		error!("api: post_tx: failed with error: {}", e);


### PR DESCRIPTION
This is a bit tricky.

A 2.1.0 node uses protocol version 2 internally via `ProtocolVersion::local()`.
But for backward compatibility expects txs via the push api (from the wallet) in proto version 1.

Building grin-wallet pulls in `ser` from node repo.
So we cannot use `ProtocolVersion::local()` in the wallet repo.

This only surfaced as an issue once we tagged node and wallet repos and started building against these.

