### PR TITLE
Tx combinator refactor

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -683,7 +683,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 [[package]]
 name = "grin_api"
 version = "3.0.0-alpha.1"
-source = "git+https://github.com/mimblewimble/grin#da2e75299191acd70d4a48bd63c3dcb2cfcc74d2"
+source = "git+https://github.com/mimblewimble/grin#50ce7ba0433e916ddf6154ff64bdd987bd0e68c2"
 dependencies = [
  "failure 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)",
  "failure_derive 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -716,7 +716,7 @@ dependencies = [
 [[package]]
 name = "grin_chain"
 version = "3.0.0-alpha.1"
-source = "git+https://github.com/mimblewimble/grin#da2e75299191acd70d4a48bd63c3dcb2cfcc74d2"
+source = "git+https://github.com/mimblewimble/grin#50ce7ba0433e916ddf6154ff64bdd987bd0e68c2"
 dependencies = [
  "bitflags 1.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "byteorder 1.3.2 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -739,7 +739,7 @@ dependencies = [
 [[package]]
 name = "grin_core"
 version = "3.0.0-alpha.1"
-source = "git+https://github.com/mimblewimble/grin#da2e75299191acd70d4a48bd63c3dcb2cfcc74d2"
+source = "git+https://github.com/mimblewimble/grin#50ce7ba0433e916ddf6154ff64bdd987bd0e68c2"
 dependencies = [
  "blake2-rfc 0.2.18 (registry+https://github.com/rust-lang/crates.io-index)",
  "byteorder 1.3.2 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -766,7 +766,7 @@ dependencies = [
 [[package]]
 name = "grin_keychain"
 version = "3.0.0-alpha.1"
-source = "git+https://github.com/mimblewimble/grin#da2e75299191acd70d4a48bd63c3dcb2cfcc74d2"
+source = "git+https://github.com/mimblewimble/grin#50ce7ba0433e916ddf6154ff64bdd987bd0e68c2"
 dependencies = [
  "blake2-rfc 0.2.18 (registry+https://github.com/rust-lang/crates.io-index)",
  "byteorder 1.3.2 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -789,7 +789,7 @@ dependencies = [
 [[package]]
 name = "grin_p2p"
 version = "3.0.0-alpha.1"
-source = "git+https://github.com/mimblewimble/grin#da2e75299191acd70d4a48bd63c3dcb2cfcc74d2"
+source = "git+https://github.com/mimblewimble/grin#50ce7ba0433e916ddf6154ff64bdd987bd0e68c2"
 dependencies = [
  "bitflags 1.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "bytes 0.4.12 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -812,7 +812,7 @@ dependencies = [
 [[package]]
 name = "grin_pool"
 version = "3.0.0-alpha.1"
-source = "git+https://github.com/mimblewimble/grin#da2e75299191acd70d4a48bd63c3dcb2cfcc74d2"
+source = "git+https://github.com/mimblewimble/grin#50ce7ba0433e916ddf6154ff64bdd987bd0e68c2"
 dependencies = [
  "blake2-rfc 0.2.18 (registry+https://github.com/rust-lang/crates.io-index)",
  "chrono 0.4.9 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -846,7 +846,7 @@ dependencies = [
 [[package]]
 name = "grin_store"
 version = "3.0.0-alpha.1"
-source = "git+https://github.com/mimblewimble/grin#da2e75299191acd70d4a48bd63c3dcb2cfcc74d2"
+source = "git+https://github.com/mimblewimble/grin#50ce7ba0433e916ddf6154ff64bdd987bd0e68c2"
 dependencies = [
  "byteorder 1.3.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "croaring 0.3.9 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -867,7 +867,7 @@ dependencies = [
 [[package]]
 name = "grin_util"
 version = "3.0.0-alpha.1"
-source = "git+https://github.com/mimblewimble/grin#da2e75299191acd70d4a48bd63c3dcb2cfcc74d2"
+source = "git+https://github.com/mimblewimble/grin#50ce7ba0433e916ddf6154ff64bdd987bd0e68c2"
 dependencies = [
  "backtrace 0.3.38 (registry+https://github.com/rust-lang/crates.io-index)",
  "base64 0.9.3 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -1570,7 +1570,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "num-integer 0.1.41 (registry+https://github.com/rust-lang/crates.io-index)",
  "num-traits 0.2.8 (registry+https://github.com/rust-lang/crates.io-index)",
- "rand 0.4.6 (registry+https://github.com/rust-lang/crates.io-index)",
+ "rand 0.3.23 (registry+https://github.com/rust-lang/crates.io-index)",
  "rustc-serialize 0.3.24 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 

--- a/libwallet/src/internal/selection.rs
+++ b/libwallet/src/internal/selection.rs
@@ -15,7 +15,7 @@
 //! Selection of inputs for building transactions
 
 use crate::error::{Error, ErrorKind};
-use crate::grin_core::core::amount_to_hr_string;
+use crate::grin_core::core::{amount_to_hr_string, KernelFeatures, TxKernel};
 use crate::grin_core::libtx::{
 	build,
 	proof::{ProofBuild, ProofBuilder},
@@ -56,15 +56,23 @@ where
 		slate.amount,
 		slate.height,
 		minimum_confirmations,
-		slate.lock_height,
 		max_outputs,
 		change_outputs,
 		selection_strategy_is_use_all,
 		&parent_key_id,
 	)?;
-	let blinding = slate.add_transaction_elements(keychain, &ProofBuilder::new(keychain), elems)?;
 
-	slate.fee = fee;
+	// Update the fee on both the slate *and* the underlying tx.
+	// Need to think through how we would support lock_height here.
+	{
+		slate.fee = fee;
+		slate.tx = slate
+			.tx
+			.clone()
+			.replace_kernel(TxKernel::with_features(KernelFeatures::Plain { fee }));
+	}
+
+	let blinding = slate.add_transaction_elements(keychain, &ProofBuilder::new(keychain), elems)?;
 
 	// Create our own private context
 	let mut context = Context::new(
@@ -270,7 +278,6 @@ pub fn select_send_tx<'a, T: ?Sized, C, K, B>(
 	amount: u64,
 	current_height: u64,
 	minimum_confirmations: u64,
-	lock_height: u64,
 	max_outputs: usize,
 	change_outputs: usize,
 	selection_strategy_is_use_all: bool,
@@ -302,13 +309,8 @@ where
 	)?;
 
 	// build transaction skeleton with inputs and change
-	let (mut parts, change_amounts_derivations) =
+	let (parts, change_amounts_derivations) =
 		inputs_and_change(&coins, wallet, keychain_mask, amount, fee, change_outputs)?;
-
-	// Build a "Plain" kernel unless lock_height>0 explicitly specified.
-	if lock_height > 0 {
-		parts.push(build::with_lock_height(lock_height));
-	}
 
 	Ok((parts, coins, change_amounts_derivations, fee))
 }
@@ -443,8 +445,6 @@ where
 
 	// calculate the total across all inputs, and how much is left
 	let total: u64 = coins.iter().map(|c| c.value).sum();
-
-	parts.push(build::with_fee(fee));
 
 	// if we are spending 10,000 coins to send 1,000 then our change will be 9,000
 	// if the fee is 80 then the recipient will receive 1000 and our change will be

--- a/libwallet/src/internal/selection.rs
+++ b/libwallet/src/internal/selection.rs
@@ -15,7 +15,7 @@
 //! Selection of inputs for building transactions
 
 use crate::error::{Error, ErrorKind};
-use crate::grin_core::core::{amount_to_hr_string, KernelFeatures, TxKernel};
+use crate::grin_core::core::amount_to_hr_string;
 use crate::grin_core::libtx::{
 	build,
 	proof::{ProofBuild, ProofBuilder},
@@ -62,15 +62,8 @@ where
 		&parent_key_id,
 	)?;
 
-	// Update the fee on both the slate *and* the underlying tx.
-	// Need to think through how we would support lock_height here.
-	{
-		slate.fee = fee;
-		slate.tx = slate
-			.tx
-			.clone()
-			.replace_kernel(TxKernel::with_features(KernelFeatures::Plain { fee }));
-	}
+	// Update the fee on the slate so we account for this when building the tx.
+	slate.fee = fee;
 
 	let blinding = slate.add_transaction_elements(keychain, &ProofBuilder::new(keychain), elems)?;
 

--- a/libwallet/src/internal/tx.rs
+++ b/libwallet/src/internal/tx.rs
@@ -365,6 +365,7 @@ where
 
 #[cfg(test)]
 mod test {
+	use crate::grin_core::core::KernelFeatures;
 	use crate::grin_core::libtx::{build, ProofBuilder};
 	use crate::grin_keychain::{ExtKeychain, ExtKeychainPath, Keychain};
 
@@ -377,12 +378,14 @@ mod test {
 		let key_id1 = ExtKeychainPath::new(1, 1, 0, 0, 0).to_identifier();
 
 		let tx1 = build::transaction(
+			KernelFeatures::Plain { fee: 0 },
 			vec![build::output(105, key_id1.clone())],
 			&keychain,
 			&builder,
 		)
 		.unwrap();
 		let tx2 = build::transaction(
+			KernelFeatures::Plain { fee: 0 },
 			vec![build::input(105, key_id1.clone())],
 			&keychain,
 			&builder,

--- a/libwallet/src/slate.rs
+++ b/libwallet/src/slate.rs
@@ -257,9 +257,9 @@ impl Slate {
 		Ok(blind)
 	}
 
-	// Update the tx kernel based on kernel features derived from the current slate.
-	// The fee may change as we build a transaction and we need to
-	// update the tx kernel to reflect this during the tx building process.
+	/// Update the tx kernel based on kernel features derived from the current slate.
+	/// The fee may change as we build a transaction and we need to
+	/// update the tx kernel to reflect this during the tx building process.
 	pub fn update_kernel(&mut self) {
 		self.tx = self
 			.tx


### PR DESCRIPTION
Resolves #248 
Related https://github.com/mimblewimble/grin/pull/3057 (must be merged before this PR)

We no longer use tx building combinators for fee and lock_height.
We now pass an existing tx into `build::partial_transaction`.
We are also responsible for updating the tx kernel to reflect the features based on the current slate (fee changes based on the tx being built).

The motivation for these changes is to increase the flexibility to support future kernel feature variants, specifically "relative height locked" kernels.
The tx building combinators `with_fee` and `with_lock_height` did not fit cleanly with adding new feature variants as the different combinations of optional fields (fee, lock_height etc.) produce different kernel features.