### PR TITLE
2.1.0 TX log entries backwards compatibility fix

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -798,7 +798,7 @@ dependencies = [
 
 [[package]]
 name = "grin_wallet"
-version = "2.1.0-beta.4"
+version = "2.1.0-beta.5"
 dependencies = [
  "built 0.3.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "clap 2.33.0 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -806,12 +806,12 @@ dependencies = [
  "easy-jsonrpc 0.5.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "failure 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)",
  "failure_derive 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)",
- "grin_wallet_api 2.1.0-beta.4",
- "grin_wallet_config 2.1.0-beta.4",
- "grin_wallet_controller 2.1.0-beta.4",
- "grin_wallet_impls 2.1.0-beta.4",
- "grin_wallet_libwallet 2.1.0-beta.4",
- "grin_wallet_util 2.1.0-beta.4",
+ "grin_wallet_api 2.1.0-beta.5",
+ "grin_wallet_config 2.1.0-beta.5",
+ "grin_wallet_controller 2.1.0-beta.5",
+ "grin_wallet_impls 2.1.0-beta.5",
+ "grin_wallet_libwallet 2.1.0-beta.5",
+ "grin_wallet_util 2.1.0-beta.5",
  "linefeed 0.5.4 (registry+https://github.com/rust-lang/crates.io-index)",
  "log 0.4.8 (registry+https://github.com/rust-lang/crates.io-index)",
  "prettytable-rs 0.7.0 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -825,17 +825,17 @@ dependencies = [
 
 [[package]]
 name = "grin_wallet_api"
-version = "2.1.0-beta.4"
+version = "2.1.0-beta.5"
 dependencies = [
  "base64 0.9.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "chrono 0.4.9 (registry+https://github.com/rust-lang/crates.io-index)",
  "easy-jsonrpc-mw 0.5.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "failure 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)",
  "failure_derive 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)",
- "grin_wallet_config 2.1.0-beta.4",
- "grin_wallet_impls 2.1.0-beta.4",
- "grin_wallet_libwallet 2.1.0-beta.4",
- "grin_wallet_util 2.1.0-beta.4",
+ "grin_wallet_config 2.1.0-beta.5",
+ "grin_wallet_impls 2.1.0-beta.5",
+ "grin_wallet_libwallet 2.1.0-beta.5",
+ "grin_wallet_util 2.1.0-beta.5",
  "log 0.4.8 (registry+https://github.com/rust-lang/crates.io-index)",
  "rand 0.5.6 (registry+https://github.com/rust-lang/crates.io-index)",
  "ring 0.13.5 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -848,10 +848,10 @@ dependencies = [
 
 [[package]]
 name = "grin_wallet_config"
-version = "2.1.0-beta.4"
+version = "2.1.0-beta.5"
 dependencies = [
  "dirs 1.0.5 (registry+https://github.com/rust-lang/crates.io-index)",
- "grin_wallet_util 2.1.0-beta.4",
+ "grin_wallet_util 2.1.0-beta.5",
  "pretty_assertions 0.5.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "rand 0.5.6 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde 1.0.100 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -861,18 +861,18 @@ dependencies = [
 
 [[package]]
 name = "grin_wallet_controller"
-version = "2.1.0-beta.4"
+version = "2.1.0-beta.5"
 dependencies = [
  "chrono 0.4.9 (registry+https://github.com/rust-lang/crates.io-index)",
  "easy-jsonrpc-mw 0.5.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "failure 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)",
  "failure_derive 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)",
  "futures 0.1.29 (registry+https://github.com/rust-lang/crates.io-index)",
- "grin_wallet_api 2.1.0-beta.4",
- "grin_wallet_config 2.1.0-beta.4",
- "grin_wallet_impls 2.1.0-beta.4",
- "grin_wallet_libwallet 2.1.0-beta.4",
- "grin_wallet_util 2.1.0-beta.4",
+ "grin_wallet_api 2.1.0-beta.5",
+ "grin_wallet_config 2.1.0-beta.5",
+ "grin_wallet_impls 2.1.0-beta.5",
+ "grin_wallet_libwallet 2.1.0-beta.5",
+ "grin_wallet_util 2.1.0-beta.5",
  "hyper 0.12.19 (registry+https://github.com/rust-lang/crates.io-index)",
  "lazy_static 1.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "log 0.4.8 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -892,16 +892,16 @@ dependencies = [
 
 [[package]]
 name = "grin_wallet_impls"
-version = "2.1.0-beta.4"
+version = "2.1.0-beta.5"
 dependencies = [
  "blake2-rfc 0.2.18 (registry+https://github.com/rust-lang/crates.io-index)",
  "chrono 0.4.9 (registry+https://github.com/rust-lang/crates.io-index)",
  "failure 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)",
  "failure_derive 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)",
  "futures 0.1.29 (registry+https://github.com/rust-lang/crates.io-index)",
- "grin_wallet_config 2.1.0-beta.4",
- "grin_wallet_libwallet 2.1.0-beta.4",
- "grin_wallet_util 2.1.0-beta.4",
+ "grin_wallet_config 2.1.0-beta.5",
+ "grin_wallet_libwallet 2.1.0-beta.5",
+ "grin_wallet_util 2.1.0-beta.5",
  "log 0.4.8 (registry+https://github.com/rust-lang/crates.io-index)",
  "rand 0.5.6 (registry+https://github.com/rust-lang/crates.io-index)",
  "ring 0.13.5 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -917,14 +917,14 @@ dependencies = [
 
 [[package]]
 name = "grin_wallet_libwallet"
-version = "2.1.0-beta.4"
+version = "2.1.0-beta.5"
 dependencies = [
  "blake2-rfc 0.2.18 (registry+https://github.com/rust-lang/crates.io-index)",
  "chrono 0.4.9 (registry+https://github.com/rust-lang/crates.io-index)",
  "failure 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)",
  "failure_derive 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)",
- "grin_wallet_config 2.1.0-beta.4",
- "grin_wallet_util 2.1.0-beta.4",
+ "grin_wallet_config 2.1.0-beta.5",
+ "grin_wallet_util 2.1.0-beta.5",
  "lazy_static 1.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "log 0.4.8 (registry+https://github.com/rust-lang/crates.io-index)",
  "rand 0.5.6 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -938,7 +938,7 @@ dependencies = [
 
 [[package]]
 name = "grin_wallet_util"
-version = "2.1.0-beta.4"
+version = "2.1.0-beta.5"
 dependencies = [
  "dirs 1.0.5 (registry+https://github.com/rust-lang/crates.io-index)",
  "grin_api 2.1.0-beta.3 (git+https://github.com/mimblewimble/grin?tag=v2.1.0-beta.3)",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "grin_wallet"
-version = "2.1.0-beta.4"
+version = "2.1.0-beta.5"
 authors = ["Grin Developers <mimblewimble@lists.launchpad.net>"]
 description = "Simple, private and scalable cryptocurrency implementation based on the MimbleWimble chain format."
 license = "Apache-2.0"
@@ -30,13 +30,13 @@ log = "0.4"
 linefeed = "0.5"
 semver = "0.9"
 
-grin_wallet_api = { path = "./api", version = "2.1.0-beta.4" }
-grin_wallet_impls = { path = "./impls", version = "2.1.0-beta.4" }
-grin_wallet_libwallet = { path = "./libwallet", version = "2.1.0-beta.4" }
-grin_wallet_controller = { path = "./controller", version = "2.1.0-beta.4" }
-grin_wallet_config = { path = "./config", version = "2.1.0-beta.4" }
+grin_wallet_api = { path = "./api", version = "2.1.0-beta.5" }
+grin_wallet_impls = { path = "./impls", version = "2.1.0-beta.5" }
+grin_wallet_libwallet = { path = "./libwallet", version = "2.1.0-beta.5" }
+grin_wallet_controller = { path = "./controller", version = "2.1.0-beta.5" }
+grin_wallet_config = { path = "./config", version = "2.1.0-beta.5" }
 
-grin_wallet_util = { path = "./util", version = "2.1.0-beta.4" }
+grin_wallet_util = { path = "./util", version = "2.1.0-beta.5" }
 
 [build-dependencies]
 built = "0.3"

--- a/api/Cargo.toml
+++ b/api/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "grin_wallet_api"
-version = "2.1.0-beta.4"
+version = "2.1.0-beta.5"
 authors = ["Grin Developers <mimblewimble@lists.launchpad.net>"]
 description = "Grin Wallet API"
 license = "Apache-2.0"
@@ -23,10 +23,10 @@ chrono = { version = "0.4.4", features = ["serde"] }
 ring = "0.13"
 base64 = "0.9"
 
-grin_wallet_libwallet = { path = "../libwallet", version = "2.1.0-beta.4" }
-grin_wallet_config = { path = "../config", version = "2.1.0-beta.4" }
-grin_wallet_impls = { path = "../impls", version = "2.1.0-beta.4" }
-grin_wallet_util = { path = "../util", version = "2.1.0-beta.4" }
+grin_wallet_libwallet = { path = "../libwallet", version = "2.1.0-beta.5" }
+grin_wallet_config = { path = "../config", version = "2.1.0-beta.5" }
+grin_wallet_impls = { path = "../impls", version = "2.1.0-beta.5" }
+grin_wallet_util = { path = "../util", version = "2.1.0-beta.5" }
 
 [dev-dependencies]
 serde_json = "1"

--- a/config/Cargo.toml
+++ b/config/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "grin_wallet_config"
-version = "2.1.0-beta.4"
+version = "2.1.0-beta.5"
 authors = ["Grin Developers <mimblewimble@lists.launchpad.net>"]
 description = "Configuration for grin wallet , a simple, private and scalable cryptocurrency implementation based on the MimbleWimble chain format."
 license = "Apache-2.0"
@@ -16,7 +16,7 @@ serde_derive = "1"
 toml = "0.4"
 dirs = "1.0.3"
 
-grin_wallet_util = { path = "../util", version = "2.1.0-beta.4" }
+grin_wallet_util = { path = "../util", version = "2.1.0-beta.5" }
 
 [dev-dependencies]
 pretty_assertions = "0.5.1"

--- a/controller/Cargo.toml
+++ b/controller/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "grin_wallet_controller"
-version = "2.1.0-beta.4"
+version = "2.1.0-beta.5"
 authors = ["Grin Developers <mimblewimble@lists.launchpad.net>"]
 description = "Controllers for grin wallet instantiation"
 license = "Apache-2.0"
@@ -32,9 +32,9 @@ chrono = { version = "0.4.4", features = ["serde"] }
 easy-jsonrpc-mw = "0.5.3"
 lazy_static = "1"
 
-grin_wallet_util = { path = "../util", version = "2.1.0-beta.4" }
+grin_wallet_util = { path = "../util", version = "2.1.0-beta.5" }
 
-grin_wallet_api = { path = "../api", version = "2.1.0-beta.4" }
-grin_wallet_impls = { path = "../impls", version = "2.1.0-beta.4" }
-grin_wallet_libwallet = { path = "../libwallet", version = "2.1.0-beta.4" }
-grin_wallet_config = { path = "../config", version = "2.1.0-beta.4" }
+grin_wallet_api = { path = "../api", version = "2.1.0-beta.5" }
+grin_wallet_impls = { path = "../impls", version = "2.1.0-beta.5" }
+grin_wallet_libwallet = { path = "../libwallet", version = "2.1.0-beta.5" }
+grin_wallet_config = { path = "../config", version = "2.1.0-beta.5" }

--- a/impls/Cargo.toml
+++ b/impls/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "grin_wallet_impls"
-version = "2.1.0-beta.4"
+version = "2.1.0-beta.5"
 authors = ["Grin Developers <mimblewimble@lists.launchpad.net>"]
 description = "Concrete types derived from libwallet traits"
 license = "Apache-2.0"
@@ -27,6 +27,6 @@ tokio-retry = "0.1"
 uuid = { version = "0.7", features = ["serde", "v4"] }
 chrono = { version = "0.4.4", features = ["serde"] }
 
-grin_wallet_util = { path = "../util", version = "2.1.0-beta.4" }
-grin_wallet_config = { path = "../config", version = "2.1.0-beta.4" }
-grin_wallet_libwallet = { path = "../libwallet", version = "2.1.0-beta.4" }
+grin_wallet_util = { path = "../util", version = "2.1.0-beta.5" }
+grin_wallet_config = { path = "../config", version = "2.1.0-beta.5" }
+grin_wallet_libwallet = { path = "../libwallet", version = "2.1.0-beta.5" }

--- a/libwallet/Cargo.toml
+++ b/libwallet/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "grin_wallet_libwallet"
-version = "2.1.0-beta.4"
+version = "2.1.0-beta.5"
 authors = ["Grin Developers <mimblewimble@lists.launchpad.net>"]
 description = "Simple, private and scalable cryptocurrency implementation based on the MimbleWimble chain format."
 license = "Apache-2.0"
@@ -25,5 +25,5 @@ lazy_static = "1"
 strum = "0.15"
 strum_macros = "0.15"
 
-grin_wallet_util = { path = "../util", version = "2.1.0-beta.4" }
-grin_wallet_config = { path = "../config", version = "2.1.0-beta.4" }
+grin_wallet_util = { path = "../util", version = "2.1.0-beta.5" }
+grin_wallet_config = { path = "../config", version = "2.1.0-beta.5" }

--- a/libwallet/src/types.rs
+++ b/libwallet/src/types.rs
@@ -759,9 +759,11 @@ pub struct TxLogEntry {
 	pub stored_tx: Option<String>,
 	/// Associated kernel excess, for later lookup if necessary
 	#[serde(with = "secp_ser::option_commitment_serde")]
+	#[serde(default)]
 	pub kernel_excess: Option<pedersen::Commitment>,
 	/// Height reported when transaction was created, if lookup
 	/// of kernel is necessary
+	#[serde(default)]
 	pub kernel_lookup_min_height: Option<u64>,
 }
 

--- a/util/Cargo.toml
+++ b/util/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "grin_wallet_util"
-version = "2.1.0-beta.4"
+version = "2.1.0-beta.5"
 authors = ["Grin Developers <mimblewimble@lists.launchpad.net>"]
 description = "Util, for generic utilities and to re-export grin crates"
 license = "Apache-2.0"


### PR DESCRIPTION
Fixes backwards compatibility issue discovered when sending to Poloniex with a 2.1.0 wallet. New fields being read from the DB didn't have a Serde default and were silently returning no transaction data when querying transactions created in  < 2.1.0