### PR TITLE
Add option to finalize and post transactions separately (for air-gap wallets)

### DIFF
--- a/controller/src/command.rs
+++ b/controller/src/command.rs
@@ -730,6 +730,32 @@ where
 	Ok(())
 }
 
+/// Post
+pub struct PostArgs {
+	pub input: String,
+	pub fluff: bool,
+}
+
+pub fn post<'a, L, C, K>(
+	wallet: Arc<Mutex<Box<dyn WalletInst<'a, L, C, K>>>>,
+	keychain_mask: Option<&SecretKey>,
+	args: PostArgs,
+) -> Result<(), Error>
+where
+	L: WalletLCProvider<'a, C, K>,
+	C: NodeClient + 'a,
+	K: keychain::Keychain + 'a,
+{
+	let slate = PathToSlate((&args.input).into()).get_tx()?;
+
+	controller::owner_single_use(wallet.clone(), keychain_mask, |api, m| {
+		api.post_tx(m, &slate.tx, args.fluff)?;
+		info!("Posted transaction");
+		return Ok(());
+	})?;
+	Ok(())
+}
+
 /// Repost
 pub struct RepostArgs {
 	pub id: u32,

--- a/src/bin/grin-wallet.yml
+++ b/src/bin/grin-wallet.yml
@@ -268,6 +268,18 @@ subcommands:
             short: t
             long: txid
             takes_value: true
+  - post:
+      about: Posts a finalized transaction to the chain
+      args:
+        - input:
+            help: File name of the transaction to post
+            short: i
+            long: input
+            takes_value: true
+        - fluff:
+            help: Fluff the transaction (ignore Dandelion relay protocol)
+            short: f
+            long: fluff
   - repost:
       about: Reposts a stored, completed but unconfirmed transaction to the chain, or dumps it to a file
       args:

--- a/src/bin/grin-wallet.yml
+++ b/src/bin/grin-wallet.yml
@@ -176,6 +176,15 @@ subcommands:
             help: Fluff the transaction (ignore Dandelion relay protocol)
             short: f
             long: fluff
+        - nopost:
+            help: Do not post the transaction.
+            short: n
+            long: nopost
+        - dest:
+            help: Specify file to save the finalized slate.
+            short: d
+            long: dest
+            takes_value: true
   - invoice:
       about: Initialize an invoice transaction.
       args:

--- a/src/cmd/wallet_args.rs
+++ b/src/cmd/wallet_args.rs
@@ -559,15 +559,24 @@ pub fn parse_receive_args(receive_args: &ArgMatches) -> Result<command::ReceiveA
 
 pub fn parse_finalize_args(args: &ArgMatches) -> Result<command::FinalizeArgs, ParseError> {
 	let fluff = args.is_present("fluff");
+	let nopost = args.is_present("nopost");
 	let tx_file = parse_required(args, "input")?;
 
 	if !Path::new(&tx_file).is_file() {
 		let msg = format!("File {} not found.", tx_file);
 		return Err(ParseError::ArgumentError(msg));
 	}
+
+	let dest_file = match args.is_present("dest") {
+		true => Some(args.value_of("dest").unwrap().to_owned()),
+		false => None,
+	};
+
 	Ok(command::FinalizeArgs {
 		input: tx_file.to_owned(),
 		fluff: fluff,
+		nopost: nopost,
+		dest: dest_file.to_owned(),
 	})
 }
 

--- a/src/cmd/wallet_args.rs
+++ b/src/cmd/wallet_args.rs
@@ -747,6 +747,16 @@ pub fn parse_txs_args(args: &ArgMatches) -> Result<command::TxsArgs, ParseError>
 	})
 }
 
+pub fn parse_post_args(args: &ArgMatches) -> Result<command::PostArgs, ParseError> {
+	let tx_file = parse_required(args, "input")?;
+	let fluff = args.is_present("fluff");
+
+	Ok(command::PostArgs {
+		input: tx_file.to_owned(),
+		fluff: fluff,
+	})
+}
+
 pub fn parse_repost_args(args: &ArgMatches) -> Result<command::RepostArgs, ParseError> {
 	let tx_id = match args.value_of("id") {
 		None => None,
@@ -1020,6 +1030,10 @@ where
 				a,
 				wallet_config.dark_background_color_scheme.unwrap_or(true),
 			)
+		}
+		("post", Some(args)) => {
+			let a = arg_parse!(parse_post_args(&args));
+			command::post(wallet, km, a)
 		}
 		("repost", Some(args)) => {
 			let a = arg_parse!(parse_repost_args(&args));


### PR DESCRIPTION
# What does this PR add?
This PR adds the ability to finalize a transaction without posting the transaction to the chain, and separately post a finalized slate to the chain.

# Why is this useful?
1) **For air-gapped wallets**: Currently there is no easy way to send transactions from an offline/air-gapped wallet. To finalize a transaction, the wallet requires a connection to a running node. With this feature, it is now possible to generate a finalized slate on an offline machine (without posting to chain), copy that slate file to another machine (with a connected Grin node), and post the transaction on that machine.

2) **For sender privacy**: Currently, the sender must reveal his IP to the network (or at least to one connected node) during transaction finalization. With this feature, a transaction sender no longer needs to reveal his/her IP to the network. The sender may simply generate a finalized transaction slate, and give that slate to the recipient, allowing the recipient to reveal his/her IP instead.

# Testing
I have functionally tested this change on Mainnet. I tested the new segregated finalize/post transaction method, as well as the original combined finalize+post method. Both transaction methods work as expected.

I am unclear about the test process for this project. I am happy to write formal test cases, if someone can give me a bit of guidance on where/how those tests should be added.