### PR TITLE
Rename `data_dir` command line switch to `top_level_dir`

### DIFF
--- a/src/bin/grin-wallet.yml
+++ b/src/bin/grin-wallet.yml
@@ -22,10 +22,10 @@ args:
       long: account
       takes_value: true
       default_value: default
-  - data_dir:
-      help: Directory in which to store wallet files
-      short: dd
-      long: data_dir
+  - top_level_dir:
+      help: Top directory in which wallet files are stored (location of 'grin-wallet.toml')
+      short: t
+      long: top_level_dir
       takes_value: true
   - external:
       help: Listen on 0.0.0.0 interface to allow external connections (default is 127.0.0.1)

--- a/src/cmd/wallet_args.rs
+++ b/src/cmd/wallet_args.rs
@@ -801,7 +801,7 @@ where
 		wallet_config.api_listen_interface = "0.0.0.0".to_string();
 	}
 
-	if let Some(dir) = wallet_args.value_of("data_dir") {
+	if let Some(dir) = wallet_args.value_of("top_level_dir") {
 		wallet_config.data_file_dir = dir.to_string().clone();
 	}
 


### PR DESCRIPTION
As explained in https://github.com/mimblewimble/grin-wallet/issues/251, this is renamed to alleviate confusion.