### PR TITLE
Fix URL Compatibility with 2.0.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -912,7 +912,6 @@ dependencies = [
  "tokio 0.1.11 (registry+https://github.com/rust-lang/crates.io-index)",
  "tokio-core 0.1.17 (registry+https://github.com/rust-lang/crates.io-index)",
  "tokio-retry 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "url 1.7.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "uuid 0.7.4 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 

--- a/impls/Cargo.toml
+++ b/impls/Cargo.toml
@@ -26,7 +26,6 @@ tokio-core = "0.1"
 tokio-retry = "0.1"
 uuid = { version = "0.7", features = ["serde", "v4"] }
 chrono = { version = "0.4.4", features = ["serde"] }
-url = "1.7.2"
 
 grin_wallet_util = { path = "../util", version = "3.0.0-alpha.1" }
 grin_wallet_config = { path = "../config", version = "3.0.0-alpha.1" }

--- a/impls/src/adapters/http.rs
+++ b/impls/src/adapters/http.rs
@@ -18,25 +18,26 @@ use crate::libwallet::{Error, ErrorKind, Slate};
 use crate::SlateSender;
 use serde::Serialize;
 use serde_json::{json, Value};
-use url::Url;
 
 #[derive(Clone)]
 pub struct HttpSlateSender {
-	base_url: Url,
+	base_url: String,
 }
 
 impl HttpSlateSender {
 	/// Create, return Err if scheme is not "http"
-	pub fn new(base_url: Url) -> Result<HttpSlateSender, SchemeNotHttp> {
-		if base_url.scheme() != "http" && base_url.scheme() != "https" {
+	pub fn new(base_url: &str) -> Result<HttpSlateSender, SchemeNotHttp> {
+		if !base_url.starts_with("http") && !base_url.starts_with("https") {
 			Err(SchemeNotHttp)
 		} else {
-			Ok(HttpSlateSender { base_url })
+			Ok(HttpSlateSender {
+				base_url: base_url.to_owned()
+			})
 		}
 	}
 
 	/// Check version of the listening wallet
-	fn check_other_version(&self, url: &Url) -> Result<(), Error> {
+	fn check_other_version(&self, url: &str) -> Result<(), Error> {
 		let req = json!({
 			"jsonrpc": "2.0",
 			"method": "check_version",
@@ -95,15 +96,15 @@ impl HttpSlateSender {
 
 impl SlateSender for HttpSlateSender {
 	fn send_tx(&self, slate: &Slate) -> Result<Slate, Error> {
-		let mut path_str = self.base_url.path().to_owned();
-		path_str = format!("{}v2/foreign", path_str);
-		let url: Url = self
-			.base_url
-			.join(&path_str)
-			.expect("/v2/foreign is an invalid url path");
-		debug!("Posting transaction slate to {}", url);
+		let trailing = match self.base_url.ends_with('/') {
+			true => "",
+			false => "/",
+		};
+		let url_str = format!("{}{}v2/foreign", self.base_url, trailing);
 
-		self.check_other_version(&url)?;
+		debug!("Posting transaction slate to {}", url_str);
+
+		self.check_other_version(&url_str)?;
 
 		// Note: not using easy-jsonrpc as don't want the dependencies in this crate
 		let req = json!({
@@ -118,7 +119,7 @@ impl SlateSender for HttpSlateSender {
 		});
 		trace!("Sending receive_tx request: {}", req);
 
-		let res: String = post(&url, None, &req).map_err(|e| {
+		let res: String = post(&url_str, None, &req).map_err(|e| {
 			let report = format!("Posting transaction slate (is recipient listening?): {}", e);
 			error!("{}", report);
 			ErrorKind::ClientCallback(report)
@@ -154,12 +155,12 @@ impl Into<Error> for SchemeNotHttp {
 	}
 }
 
-pub fn post<IN>(url: &Url, api_secret: Option<String>, input: &IN) -> Result<String, api::Error>
+pub fn post<IN>(url: &str, api_secret: Option<String>, input: &IN) -> Result<String, api::Error>
 where
 	IN: Serialize,
 {
 	// TODO: change create_post_request to accept a url instead of a &str
-	let req = api::client::create_post_request(url.as_str(), api_secret, input)?;
+	let req = api::client::create_post_request(url, api_secret, input)?;
 	let res = api::client::send_request(req)?;
 	Ok(res)
 }

--- a/impls/src/adapters/http.rs
+++ b/impls/src/adapters/http.rs
@@ -95,9 +95,10 @@ impl HttpSlateSender {
 
 impl SlateSender for HttpSlateSender {
 	fn send_tx(&self, slate: &Slate) -> Result<Slate, Error> {
-		let url: Url = self
-			.base_url
-			.join("/v2/foreign")
+		let mut path_str = self.base_url.path().to_owned();
+		path_str = format!("{}v2/foreign", path_str);
+		let url: Url = self.base_url
+			.join(&path_str)
 			.expect("/v2/foreign is an invalid url path");
 		debug!("Posting transaction slate to {}", url);
 

--- a/impls/src/adapters/http.rs
+++ b/impls/src/adapters/http.rs
@@ -31,7 +31,7 @@ impl HttpSlateSender {
 			Err(SchemeNotHttp)
 		} else {
 			Ok(HttpSlateSender {
-				base_url: base_url.to_owned()
+				base_url: base_url.to_owned(),
 			})
 		}
 	}

--- a/impls/src/adapters/http.rs
+++ b/impls/src/adapters/http.rs
@@ -97,7 +97,8 @@ impl SlateSender for HttpSlateSender {
 	fn send_tx(&self, slate: &Slate) -> Result<Slate, Error> {
 		let mut path_str = self.base_url.path().to_owned();
 		path_str = format!("{}v2/foreign", path_str);
-		let url: Url = self.base_url
+		let url: Url = self
+			.base_url
 			.join(&path_str)
 			.expect("/v2/foreign is an invalid url path");
 		debug!("Posting transaction slate to {}", url);

--- a/impls/src/adapters/mod.rs
+++ b/impls/src/adapters/mod.rs
@@ -58,7 +58,6 @@ pub trait SlateGetter {
 
 /// select a SlateSender based on method and dest fields from, e.g., SendArgs
 pub fn create_sender(method: &str, dest: &str) -> Result<Box<dyn SlateSender>, Error> {
-	use url::Url;
 
 	let invalid = || {
 		ErrorKind::WalletComms(format!(
@@ -68,8 +67,7 @@ pub fn create_sender(method: &str, dest: &str) -> Result<Box<dyn SlateSender>, E
 	};
 	Ok(match method {
 		"http" => {
-			let url: Url = dest.parse().map_err(|_| invalid())?;
-			Box::new(HttpSlateSender::new(url).map_err(|_| invalid())?)
+			Box::new(HttpSlateSender::new(dest).map_err(|_| invalid())?)
 		}
 		"keybase" => Box::new(KeybaseChannel::new(dest.to_owned())?),
 		"self" => {

--- a/impls/src/adapters/mod.rs
+++ b/impls/src/adapters/mod.rs
@@ -58,7 +58,6 @@ pub trait SlateGetter {
 
 /// select a SlateSender based on method and dest fields from, e.g., SendArgs
 pub fn create_sender(method: &str, dest: &str) -> Result<Box<dyn SlateSender>, Error> {
-
 	let invalid = || {
 		ErrorKind::WalletComms(format!(
 			"Invalid wallet comm type and destination. method: {}, dest: {}",
@@ -66,9 +65,7 @@ pub fn create_sender(method: &str, dest: &str) -> Result<Box<dyn SlateSender>, E
 		))
 	};
 	Ok(match method {
-		"http" => {
-			Box::new(HttpSlateSender::new(dest).map_err(|_| invalid())?)
-		}
+		"http" => Box::new(HttpSlateSender::new(dest).map_err(|_| invalid())?),
 		"keybase" => Box::new(KeybaseChannel::new(dest.to_owned())?),
 		"self" => {
 			return Err(ErrorKind::WalletComms(


### PR DESCRIPTION
Unintended consequence of earlier changes to how urls are handled meant that everything but the base URL was being stripped when sending to another wallet. This fix reverts to earlier behaviour, keeping the entire URL+Path intact.

Going to merge into master first, then cherry-pick into the `current/2.1.x` branch