### PR TITLE
V2 Slate Compatibility

### DIFF
--- a/api/src/foreign_rpc.rs
+++ b/api/src/foreign_rpc.rs
@@ -553,9 +553,10 @@ where
 		message: Option<String>,
 	) -> Result<VersionedSlate, ErrorKind> {
 		let version = in_slate.version();
+		let slate_from = Slate::from(in_slate);
 		let out_slate = Foreign::receive_tx(
 			self,
-			&Slate::from(in_slate),
+			&slate_from,
 			dest_acct_name.as_ref().map(String::as_str),
 			message,
 		)

--- a/api/src/foreign_rpc.rs
+++ b/api/src/foreign_rpc.rs
@@ -53,7 +53,8 @@ pub trait ForeignRpc {
 			"Ok": {
 				"foreign_api_version": 2,
 				"supported_slate_versions": [
-					"V3"
+					"V3",
+					"V2"
 				]
 			}
 		}

--- a/controller/src/command.rs
+++ b/controller/src/command.rs
@@ -513,9 +513,7 @@ where
 {
 	controller::owner_single_use(wallet.clone(), keychain_mask, |api, m| {
 		let slate = api.issue_invoice_tx(m, args.issue_args)?;
-		let mut tx_file = File::create(args.dest.clone())?;
-		tx_file.write_all(json::to_string(&slate).unwrap().as_bytes())?;
-		tx_file.sync_all()?;
+		PathToSlate((&args.dest).into()).put_tx(&slate)?;
 		Ok(())
 	})?;
 	Ok(())

--- a/controller/src/controller.rs
+++ b/controller/src/controller.rs
@@ -19,7 +19,7 @@ use crate::config::TorConfig;
 use crate::keychain::Keychain;
 use crate::libwallet::{
 	address, Error, ErrorKind, NodeClient, NodeVersionInfo, Slate, WalletInst, WalletLCProvider,
-	CURRENT_SLATE_VERSION, GRIN_BLOCK_HEADER_VERSION,
+	GRIN_BLOCK_HEADER_VERSION,
 };
 use crate::util::secp::key::SecretKey;
 use crate::util::{from_hex, static_secp_instance, to_base64, Mutex};
@@ -63,9 +63,7 @@ fn check_middleware(
 				bhv = n.block_header_version;
 			}
 			if let Some(s) = slate {
-				if s.version_info.version < CURRENT_SLATE_VERSION
-//					|| (bhv == 3 && s.version_info.block_header_version != 3)
-					|| (bhv > 3 && s.version_info.block_header_version < GRIN_BLOCK_HEADER_VERSION)
+				if bhv > 3 && s.version_info.block_header_version < GRIN_BLOCK_HEADER_VERSION
 				{
 					Err(ErrorKind::Compatibility(
 						"Incoming Slate is not compatible with this wallet. \

--- a/controller/src/controller.rs
+++ b/controller/src/controller.rs
@@ -63,8 +63,7 @@ fn check_middleware(
 				bhv = n.block_header_version;
 			}
 			if let Some(s) = slate {
-				if bhv > 3 && s.version_info.block_header_version < GRIN_BLOCK_HEADER_VERSION
-				{
+				if bhv > 3 && s.version_info.block_header_version < GRIN_BLOCK_HEADER_VERSION {
 					Err(ErrorKind::Compatibility(
 						"Incoming Slate is not compatible with this wallet. \
 						 Please upgrade the node or use a different one."

--- a/impls/src/adapters/file.rs
+++ b/impls/src/adapters/file.rs
@@ -16,7 +16,7 @@
 use std::fs::File;
 use std::io::{Read, Write};
 
-use crate::libwallet::{Error, ErrorKind, Slate, VersionedSlate, SlateVersion};
+use crate::libwallet::{Error, ErrorKind, Slate, SlateVersion, VersionedSlate};
 use crate::{SlateGetter, SlatePutter};
 use std::path::PathBuf;
 

--- a/impls/src/adapters/file.rs
+++ b/impls/src/adapters/file.rs
@@ -28,6 +28,8 @@ impl SlatePutter for PathToSlate {
 		let mut pub_tx = File::create(&self.0)?;
 		let out_slate = {
 			if slate.payment_proof.is_some() || slate.ttl_cutoff_height.is_some() {
+				warn!("Transaction contains features that require grin-wallet 3.0.0 or later");
+				warn!("Please ensure the other party is running grin-wallet v3.0.0 or later before sending");
 				VersionedSlate::into_version(slate.clone(), SlateVersion::V3)
 			} else {
 				let mut s = slate.clone();

--- a/impls/src/adapters/http.rs
+++ b/impls/src/adapters/http.rs
@@ -15,6 +15,7 @@
 /// HTTP Wallet 'plugin' implementation
 use crate::client_utils::{Client, ClientError};
 use crate::libwallet::{Error, ErrorKind, Slate};
+use crate::libwallet::slate_versions::{SlateVersion, VersionedSlate};
 use crate::SlateSender;
 use serde::Serialize;
 use serde_json::{json, Value};
@@ -64,7 +65,7 @@ impl HttpSlateSender {
 	}
 
 	/// Check version of the listening wallet
-	fn check_other_version(&self, url: &str) -> Result<(), Error> {
+	fn check_other_version(&self, url: &str) -> Result<SlateVersion, Error> {
 		let req = json!({
 			"jsonrpc": "2.0",
 			"method": "check_version",
@@ -111,13 +112,16 @@ impl HttpSlateSender {
 			return Err(ErrorKind::ClientCallback(report).into());
 		}
 
-		if !supported_slate_versions.contains(&"V3".to_owned()) {
-			let report = format!("Unable to negotiate slate format with other wallet.");
-			error!("{}", report);
-			return Err(ErrorKind::ClientCallback(report).into());
+		if supported_slate_versions.contains(&"V3".to_owned()) {
+			return Ok(SlateVersion::V3);
+		}
+		if supported_slate_versions.contains(&"V2".to_owned()) {
+			return Ok(SlateVersion::V2);
 		}
 
-		Ok(())
+		let report = format!("Unable to negotiate slate format with other wallet.");
+		error!("{}", report);
+		Err(ErrorKind::ClientCallback(report).into())
 	}
 
 	fn post<IN>(
@@ -173,15 +177,28 @@ impl SlateSender for HttpSlateSender {
 				.map_err(|e| ErrorKind::TorProcess(format!("{:?}", e).into()))?;
 		}
 
-		self.check_other_version(&url_str)?;
-
+		let slate_send = match self.check_other_version(&url_str)? {
+			SlateVersion::V3 => VersionedSlate::into_version(slate.clone(), SlateVersion::V3),
+			SlateVersion::V2 => {
+				let mut slate = slate.clone();
+				if let Some(_) = slate.payment_proof {
+					return Err(ErrorKind::ClientCallback("Payment proof requested, but other wallet does not support payment proofs. Please urge other user to upgrade, or re-send tx without a payment proof".into()).into());
+				}
+				if let Some(_) = slate.ttl_cutoff_height {
+					warn!("Slate TTL value will be ignored and removed by other wallet, as other wallet does not support this feature. Please urge other user to upgrade");
+				}
+				slate.version_info.version = 2;
+				slate.version_info.orig_version = 2;
+				VersionedSlate::into_version(slate, SlateVersion::V2)
+			}
+		};
 		// Note: not using easy-jsonrpc as don't want the dependencies in this crate
 		let req = json!({
 			"jsonrpc": "2.0",
 			"method": "receive_tx",
 			"id": 1,
 			"params": [
-						slate,
+						slate_send,
 						null,
 						null
 					]

--- a/impls/src/adapters/http.rs
+++ b/impls/src/adapters/http.rs
@@ -14,8 +14,8 @@
 
 /// HTTP Wallet 'plugin' implementation
 use crate::client_utils::{Client, ClientError};
-use crate::libwallet::{Error, ErrorKind, Slate};
 use crate::libwallet::slate_versions::{SlateVersion, VersionedSlate};
+use crate::libwallet::{Error, ErrorKind, Slate};
 use crate::SlateSender;
 use serde::Serialize;
 use serde_json::{json, Value};

--- a/libwallet/src/slate.rs
+++ b/libwallet/src/slate.rs
@@ -42,11 +42,11 @@ use std::fmt;
 use std::sync::Arc;
 use uuid::Uuid;
 
+use crate::slate_versions::v2::SlateV2;
 use crate::slate_versions::v3::{
 	CoinbaseV3, InputV3, OutputV3, ParticipantDataV3, PaymentInfoV3, SlateV3, TransactionBodyV3,
 	TransactionV3, TxKernelV3, VersionCompatInfoV3,
 };
-use crate::slate_versions::v2::SlateV2;
 use crate::slate_versions::{CURRENT_SLATE_VERSION, GRIN_BLOCK_HEADER_VERSION};
 use crate::types::CbData;
 

--- a/libwallet/src/slate.rs
+++ b/libwallet/src/slate.rs
@@ -46,6 +46,7 @@ use crate::slate_versions::v3::{
 	CoinbaseV3, InputV3, OutputV3, ParticipantDataV3, PaymentInfoV3, SlateV3, TransactionBodyV3,
 	TransactionV3, TxKernelV3, VersionCompatInfoV3,
 };
+use crate::slate_versions::v2::SlateV2;
 use crate::slate_versions::{CURRENT_SLATE_VERSION, GRIN_BLOCK_HEADER_VERSION};
 use crate::types::CbData;
 
@@ -232,13 +233,11 @@ impl Slate {
 		let version = Slate::parse_slate_version(slate_json)?;
 		let v3: SlateV3 = match version {
 			3 => serde_json::from_str(slate_json).context(ErrorKind::SlateDeser)?,
-			// left as a reminder
-			/*0 => {
-				let v0: SlateV0 =
+			2 => {
+				let v2: SlateV2 =
 					serde_json::from_str(slate_json).context(ErrorKind::SlateDeser)?;
-				let v1 = SlateV1::from(v0);
-				SlateV3::from(v1)
-			}*/
+				SlateV3::from(v2)
+			}
 			_ => return Err(ErrorKind::SlateVersion(version).into()),
 		};
 		Ok(v3.into())
@@ -728,11 +727,10 @@ impl Serialize for Slate {
 		match self.version_info.orig_version {
 			3 => v3.serialize(serializer),
 			// left as a reminder
-			/*0 => {
-				let v1 = SlateV1::from(v2);
-				let v0 = SlateV0::from(v1);
-				v0.serialize(serializer)
-			}*/
+			2 => {
+				let v2 = SlateV2::from(&v3);
+				v2.serialize(serializer)
+			}
 			v => Err(S::Error::custom(format!("Unknown slate version {}", v))),
 		}
 	}

--- a/libwallet/src/slate_versions/mod.rs
+++ b/libwallet/src/slate_versions/mod.rs
@@ -18,16 +18,16 @@
 //! remains for future needs
 
 use crate::slate::Slate;
-use crate::slate_versions::v3::{CoinbaseV3, SlateV3};
 use crate::slate_versions::v2::{CoinbaseV2, SlateV2};
+use crate::slate_versions::v3::{CoinbaseV3, SlateV3};
 use crate::types::CbData;
 
 pub mod ser;
 
 #[allow(missing_docs)]
-pub mod v3;
-#[allow(missing_docs)]
 pub mod v2;
+#[allow(missing_docs)]
+pub mod v3;
 
 /// The most recent version of the slate
 pub const CURRENT_SLATE_VERSION: u16 = 3;

--- a/libwallet/src/slate_versions/mod.rs
+++ b/libwallet/src/slate_versions/mod.rs
@@ -85,7 +85,7 @@ impl From<VersionedSlate> for Slate {
 			VersionedSlate::V3(s) => {
 				let s = SlateV3::from(s);
 				Slate::from(s)
-			} // Again, left in as a reminder
+			}
 			VersionedSlate::V2(s) => {
 				let s = SlateV3::from(s);
 				Slate::from(s)

--- a/libwallet/src/slate_versions/mod.rs
+++ b/libwallet/src/slate_versions/mod.rs
@@ -19,12 +19,15 @@
 
 use crate::slate::Slate;
 use crate::slate_versions::v3::{CoinbaseV3, SlateV3};
+use crate::slate_versions::v2::{CoinbaseV2, SlateV2};
 use crate::types::CbData;
 
 pub mod ser;
 
 #[allow(missing_docs)]
 pub mod v3;
+#[allow(missing_docs)]
+pub mod v2;
 
 /// The most recent version of the slate
 pub const CURRENT_SLATE_VERSION: u16 = 3;
@@ -37,6 +40,8 @@ pub const GRIN_BLOCK_HEADER_VERSION: u16 = 3;
 pub enum SlateVersion {
 	/// V3 (most current)
 	V3,
+	/// V2 (2.0.0 - Onwards)
+	V2,
 }
 
 #[derive(Debug, Serialize, Deserialize)]
@@ -46,6 +51,8 @@ pub enum SlateVersion {
 pub enum VersionedSlate {
 	/// Current (3.0.0 Onwards )
 	V3(SlateV3),
+	/// V2 (2.0.0 - Onwards)
+	V2(SlateV2),
 }
 
 impl VersionedSlate {
@@ -53,6 +60,7 @@ impl VersionedSlate {
 	pub fn version(&self) -> SlateVersion {
 		match *self {
 			VersionedSlate::V3(_) => SlateVersion::V3,
+			VersionedSlate::V2(_) => SlateVersion::V2,
 		}
 	}
 
@@ -62,12 +70,11 @@ impl VersionedSlate {
 			SlateVersion::V3 => VersionedSlate::V3(slate.into()),
 			// Left here as a reminder of what needs to be inserted on
 			// the release of a new slate
-			/*SlateVersion::V0 => {
+			SlateVersion::V2 => {
 				let s = SlateV3::from(slate);
-				let s = SlateV1::from(s);
-				let s = SlateV0::from(s);
-				VersionedSlate::V0(s)
-			}*/
+				let s = SlateV2::from(&s);
+				VersionedSlate::V2(s)
+			}
 		}
 	}
 }
@@ -79,12 +86,10 @@ impl From<VersionedSlate> for Slate {
 				let s = SlateV3::from(s);
 				Slate::from(s)
 			} // Again, left in as a reminder
-			  /*VersionedSlate::V0(s) => {
-				  let s = SlateV0::from(s);
-				  let s = SlateV1::from(s);
-				  let s = SlateV2::from(s);
-				  Slate::from(s)
-			  }*/
+			VersionedSlate::V2(s) => {
+				let s = SlateV3::from(s);
+				Slate::from(s)
+			}
 		}
 	}
 }
@@ -96,6 +101,8 @@ impl From<VersionedSlate> for Slate {
 pub enum VersionedCoinbase {
 	/// Current supported coinbase version.
 	V3(CoinbaseV3),
+	/// Previous
+	V2(CoinbaseV2),
 }
 
 impl VersionedCoinbase {
@@ -103,6 +110,7 @@ impl VersionedCoinbase {
 	pub fn into_version(cb: CbData, version: SlateVersion) -> VersionedCoinbase {
 		match version {
 			SlateVersion::V3 => VersionedCoinbase::V3(cb.into()),
+			SlateVersion::V2 => VersionedCoinbase::V2(cb.into()),
 		}
 	}
 }

--- a/libwallet/src/slate_versions/v2.rs
+++ b/libwallet/src/slate_versions/v2.rs
@@ -43,7 +43,9 @@ use crate::grin_util::secp::key::PublicKey;
 use crate::grin_util::secp::pedersen::{Commitment, RangeProof};
 use crate::grin_util::secp::Signature;
 use crate::slate::CompatKernelFeatures;
+use crate::types::CbData;
 use uuid::Uuid;
+use crate::slate_versions::v3::{OutputV3, TxKernelV3};
 
 #[derive(Serialize, Deserialize, Debug, Clone)]
 pub struct SlateV2 {
@@ -194,4 +196,19 @@ pub struct CoinbaseV2 {
 	pub kernel: TxKernelV2,
 	/// Key Id
 	pub key_id: Option<Identifier>,
+}
+
+// Coinbase data to versioned.
+impl From<CbData> for CoinbaseV2 {
+	fn from(cb: CbData) -> CoinbaseV2 {
+		let output = OutputV3::from(&cb.output);
+		let output = OutputV2::from(&output);
+		let kernel = TxKernelV3::from(&cb.kernel);
+		let kernel = TxKernelV2::from(&kernel);
+		CoinbaseV2 {
+			output,
+			kernel,
+			key_id: cb.key_id,
+		}
+	}
 }

--- a/libwallet/src/slate_versions/v2.rs
+++ b/libwallet/src/slate_versions/v2.rs
@@ -12,10 +12,28 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-//! Contains V3 of the slate (grin-wallet 3.0.0)
-//! Changes from V2:
-//! * Addition of payment_proof (PaymentInfo struct)
-//! * Addition of a u64 ttl_cutoff_height field
+//! Contains V2 of the slate (grin-wallet 1.1.0)
+//! Changes from V1:
+//! * ParticipantData struct fields serialized as hex strings instead of arrays:
+//!    * public_blind_excess
+//!    * public_nonce
+//!    * part_sig
+//!    * message_sig
+//! * Transaction fields serialized as hex strings instead of arrays:
+//!    * offset
+//! * Input field serialized as hex strings instead of arrays:
+//!    commit
+//! * Output fields serialized as hex strings instead of arrays:
+//!    commit
+//!    proof
+//! * TxKernel fields serialized as hex strings instead of arrays:
+//!    commit
+//!    signature
+//! * version field removed
+//! * VersionCompatInfo struct created with fields and added to beginning of struct
+//!    version: u16
+//!    orig_version: u16,
+//!    block_header_version: u16,
 
 use crate::grin_core::core::transaction::OutputFeatures;
 use crate::grin_core::libtx::secp_ser;
@@ -25,22 +43,19 @@ use crate::grin_util::secp::key::PublicKey;
 use crate::grin_util::secp::pedersen::{Commitment, RangeProof};
 use crate::grin_util::secp::Signature;
 use crate::slate::CompatKernelFeatures;
-use crate::slate_versions::ser as dalek_ser;
-use ed25519_dalek::PublicKey as DalekPublicKey;
-use ed25519_dalek::Signature as DalekSignature;
 use uuid::Uuid;
 
 #[derive(Serialize, Deserialize, Debug, Clone)]
-pub struct SlateV3 {
+pub struct SlateV2 {
 	/// Versioning info
-	pub version_info: VersionCompatInfoV3,
+	pub version_info: VersionCompatInfoV2,
 	/// The number of participants intended to take part in this transaction
 	pub num_participants: usize,
 	/// Unique transaction ID, selected by sender
 	pub id: Uuid,
 	/// The core transaction data:
 	/// inputs, outputs, kernels, kernel offset
-	pub tx: TransactionV3,
+	pub tx: TransactionV2,
 	/// base amount (excluding fee)
 	#[serde(with = "secp_ser::string_or_u64")]
 	pub amount: u64,
@@ -53,26 +68,14 @@ pub struct SlateV3 {
 	/// Lock height
 	#[serde(with = "secp_ser::string_or_u64")]
 	pub lock_height: u64,
-	/// TTL, the block height at which wallets
-	/// should refuse to process the transaction and unlock all
-	/// associated outputs
-	#[serde(with = "secp_ser::opt_string_or_u64")]
-	pub ttl_cutoff_height: Option<u64>,
 	/// Participant data, each participant in the transaction will
 	/// insert their public data here. For now, 0 is sender and 1
 	/// is receiver, though this will change for multi-party
-	pub participant_data: Vec<ParticipantDataV3>,
-	/// Payment Proof
-	#[serde(default = "default_payment_none")]
-	pub payment_proof: Option<PaymentInfoV3>,
-}
-
-fn default_payment_none() -> Option<PaymentInfoV3> {
-	None
+	pub participant_data: Vec<ParticipantDataV2>,
 }
 
 #[derive(Serialize, Deserialize, Debug, Clone)]
-pub struct VersionCompatInfoV3 {
+pub struct VersionCompatInfoV2 {
 	/// The current version of the slate format
 	pub version: u16,
 	/// Original version this slate was converted from
@@ -82,7 +85,7 @@ pub struct VersionCompatInfoV3 {
 }
 
 #[derive(Serialize, Deserialize, Debug, Clone)]
-pub struct ParticipantDataV3 {
+pub struct ParticipantDataV2 {
 	/// Id of participant in the transaction. (For now, 0=sender, 1=rec)
 	#[serde(with = "secp_ser::string_or_u64")]
 	pub id: u64,
@@ -102,19 +105,9 @@ pub struct ParticipantDataV3 {
 	pub message_sig: Option<Signature>,
 }
 
-#[derive(Serialize, Deserialize, Debug, Clone)]
-pub struct PaymentInfoV3 {
-	#[serde(with = "dalek_ser::dalek_pubkey_serde")]
-	pub sender_address: DalekPublicKey,
-	#[serde(with = "dalek_ser::dalek_pubkey_serde")]
-	pub receiver_address: DalekPublicKey,
-	#[serde(with = "dalek_ser::option_dalek_sig_serde")]
-	pub receiver_signature: Option<DalekSignature>,
-}
-
 /// A transaction
 #[derive(Serialize, Deserialize, Debug, Clone)]
-pub struct TransactionV3 {
+pub struct TransactionV2 {
 	/// The kernel "offset" k2
 	/// excess is k1G after splitting the key k = k1 + k2
 	#[serde(
@@ -123,21 +116,21 @@ pub struct TransactionV3 {
 	)]
 	pub offset: BlindingFactor,
 	/// The transaction body - inputs/outputs/kernels
-	pub body: TransactionBodyV3,
+	pub body: TransactionBodyV2,
 }
 
 /// TransactionBody is a common abstraction for transaction and block
 #[derive(Serialize, Deserialize, Debug, Clone)]
-pub struct TransactionBodyV3 {
+pub struct TransactionBodyV2 {
 	/// List of inputs spent by the transaction.
-	pub inputs: Vec<InputV3>,
+	pub inputs: Vec<InputV2>,
 	/// List of outputs the transaction produces.
-	pub outputs: Vec<OutputV3>,
+	pub outputs: Vec<OutputV2>,
 	/// List of kernels that make up this transaction (usually a single kernel).
-	pub kernels: Vec<TxKernelV3>,
+	pub kernels: Vec<TxKernelV2>,
 }
 #[derive(Serialize, Deserialize, Debug, Clone)]
-pub struct InputV3 {
+pub struct InputV2 {
 	/// The features of the output being spent.
 	/// We will check maturity for coinbase output.
 	pub features: OutputFeatures,
@@ -150,7 +143,7 @@ pub struct InputV3 {
 }
 
 #[derive(Debug, Copy, Clone, Serialize, Deserialize)]
-pub struct OutputV3 {
+pub struct OutputV2 {
 	/// Options for an output's structure or use
 	pub features: OutputFeatures,
 	/// The homomorphic commitment representing the output amount
@@ -168,7 +161,7 @@ pub struct OutputV3 {
 }
 
 #[derive(Serialize, Deserialize, Debug, Clone)]
-pub struct TxKernelV3 {
+pub struct TxKernelV2 {
 	/// Options for a kernel's structure or use
 	pub features: CompatKernelFeatures,
 	/// Fee originally included in the transaction this proof is for.
@@ -194,178 +187,11 @@ pub struct TxKernelV3 {
 
 /// A mining node requests new coinbase via the foreign api every time a new candidate block is built.
 #[derive(Serialize, Deserialize, Debug, Clone)]
-pub struct CoinbaseV3 {
+pub struct CoinbaseV2 {
 	/// Output
-	pub output: OutputV3,
+	pub output: OutputV2,
 	/// Kernel
-	pub kernel: TxKernelV3,
+	pub kernel: TxKernelV2,
 	/// Key Id
 	pub key_id: Option<Identifier>,
-}
-
-// V2 to V3 For Slate
-impl From<SlateV2> for SlateV3 {
-	fn from(slate: SlateV2) -> SlateV3 {
-		let SlateV2 {
-			num_participants,
-			id,
-			tx,
-			amount,
-			fee,
-			height,
-			lock_height,
-			ttl_cutoff_height,
-			participant_data,
-			version_info,
-			payment_proof,
-		} = slate;
-		let participant_data = map_vec!(participant_data, |data| ParticipantData::from(data));
-		let version_info = VersionCompatInfo::from(&version_info);
-		let payment_proof = match payment_proof {
-			Some(p) => Some(PaymentInfo::from(&p)),
-			None => None,
-		};
-		let tx = Transaction::from(tx);
-		Slate {
-			num_participants,
-			id,
-			tx,
-			amount,
-			fee,
-			height,
-			lock_height,
-			ttl_cutoff_height,
-			participant_data,
-			version_info,
-			payment_proof,
-		}
-	}
-}
-
-impl From<&ParticipantDataV3> for ParticipantData {
-	fn from(data: &ParticipantDataV3) -> ParticipantData {
-		let ParticipantDataV3 {
-			id,
-			public_blind_excess,
-			public_nonce,
-			part_sig,
-			message,
-			message_sig,
-		} = data;
-		let id = *id;
-		let public_blind_excess = *public_blind_excess;
-		let public_nonce = *public_nonce;
-		let part_sig = *part_sig;
-		let message: Option<String> = message.as_ref().map(|t| String::from(&**t));
-		let message_sig = *message_sig;
-		ParticipantData {
-			id,
-			public_blind_excess,
-			public_nonce,
-			part_sig,
-			message,
-			message_sig,
-		}
-	}
-}
-
-impl From<&VersionCompatInfoV3> for VersionCompatInfo {
-	fn from(data: &VersionCompatInfoV3) -> VersionCompatInfo {
-		let VersionCompatInfoV3 {
-			version,
-			orig_version,
-			block_header_version,
-		} = data;
-		let version = *version;
-		let orig_version = *orig_version;
-		let block_header_version = *block_header_version;
-		VersionCompatInfo {
-			version,
-			orig_version,
-			block_header_version,
-		}
-	}
-}
-
-impl From<&PaymentInfoV3> for PaymentInfo {
-	fn from(data: &PaymentInfoV3) -> PaymentInfo {
-		let PaymentInfoV3 {
-			sender_address,
-			receiver_address,
-			receiver_signature,
-		} = data;
-		let sender_address = *sender_address;
-		let receiver_address = *receiver_address;
-		let receiver_signature = *receiver_signature;
-		PaymentInfo {
-			sender_address,
-			receiver_address,
-			receiver_signature,
-		}
-	}
-}
-
-impl From<TransactionV3> for Transaction {
-	fn from(tx: TransactionV3) -> Transaction {
-		let TransactionV3 { offset, body } = tx;
-		let body = TransactionBody::from(&body);
-		Transaction { offset, body }
-	}
-}
-
-impl From<&TransactionBodyV3> for TransactionBody {
-	fn from(body: &TransactionBodyV3) -> TransactionBody {
-		let TransactionBodyV3 {
-			inputs,
-			outputs,
-			kernels,
-		} = body;
-
-		let inputs = map_vec!(inputs, |inp| Input::from(inp));
-		let outputs = map_vec!(outputs, |out| Output::from(out));
-		let kernels = map_vec!(kernels, |kern| TxKernel::from(kern));
-		TransactionBody {
-			inputs,
-			outputs,
-			kernels,
-		}
-	}
-}
-
-impl From<&InputV3> for Input {
-	fn from(input: &InputV3) -> Input {
-		let InputV3 { features, commit } = *input;
-		Input { features, commit }
-	}
-}
-
-impl From<&OutputV3> for Output {
-	fn from(output: &OutputV3) -> Output {
-		let OutputV3 {
-			features,
-			commit,
-			proof,
-		} = *output;
-		Output {
-			features,
-			commit,
-			proof,
-		}
-	}
-}
-
-impl From<&TxKernelV3> for TxKernel {
-	fn from(kernel: &TxKernelV3) -> TxKernel {
-		let (fee, lock_height) = (kernel.fee, kernel.lock_height);
-		let features = match kernel.features {
-			CompatKernelFeatures::Plain => KernelFeatures::Plain { fee },
-			CompatKernelFeatures::Coinbase => KernelFeatures::Coinbase,
-			CompatKernelFeatures::HeightLocked => KernelFeatures::HeightLocked { fee, lock_height },
-		};
-		TxKernel {
-			features,
-			excess: kernel.excess,
-			excess_sig: kernel.excess_sig,
-		}
-	}
 }

--- a/libwallet/src/slate_versions/v2.rs
+++ b/libwallet/src/slate_versions/v2.rs
@@ -43,9 +43,9 @@ use crate::grin_util::secp::key::PublicKey;
 use crate::grin_util::secp::pedersen::{Commitment, RangeProof};
 use crate::grin_util::secp::Signature;
 use crate::slate::CompatKernelFeatures;
+use crate::slate_versions::v3::{OutputV3, TxKernelV3};
 use crate::types::CbData;
 use uuid::Uuid;
-use crate::slate_versions::v3::{OutputV3, TxKernelV3};
 
 #[derive(Serialize, Deserialize, Debug, Clone)]
 pub struct SlateV2 {

--- a/libwallet/src/slate_versions/v3.rs
+++ b/libwallet/src/slate_versions/v3.rs
@@ -19,6 +19,7 @@
 
 use crate::grin_core::core::transaction::OutputFeatures;
 use crate::grin_core::libtx::secp_ser;
+use crate::grin_core::map_vec;
 use crate::grin_keychain::{BlindingFactor, Identifier};
 use crate::grin_util::secp;
 use crate::grin_util::secp::key::PublicKey;
@@ -29,6 +30,11 @@ use crate::slate_versions::ser as dalek_ser;
 use ed25519_dalek::PublicKey as DalekPublicKey;
 use ed25519_dalek::Signature as DalekSignature;
 use uuid::Uuid;
+
+use crate::slate_versions::v2::{
+	InputV2, OutputV2, ParticipantDataV2, SlateV2, TransactionBodyV2,
+	TransactionV2, TxKernelV2, VersionCompatInfoV2,
+};
 
 #[derive(Serialize, Deserialize, Debug, Clone)]
 pub struct SlateV3 {
@@ -214,19 +220,140 @@ impl From<SlateV2> for SlateV3 {
 			fee,
 			height,
 			lock_height,
-			ttl_cutoff_height,
 			participant_data,
 			version_info,
-			payment_proof,
 		} = slate;
-		let participant_data = map_vec!(participant_data, |data| ParticipantData::from(data));
-		let version_info = VersionCompatInfo::from(&version_info);
-		let payment_proof = match payment_proof {
-			Some(p) => Some(PaymentInfo::from(&p)),
-			None => None,
-		};
-		let tx = Transaction::from(tx);
-		Slate {
+		let participant_data = map_vec!(participant_data, |data| ParticipantDataV3::from(data));
+		let version_info = VersionCompatInfoV3::from(&version_info);
+		let tx = TransactionV3::from(tx);
+		SlateV3 {
+			num_participants,
+			id,
+			tx,
+			amount,
+			fee,
+			height,
+			lock_height,
+			ttl_cutoff_height: None,
+			participant_data,
+			version_info,
+			payment_proof: None,
+		}
+	}
+}
+
+impl From<&ParticipantDataV2> for ParticipantDataV3 {
+	fn from(data: &ParticipantDataV2) -> ParticipantDataV3 {
+		let ParticipantDataV2 {
+			id,
+			public_blind_excess,
+			public_nonce,
+			part_sig,
+			message,
+			message_sig,
+		} = data;
+		let id = *id;
+		let public_blind_excess = *public_blind_excess;
+		let public_nonce = *public_nonce;
+		let part_sig = *part_sig;
+		let message: Option<String> = message.as_ref().map(|t| String::from(&**t));
+		let message_sig = *message_sig;
+		ParticipantDataV3 {
+			id,
+			public_blind_excess,
+			public_nonce,
+			part_sig,
+			message,
+			message_sig,
+		}
+	}
+}
+
+impl From<&VersionCompatInfoV2> for VersionCompatInfoV3 {
+	fn from(data: &VersionCompatInfoV2) -> VersionCompatInfoV3 {
+		let VersionCompatInfoV2 {
+			version,
+			orig_version,
+			block_header_version,
+		} = data;
+		let version = *version;
+		let orig_version = *orig_version;
+		let block_header_version = *block_header_version;
+		VersionCompatInfoV3 {
+			version,
+			orig_version,
+			block_header_version,
+		}
+	}
+}
+
+impl From<TransactionV2> for TransactionV3 {
+	fn from(tx: TransactionV2) -> TransactionV3 {
+		let TransactionV2 { offset, body } = tx;
+		let body = TransactionBodyV3::from(&body);
+		TransactionV3 { offset, body }
+	}
+}
+
+impl From<&TransactionBodyV2> for TransactionBodyV3 {
+	fn from(body: &TransactionBodyV2) -> TransactionBodyV3 {
+		let TransactionBodyV2 {
+			inputs,
+			outputs,
+			kernels,
+		} = body;
+
+		let inputs = map_vec!(inputs, |inp| InputV3::from(inp));
+		let outputs = map_vec!(outputs, |out| OutputV3::from(out));
+		let kernels = map_vec!(kernels, |kern| TxKernelV3::from(kern));
+		TransactionBodyV3 {
+			inputs,
+			outputs,
+			kernels,
+		}
+	}
+}
+
+impl From<&InputV2> for InputV3 {
+	fn from(input: &InputV2) -> InputV3 {
+		let InputV2 { features, commit } = *input;
+		InputV3 { features, commit }
+	}
+}
+
+impl From<&OutputV2> for OutputV3 {
+	fn from(output: &OutputV2) -> OutputV3 {
+		let OutputV2 {
+			features,
+			commit,
+			proof,
+		} = *output;
+		OutputV3 {
+			features,
+			commit,
+			proof,
+		}
+	}
+}
+
+impl From<&TxKernelV2> for TxKernelV3 {
+	fn from(kernel: &TxKernelV2) -> TxKernelV3 {
+		let (fee, lock_height) = (kernel.fee, kernel.lock_height);
+		TxKernelV3 {
+			features: kernel.features,
+			fee,
+			lock_height,
+			excess: kernel.excess,
+			excess_sig: kernel.excess_sig,
+		}
+	}
+}
+
+// V3 to V2
+#[allow(unused_variables)]
+impl From<&SlateV3> for SlateV2 {
+	fn from(slate: &SlateV3) -> SlateV2 {
+		let SlateV3 {
 			num_participants,
 			id,
 			tx,
@@ -238,12 +365,32 @@ impl From<SlateV2> for SlateV3 {
 			participant_data,
 			version_info,
 			payment_proof,
+		} = slate;
+		let num_participants = *num_participants;
+		let id = *id;
+		let tx = TransactionV2::from(tx);
+		let amount = *amount;
+		let fee = *fee;
+		let height = *height;
+		let lock_height = *lock_height;
+		let participant_data = map_vec!(participant_data, |data| ParticipantDataV2::from(data));
+		let version_info = VersionCompatInfoV2::from(version_info);
+		SlateV2 {
+			num_participants,
+			id,
+			tx,
+			amount,
+			fee,
+			height,
+			lock_height,
+			participant_data,
+			version_info,
 		}
 	}
 }
 
-impl From<&ParticipantDataV3> for ParticipantData {
-	fn from(data: &ParticipantDataV3) -> ParticipantData {
+impl From<&ParticipantDataV3> for ParticipantDataV2 {
+	fn from(data: &ParticipantDataV3) -> ParticipantDataV2 {
 		let ParticipantDataV3 {
 			id,
 			public_blind_excess,
@@ -258,7 +405,7 @@ impl From<&ParticipantDataV3> for ParticipantData {
 		let part_sig = *part_sig;
 		let message: Option<String> = message.as_ref().map(|t| String::from(&**t));
 		let message_sig = *message_sig;
-		ParticipantData {
+		ParticipantDataV2 {
 			id,
 			public_blind_excess,
 			public_nonce,
@@ -269,8 +416,8 @@ impl From<&ParticipantDataV3> for ParticipantData {
 	}
 }
 
-impl From<&VersionCompatInfoV3> for VersionCompatInfo {
-	fn from(data: &VersionCompatInfoV3) -> VersionCompatInfo {
+impl From<&VersionCompatInfoV3> for VersionCompatInfoV2 {
+	fn from(data: &VersionCompatInfoV3) -> VersionCompatInfoV2 {
 		let VersionCompatInfoV3 {
 			version,
 			orig_version,
@@ -279,7 +426,7 @@ impl From<&VersionCompatInfoV3> for VersionCompatInfo {
 		let version = *version;
 		let orig_version = *orig_version;
 		let block_header_version = *block_header_version;
-		VersionCompatInfo {
+		VersionCompatInfoV2 {
 			version,
 			orig_version,
 			block_header_version,
@@ -287,44 +434,35 @@ impl From<&VersionCompatInfoV3> for VersionCompatInfo {
 	}
 }
 
-impl From<&PaymentInfoV3> for PaymentInfo {
-	fn from(data: &PaymentInfoV3) -> PaymentInfo {
-		let PaymentInfoV3 {
-			sender_address,
-			receiver_address,
-			receiver_signature,
-		} = data;
-		let sender_address = *sender_address;
-		let receiver_address = *receiver_address;
-		let receiver_signature = *receiver_signature;
-		PaymentInfo {
-			sender_address,
-			receiver_address,
-			receiver_signature,
-		}
-	}
-}
-
-impl From<TransactionV3> for Transaction {
-	fn from(tx: TransactionV3) -> Transaction {
+impl From<TransactionV3> for TransactionV2 {
+	fn from(tx: TransactionV3) -> TransactionV2 {
 		let TransactionV3 { offset, body } = tx;
-		let body = TransactionBody::from(&body);
-		Transaction { offset, body }
+		let body = TransactionBodyV2::from(&body);
+		TransactionV2 { offset, body }
 	}
 }
 
-impl From<&TransactionBodyV3> for TransactionBody {
-	fn from(body: &TransactionBodyV3) -> TransactionBody {
+impl From<&TransactionV3> for TransactionV2 {
+	fn from(tx: &TransactionV3) -> TransactionV2 {
+		let TransactionV3 { offset, body } = tx;
+		let offset = offset.clone();
+		let body = TransactionBodyV2::from(body);
+		TransactionV2 { offset, body }
+	}
+}
+
+impl From<&TransactionBodyV3> for TransactionBodyV2 {
+	fn from(body: &TransactionBodyV3) -> TransactionBodyV2 {
 		let TransactionBodyV3 {
 			inputs,
 			outputs,
 			kernels,
 		} = body;
 
-		let inputs = map_vec!(inputs, |inp| Input::from(inp));
-		let outputs = map_vec!(outputs, |out| Output::from(out));
-		let kernels = map_vec!(kernels, |kern| TxKernel::from(kern));
-		TransactionBody {
+		let inputs = map_vec!(inputs, |inp| InputV2::from(inp));
+		let outputs = map_vec!(outputs, |out| OutputV2::from(out));
+		let kernels = map_vec!(kernels, |kern| TxKernelV2::from(kern));
+		TransactionBodyV2 {
 			inputs,
 			outputs,
 			kernels,
@@ -332,21 +470,21 @@ impl From<&TransactionBodyV3> for TransactionBody {
 	}
 }
 
-impl From<&InputV3> for Input {
-	fn from(input: &InputV3) -> Input {
+impl From<&InputV3> for InputV2 {
+	fn from(input: &InputV3) -> InputV2 {
 		let InputV3 { features, commit } = *input;
-		Input { features, commit }
+		InputV2 { features, commit }
 	}
 }
 
-impl From<&OutputV3> for Output {
-	fn from(output: &OutputV3) -> Output {
+impl From<&OutputV3> for OutputV2 {
+	fn from(output: &OutputV3) -> OutputV2 {
 		let OutputV3 {
 			features,
 			commit,
 			proof,
 		} = *output;
-		Output {
+		OutputV2 {
 			features,
 			commit,
 			proof,
@@ -354,18 +492,15 @@ impl From<&OutputV3> for Output {
 	}
 }
 
-impl From<&TxKernelV3> for TxKernel {
-	fn from(kernel: &TxKernelV3) -> TxKernel {
-		let (fee, lock_height) = (kernel.fee, kernel.lock_height);
-		let features = match kernel.features {
-			CompatKernelFeatures::Plain => KernelFeatures::Plain { fee },
-			CompatKernelFeatures::Coinbase => KernelFeatures::Coinbase,
-			CompatKernelFeatures::HeightLocked => KernelFeatures::HeightLocked { fee, lock_height },
-		};
-		TxKernel {
-			features,
+impl From<&TxKernelV3> for TxKernelV2 {
+	fn from(kernel: &TxKernelV3) -> TxKernelV2 {
+		TxKernelV2 {
+			features: kernel.features,
+			fee: kernel.fee,
+			lock_height: kernel.lock_height,
 			excess: kernel.excess,
 			excess_sig: kernel.excess_sig,
 		}
 	}
 }
+

--- a/libwallet/src/slate_versions/v3.rs
+++ b/libwallet/src/slate_versions/v3.rs
@@ -32,8 +32,8 @@ use ed25519_dalek::Signature as DalekSignature;
 use uuid::Uuid;
 
 use crate::slate_versions::v2::{
-	InputV2, OutputV2, ParticipantDataV2, SlateV2, TransactionBodyV2,
-	TransactionV2, TxKernelV2, VersionCompatInfoV2,
+	InputV2, OutputV2, ParticipantDataV2, SlateV2, TransactionBodyV2, TransactionV2, TxKernelV2,
+	VersionCompatInfoV2,
 };
 
 #[derive(Serialize, Deserialize, Debug, Clone)]
@@ -503,4 +503,3 @@ impl From<&TxKernelV3> for TxKernelV2 {
 		}
 	}
 }
-

--- a/src/bin/grin-wallet.yml
+++ b/src/bin/grin-wallet.yml
@@ -155,11 +155,6 @@ subcommands:
             short: t
             long: stored_tx
             takes_value: true
-        - slate_version:
-            help: Target slate version to output/send to receiver
-            short: v
-            long: slate_version
-            takes_value: true
   - receive:
       about: Processes a transaction file to accept a transfer from a sender
       args:
@@ -204,11 +199,6 @@ subcommands:
             help: Optional participant message to include
             short: g
             long: message
-            takes_value: true
-        - slate_version:
-            help: Target slate version to output/send to receiver
-            short: v
-            long: slate_version
             takes_value: true
         - dest:
             help: Name of destination slate output file


### PR DESCRIPTION
This restores wallet-to-wallet compatibility between V3.0.0 and V2.0.0 by re-introducing the V2 slate. The rules for conversion are:

When sending via HTTP (including TOR), the slate version on the remote side is checked and:
   * If V3 support is reported back, send slate as a V3 slate
   * If V2 only is reported back:
      * Downgrade slate to V2 before sending if `payment_proof` is None
      * If `payment_proof` is Some then stop the transaction with an error saying proofs aren't supported by the other side
      * If `ttl_cutoff_height` is some, warn the user that it will be ignored by the other side and dropped by them in the slate, but continue to downgrade to V2

When outputting a file (either via send or invoice):
   * If both `payment_proof` and `ttl_cutoff_height` are None, downgrade slate to V2 before outputting
   * If either `payment_proof` or `ttl_cutoff_height` are Some, output V3 slate with a warning that the other side must be upgraded to grin-wallet v3.0.0 or later

Tested sending back and forth between v2.0.0 and 3.0.0 wallets, sends via direct http and files, also invoices.