### PR TITLE
Bits and Pieces for 3.0.0 beta

### DIFF
--- a/api/src/owner.rs
+++ b/api/src/owner.rs
@@ -1226,12 +1226,16 @@ where
 		start_height: Option<u64>,
 		delete_unconfirmed: bool,
 	) -> Result<(), Error> {
+		let tx = {
+			let t = self.status_tx.lock();
+			t.clone()
+		};
 		owner::scan(
 			self.wallet_inst.clone(),
 			keychain_mask,
 			start_height,
 			delete_unconfirmed,
-			&None,
+			&tx,
 		)
 	}
 

--- a/api/src/owner_rpc.rs
+++ b/api/src/owner_rpc.rs
@@ -67,7 +67,10 @@ pub trait OwnerRpc: Sync + Send {
 	# , false, 4, false, false, false);
 	```
 	*/
-	#[deprecated(since="3.0.0", note="The V2 Owner API (OwnerRpc) will be removed in grin-wallet 4.0.0. Please migrate to the V3 (OwnerRpcS) API as soon as possible.")]
+	#[deprecated(
+		since = "3.0.0",
+		note = "The V2 Owner API (OwnerRpc) will be removed in grin-wallet 4.0.0. Please migrate to the V3 (OwnerRpcS) API as soon as possible."
+	)]
 	fn accounts(&self) -> Result<Vec<AcctPathMapping>, ErrorKind>;
 
 	/**

--- a/api/src/owner_rpc.rs
+++ b/api/src/owner_rpc.rs
@@ -67,6 +67,7 @@ pub trait OwnerRpc: Sync + Send {
 	# , false, 4, false, false, false);
 	```
 	*/
+	#[deprecated(since="3.0.0", note="The V2 Owner API (OwnerRpc) will be removed in grin-wallet 4.0.0. Please migrate to the V3 (OwnerRpcS) API as soon as possible.")]
 	fn accounts(&self) -> Result<Vec<AcctPathMapping>, ErrorKind>;
 
 	/**

--- a/controller/tests/updater_thread.rs
+++ b/controller/tests/updater_thread.rs
@@ -98,7 +98,7 @@ fn updater_thread_test_impl(test_dir: &'static str) -> Result<(), libwallet::Err
 	thread::sleep(Duration::from_secs(10));
 
 	let messages = owner_api.get_updater_messages(1000)?;
-	assert_eq!(messages.len(), 34);
+	assert_eq!(messages.len(), 32);
 
 	owner_api.stop_updater()?;
 	thread::sleep(Duration::from_secs(2));

--- a/libwallet/src/api_impl/owner.rs
+++ b/libwallet/src/api_impl/owner.rs
@@ -722,8 +722,7 @@ where
 	let start_index = last_scanned_block.height.saturating_sub(100);
 
 	if last_scanned_block.height == 0 {
-		let msg = format!("This wallet's contents has not been initialized with a full chain scan, performing scan now.
-		This operation may take a while for the first scan, but should be much quicker once the initial scan is done.");
+		let msg = format!("This wallet has not been scanned against the current chain. Beginning full scan... (this first scan may take a while, but subsequent scans will be much quicker)");
 		if let Some(ref s) = status_send_channel {
 			let _ = s.send(StatusMessage::FullScanWarn(msg));
 		}

--- a/libwallet/src/internal/scan.rs
+++ b/libwallet/src/internal/scan.rs
@@ -164,10 +164,7 @@ where
 
 		let range = highest_index as f64 - start_index_stat as f64;
 		let progress = last_retrieved_index as f64 - start_index_stat as f64;
-		let perc_complete = cmp::min(
-			((progress / range) * 100.0) as u8,
-			99,
-		);
+		let perc_complete = cmp::min(((progress / range) * 100.0) as u8, 99);
 
 		let msg = format!(
 			"Checking {} outputs, up to index {}. (Highest index: {})",

--- a/libwallet/src/internal/scan.rs
+++ b/libwallet/src/internal/scan.rs
@@ -73,13 +73,6 @@ where
 	K: Keychain + 'a,
 {
 	let mut wallet_outputs: Vec<OutputResult> = Vec::new();
-	let msg = format!(
-		"Scanning {} outputs in the current Grin utxo set",
-		outputs.len(),
-	);
-	if let Some(ref s) = status_send_channel {
-		let _ = s.send(StatusMessage::Scanning(msg, percentage_complete));
-	}
 
 	let legacy_builder = proof::LegacyProofBuilder::new(keychain);
 	let builder = proof::ProofBuilder::new(keychain);
@@ -161,14 +154,18 @@ where
 	K: Keychain + 'a,
 {
 	let batch_size = 1000;
+	let start_index_stat = start_index;
 	let mut start_index = start_index;
 	let mut result_vec: Vec<OutputResult> = vec![];
 	let last_retrieved_return_index;
 	loop {
 		let (highest_index, last_retrieved_index, outputs) =
 			client.get_outputs_by_pmmr_index(start_index, end_index, batch_size)?;
+
+		let range = highest_index as f64 - start_index_stat as f64;
+		let progress = last_retrieved_index as f64 - start_index_stat as f64;
 		let perc_complete = cmp::min(
-			((last_retrieved_index as f64 / highest_index as f64) * 100.0) as u8,
+			((progress / range) * 100.0) as u8,
 			99,
 		);
 


### PR DESCRIPTION
A few smaller items in one go rather than creating several micro PRs. Will keep this updated as I go

* Add a deprecation warning for the V2 Owner API.
* Fix scan output not appearing when running `grin-wallet scan`
* Fix scan percentage complete calculation in reported messages, fix message being sent twice per iteration