### PR TITLE
3.0.0-beta.1 Versioning

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -708,18 +708,19 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
 name = "grin_api"
-version = "3.0.0-alpha.1"
-source = "git+https://github.com/mimblewimble/grin#8b8f0a0abdb3f5058e452b8a550001f60e8b51fa"
+version = "3.0.0-beta.1"
+source = "git+https://github.com/mimblewimble/grin?tag=v3.0.0-beta.1#6a543345760b1d5518098923299d4556743b3694"
 dependencies = [
+ "easy-jsonrpc-mw 0.5.4 (registry+https://github.com/rust-lang/crates.io-index)",
  "failure 0.1.6 (registry+https://github.com/rust-lang/crates.io-index)",
  "failure_derive 0.1.6 (registry+https://github.com/rust-lang/crates.io-index)",
  "futures 0.1.29 (registry+https://github.com/rust-lang/crates.io-index)",
- "grin_chain 3.0.0-alpha.1 (git+https://github.com/mimblewimble/grin)",
- "grin_core 3.0.0-alpha.1 (git+https://github.com/mimblewimble/grin)",
- "grin_p2p 3.0.0-alpha.1 (git+https://github.com/mimblewimble/grin)",
- "grin_pool 3.0.0-alpha.1 (git+https://github.com/mimblewimble/grin)",
- "grin_store 3.0.0-alpha.1 (git+https://github.com/mimblewimble/grin)",
- "grin_util 3.0.0-alpha.1 (git+https://github.com/mimblewimble/grin)",
+ "grin_chain 3.0.0-beta.1 (git+https://github.com/mimblewimble/grin?tag=v3.0.0-beta.1)",
+ "grin_core 3.0.0-beta.1 (git+https://github.com/mimblewimble/grin?tag=v3.0.0-beta.1)",
+ "grin_p2p 3.0.0-beta.1 (git+https://github.com/mimblewimble/grin?tag=v3.0.0-beta.1)",
+ "grin_pool 3.0.0-beta.1 (git+https://github.com/mimblewimble/grin?tag=v3.0.0-beta.1)",
+ "grin_store 3.0.0-beta.1 (git+https://github.com/mimblewimble/grin?tag=v3.0.0-beta.1)",
+ "grin_util 3.0.0-beta.1 (git+https://github.com/mimblewimble/grin?tag=v3.0.0-beta.1)",
  "http 0.1.21 (registry+https://github.com/rust-lang/crates.io-index)",
  "hyper 0.12.19 (registry+https://github.com/rust-lang/crates.io-index)",
  "hyper-rustls 0.14.0 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -741,8 +742,8 @@ dependencies = [
 
 [[package]]
 name = "grin_chain"
-version = "3.0.0-alpha.1"
-source = "git+https://github.com/mimblewimble/grin#8b8f0a0abdb3f5058e452b8a550001f60e8b51fa"
+version = "3.0.0-beta.1"
+source = "git+https://github.com/mimblewimble/grin?tag=v3.0.0-beta.1#6a543345760b1d5518098923299d4556743b3694"
 dependencies = [
  "bit-vec 0.6.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "bitflags 1.2.1 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -751,10 +752,10 @@ dependencies = [
  "croaring 0.3.9 (registry+https://github.com/rust-lang/crates.io-index)",
  "failure 0.1.6 (registry+https://github.com/rust-lang/crates.io-index)",
  "failure_derive 0.1.6 (registry+https://github.com/rust-lang/crates.io-index)",
- "grin_core 3.0.0-alpha.1 (git+https://github.com/mimblewimble/grin)",
- "grin_keychain 3.0.0-alpha.1 (git+https://github.com/mimblewimble/grin)",
- "grin_store 3.0.0-alpha.1 (git+https://github.com/mimblewimble/grin)",
- "grin_util 3.0.0-alpha.1 (git+https://github.com/mimblewimble/grin)",
+ "grin_core 3.0.0-beta.1 (git+https://github.com/mimblewimble/grin?tag=v3.0.0-beta.1)",
+ "grin_keychain 3.0.0-beta.1 (git+https://github.com/mimblewimble/grin?tag=v3.0.0-beta.1)",
+ "grin_store 3.0.0-beta.1 (git+https://github.com/mimblewimble/grin?tag=v3.0.0-beta.1)",
+ "grin_util 3.0.0-beta.1 (git+https://github.com/mimblewimble/grin?tag=v3.0.0-beta.1)",
  "lazy_static 1.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "log 0.4.8 (registry+https://github.com/rust-lang/crates.io-index)",
  "lru-cache 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -765,8 +766,8 @@ dependencies = [
 
 [[package]]
 name = "grin_core"
-version = "3.0.0-alpha.1"
-source = "git+https://github.com/mimblewimble/grin#8b8f0a0abdb3f5058e452b8a550001f60e8b51fa"
+version = "3.0.0-beta.1"
+source = "git+https://github.com/mimblewimble/grin?tag=v3.0.0-beta.1#6a543345760b1d5518098923299d4556743b3694"
 dependencies = [
  "blake2-rfc 0.2.18 (registry+https://github.com/rust-lang/crates.io-index)",
  "byteorder 1.3.2 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -775,8 +776,8 @@ dependencies = [
  "enum_primitive 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "failure 0.1.6 (registry+https://github.com/rust-lang/crates.io-index)",
  "failure_derive 0.1.6 (registry+https://github.com/rust-lang/crates.io-index)",
- "grin_keychain 3.0.0-alpha.1 (git+https://github.com/mimblewimble/grin)",
- "grin_util 3.0.0-alpha.1 (git+https://github.com/mimblewimble/grin)",
+ "grin_keychain 3.0.0-beta.1 (git+https://github.com/mimblewimble/grin?tag=v3.0.0-beta.1)",
+ "grin_util 3.0.0-beta.1 (git+https://github.com/mimblewimble/grin?tag=v3.0.0-beta.1)",
  "lazy_static 1.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "log 0.4.8 (registry+https://github.com/rust-lang/crates.io-index)",
  "lru-cache 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -792,13 +793,13 @@ dependencies = [
 
 [[package]]
 name = "grin_keychain"
-version = "3.0.0-alpha.1"
-source = "git+https://github.com/mimblewimble/grin#8b8f0a0abdb3f5058e452b8a550001f60e8b51fa"
+version = "3.0.0-beta.1"
+source = "git+https://github.com/mimblewimble/grin?tag=v3.0.0-beta.1#6a543345760b1d5518098923299d4556743b3694"
 dependencies = [
  "blake2-rfc 0.2.18 (registry+https://github.com/rust-lang/crates.io-index)",
  "byteorder 1.3.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "digest 0.7.6 (registry+https://github.com/rust-lang/crates.io-index)",
- "grin_util 3.0.0-alpha.1 (git+https://github.com/mimblewimble/grin)",
+ "grin_util 3.0.0-beta.1 (git+https://github.com/mimblewimble/grin?tag=v3.0.0-beta.1)",
  "hmac 0.6.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "lazy_static 1.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "log 0.4.8 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -815,17 +816,17 @@ dependencies = [
 
 [[package]]
 name = "grin_p2p"
-version = "3.0.0-alpha.1"
-source = "git+https://github.com/mimblewimble/grin#8b8f0a0abdb3f5058e452b8a550001f60e8b51fa"
+version = "3.0.0-beta.1"
+source = "git+https://github.com/mimblewimble/grin?tag=v3.0.0-beta.1#6a543345760b1d5518098923299d4556743b3694"
 dependencies = [
  "bitflags 1.2.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "bytes 0.4.12 (registry+https://github.com/rust-lang/crates.io-index)",
  "chrono 0.4.10 (registry+https://github.com/rust-lang/crates.io-index)",
  "enum_primitive 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "grin_chain 3.0.0-alpha.1 (git+https://github.com/mimblewimble/grin)",
- "grin_core 3.0.0-alpha.1 (git+https://github.com/mimblewimble/grin)",
- "grin_store 3.0.0-alpha.1 (git+https://github.com/mimblewimble/grin)",
- "grin_util 3.0.0-alpha.1 (git+https://github.com/mimblewimble/grin)",
+ "grin_chain 3.0.0-beta.1 (git+https://github.com/mimblewimble/grin?tag=v3.0.0-beta.1)",
+ "grin_core 3.0.0-beta.1 (git+https://github.com/mimblewimble/grin?tag=v3.0.0-beta.1)",
+ "grin_store 3.0.0-beta.1 (git+https://github.com/mimblewimble/grin?tag=v3.0.0-beta.1)",
+ "grin_util 3.0.0-beta.1 (git+https://github.com/mimblewimble/grin?tag=v3.0.0-beta.1)",
  "log 0.4.8 (registry+https://github.com/rust-lang/crates.io-index)",
  "lru-cache 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "net2 0.2.33 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -838,17 +839,17 @@ dependencies = [
 
 [[package]]
 name = "grin_pool"
-version = "3.0.0-alpha.1"
-source = "git+https://github.com/mimblewimble/grin#8b8f0a0abdb3f5058e452b8a550001f60e8b51fa"
+version = "3.0.0-beta.1"
+source = "git+https://github.com/mimblewimble/grin?tag=v3.0.0-beta.1#6a543345760b1d5518098923299d4556743b3694"
 dependencies = [
  "blake2-rfc 0.2.18 (registry+https://github.com/rust-lang/crates.io-index)",
  "chrono 0.4.10 (registry+https://github.com/rust-lang/crates.io-index)",
  "failure 0.1.6 (registry+https://github.com/rust-lang/crates.io-index)",
  "failure_derive 0.1.6 (registry+https://github.com/rust-lang/crates.io-index)",
- "grin_core 3.0.0-alpha.1 (git+https://github.com/mimblewimble/grin)",
- "grin_keychain 3.0.0-alpha.1 (git+https://github.com/mimblewimble/grin)",
- "grin_store 3.0.0-alpha.1 (git+https://github.com/mimblewimble/grin)",
- "grin_util 3.0.0-alpha.1 (git+https://github.com/mimblewimble/grin)",
+ "grin_core 3.0.0-beta.1 (git+https://github.com/mimblewimble/grin?tag=v3.0.0-beta.1)",
+ "grin_keychain 3.0.0-beta.1 (git+https://github.com/mimblewimble/grin?tag=v3.0.0-beta.1)",
+ "grin_store 3.0.0-beta.1 (git+https://github.com/mimblewimble/grin?tag=v3.0.0-beta.1)",
+ "grin_util 3.0.0-beta.1 (git+https://github.com/mimblewimble/grin?tag=v3.0.0-beta.1)",
  "log 0.4.8 (registry+https://github.com/rust-lang/crates.io-index)",
  "rand 0.6.5 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde 1.0.103 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -872,8 +873,8 @@ dependencies = [
 
 [[package]]
 name = "grin_store"
-version = "3.0.0-alpha.1"
-source = "git+https://github.com/mimblewimble/grin#8b8f0a0abdb3f5058e452b8a550001f60e8b51fa"
+version = "3.0.0-beta.1"
+source = "git+https://github.com/mimblewimble/grin?tag=v3.0.0-beta.1#6a543345760b1d5518098923299d4556743b3694"
 dependencies = [
  "bit-vec 0.6.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "byteorder 1.3.2 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -881,8 +882,8 @@ dependencies = [
  "env_logger 0.5.13 (registry+https://github.com/rust-lang/crates.io-index)",
  "failure 0.1.6 (registry+https://github.com/rust-lang/crates.io-index)",
  "failure_derive 0.1.6 (registry+https://github.com/rust-lang/crates.io-index)",
- "grin_core 3.0.0-alpha.1 (git+https://github.com/mimblewimble/grin)",
- "grin_util 3.0.0-alpha.1 (git+https://github.com/mimblewimble/grin)",
+ "grin_core 3.0.0-beta.1 (git+https://github.com/mimblewimble/grin?tag=v3.0.0-beta.1)",
+ "grin_util 3.0.0-beta.1 (git+https://github.com/mimblewimble/grin?tag=v3.0.0-beta.1)",
  "libc 0.2.66 (registry+https://github.com/rust-lang/crates.io-index)",
  "lmdb-zero 0.4.4 (registry+https://github.com/rust-lang/crates.io-index)",
  "log 0.4.8 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -894,8 +895,8 @@ dependencies = [
 
 [[package]]
 name = "grin_util"
-version = "3.0.0-alpha.1"
-source = "git+https://github.com/mimblewimble/grin#8b8f0a0abdb3f5058e452b8a550001f60e8b51fa"
+version = "3.0.0-beta.1"
+source = "git+https://github.com/mimblewimble/grin?tag=v3.0.0-beta.1#6a543345760b1d5518098923299d4556743b3694"
 dependencies = [
  "backtrace 0.3.40 (registry+https://github.com/rust-lang/crates.io-index)",
  "base64 0.9.3 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -1075,12 +1076,12 @@ name = "grin_wallet_util"
 version = "3.0.0-beta.1"
 dependencies = [
  "dirs 1.0.5 (registry+https://github.com/rust-lang/crates.io-index)",
- "grin_api 3.0.0-alpha.1 (git+https://github.com/mimblewimble/grin)",
- "grin_chain 3.0.0-alpha.1 (git+https://github.com/mimblewimble/grin)",
- "grin_core 3.0.0-alpha.1 (git+https://github.com/mimblewimble/grin)",
- "grin_keychain 3.0.0-alpha.1 (git+https://github.com/mimblewimble/grin)",
- "grin_store 3.0.0-alpha.1 (git+https://github.com/mimblewimble/grin)",
- "grin_util 3.0.0-alpha.1 (git+https://github.com/mimblewimble/grin)",
+ "grin_api 3.0.0-beta.1 (git+https://github.com/mimblewimble/grin?tag=v3.0.0-beta.1)",
+ "grin_chain 3.0.0-beta.1 (git+https://github.com/mimblewimble/grin?tag=v3.0.0-beta.1)",
+ "grin_core 3.0.0-beta.1 (git+https://github.com/mimblewimble/grin?tag=v3.0.0-beta.1)",
+ "grin_keychain 3.0.0-beta.1 (git+https://github.com/mimblewimble/grin?tag=v3.0.0-beta.1)",
+ "grin_store 3.0.0-beta.1 (git+https://github.com/mimblewimble/grin?tag=v3.0.0-beta.1)",
+ "grin_util 3.0.0-beta.1 (git+https://github.com/mimblewimble/grin?tag=v3.0.0-beta.1)",
  "pretty_assertions 0.5.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "rand 0.5.6 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde 1.0.103 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -3221,15 +3222,15 @@ dependencies = [
 "checksum getrandom 0.1.13 (registry+https://github.com/rust-lang/crates.io-index)" = "e7db7ca94ed4cd01190ceee0d8a8052f08a247aa1b469a7f68c6a3b71afcf407"
 "checksum git2 0.10.2 (registry+https://github.com/rust-lang/crates.io-index)" = "7c1af51ea8a906616af45a4ce78eacf25860f7a13ae7bf8a814693f0f4037a26"
 "checksum glob 0.2.11 (registry+https://github.com/rust-lang/crates.io-index)" = "8be18de09a56b60ed0edf84bc9df007e30040691af7acd1c41874faac5895bfb"
-"checksum grin_api 3.0.0-alpha.1 (git+https://github.com/mimblewimble/grin)" = "<none>"
-"checksum grin_chain 3.0.0-alpha.1 (git+https://github.com/mimblewimble/grin)" = "<none>"
-"checksum grin_core 3.0.0-alpha.1 (git+https://github.com/mimblewimble/grin)" = "<none>"
-"checksum grin_keychain 3.0.0-alpha.1 (git+https://github.com/mimblewimble/grin)" = "<none>"
-"checksum grin_p2p 3.0.0-alpha.1 (git+https://github.com/mimblewimble/grin)" = "<none>"
-"checksum grin_pool 3.0.0-alpha.1 (git+https://github.com/mimblewimble/grin)" = "<none>"
+"checksum grin_api 3.0.0-beta.1 (git+https://github.com/mimblewimble/grin?tag=v3.0.0-beta.1)" = "<none>"
+"checksum grin_chain 3.0.0-beta.1 (git+https://github.com/mimblewimble/grin?tag=v3.0.0-beta.1)" = "<none>"
+"checksum grin_core 3.0.0-beta.1 (git+https://github.com/mimblewimble/grin?tag=v3.0.0-beta.1)" = "<none>"
+"checksum grin_keychain 3.0.0-beta.1 (git+https://github.com/mimblewimble/grin?tag=v3.0.0-beta.1)" = "<none>"
+"checksum grin_p2p 3.0.0-beta.1 (git+https://github.com/mimblewimble/grin?tag=v3.0.0-beta.1)" = "<none>"
+"checksum grin_pool 3.0.0-beta.1 (git+https://github.com/mimblewimble/grin?tag=v3.0.0-beta.1)" = "<none>"
 "checksum grin_secp256k1zkp 0.7.7 (registry+https://github.com/rust-lang/crates.io-index)" = "23027a7673df2c2b20fb9589d742ff400a10a9c3e4c769a77e9fa3bd19586822"
-"checksum grin_store 3.0.0-alpha.1 (git+https://github.com/mimblewimble/grin)" = "<none>"
-"checksum grin_util 3.0.0-alpha.1 (git+https://github.com/mimblewimble/grin)" = "<none>"
+"checksum grin_store 3.0.0-beta.1 (git+https://github.com/mimblewimble/grin?tag=v3.0.0-beta.1)" = "<none>"
+"checksum grin_util 3.0.0-beta.1 (git+https://github.com/mimblewimble/grin?tag=v3.0.0-beta.1)" = "<none>"
 "checksum h2 0.1.26 (registry+https://github.com/rust-lang/crates.io-index)" = "a5b34c246847f938a410a03c5458c7fee2274436675e76d8b903c08efc29c462"
 "checksum heck 0.3.1 (registry+https://github.com/rust-lang/crates.io-index)" = "20564e78d53d2bb135c343b3f47714a56af2061f1c928fdb541dc7b9fdd94205"
 "checksum hermit-abi 0.1.3 (registry+https://github.com/rust-lang/crates.io-index)" = "307c3c9f937f38e3534b1d6447ecf090cafcc9744e4a6360e8b037b2cf5af120"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -88,7 +88,7 @@ name = "backtrace-sys"
 version = "0.1.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "cc 1.0.47 (registry+https://github.com/rust-lang/crates.io-index)",
+ "cc 1.0.48 (registry+https://github.com/rust-lang/crates.io-index)",
  "libc 0.2.66 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
@@ -240,7 +240,7 @@ dependencies = [
 
 [[package]]
 name = "cc"
-version = "1.0.47"
+version = "1.0.48"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "jobserver 0.1.17 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -301,7 +301,7 @@ name = "clear_on_drop"
 version = "0.2.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "cc 1.0.47 (registry+https://github.com/rust-lang/crates.io-index)",
+ "cc 1.0.48 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -340,7 +340,7 @@ version = "0.3.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "bindgen 0.37.4 (registry+https://github.com/rust-lang/crates.io-index)",
- "cc 1.0.47 (registry+https://github.com/rust-lang/crates.io-index)",
+ "cc 1.0.48 (registry+https://github.com/rust-lang/crates.io-index)",
  "libc 0.2.66 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
@@ -504,7 +504,7 @@ dependencies = [
  "jsonrpc-core 10.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "rand 0.6.5 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde 1.0.103 (registry+https://github.com/rust-lang/crates.io-index)",
- "serde_json 1.0.42 (registry+https://github.com/rust-lang/crates.io-index)",
+ "serde_json 1.0.44 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -516,7 +516,7 @@ dependencies = [
  "jsonrpc-core 10.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "rand 0.6.5 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde 1.0.103 (registry+https://github.com/rust-lang/crates.io-index)",
- "serde_json 1.0.42 (registry+https://github.com/rust-lang/crates.io-index)",
+ "serde_json 1.0.44 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -709,7 +709,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 [[package]]
 name = "grin_api"
 version = "3.0.0-alpha.1"
-source = "git+https://github.com/mimblewimble/grin#52ea906b6128b554848f62f8c234bfd681d4a8ee"
+source = "git+https://github.com/mimblewimble/grin#8b8f0a0abdb3f5058e452b8a550001f60e8b51fa"
 dependencies = [
  "failure 0.1.6 (registry+https://github.com/rust-lang/crates.io-index)",
  "failure_derive 0.1.6 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -731,7 +731,7 @@ dependencies = [
  "rustls 0.13.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde 1.0.103 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde_derive 1.0.103 (registry+https://github.com/rust-lang/crates.io-index)",
- "serde_json 1.0.42 (registry+https://github.com/rust-lang/crates.io-index)",
+ "serde_json 1.0.44 (registry+https://github.com/rust-lang/crates.io-index)",
  "tokio 0.1.11 (registry+https://github.com/rust-lang/crates.io-index)",
  "tokio-core 0.1.17 (registry+https://github.com/rust-lang/crates.io-index)",
  "tokio-rustls 0.7.2 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -742,7 +742,7 @@ dependencies = [
 [[package]]
 name = "grin_chain"
 version = "3.0.0-alpha.1"
-source = "git+https://github.com/mimblewimble/grin#52ea906b6128b554848f62f8c234bfd681d4a8ee"
+source = "git+https://github.com/mimblewimble/grin#8b8f0a0abdb3f5058e452b8a550001f60e8b51fa"
 dependencies = [
  "bit-vec 0.6.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "bitflags 1.2.1 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -766,7 +766,7 @@ dependencies = [
 [[package]]
 name = "grin_core"
 version = "3.0.0-alpha.1"
-source = "git+https://github.com/mimblewimble/grin#52ea906b6128b554848f62f8c234bfd681d4a8ee"
+source = "git+https://github.com/mimblewimble/grin#8b8f0a0abdb3f5058e452b8a550001f60e8b51fa"
 dependencies = [
  "blake2-rfc 0.2.18 (registry+https://github.com/rust-lang/crates.io-index)",
  "byteorder 1.3.2 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -793,7 +793,7 @@ dependencies = [
 [[package]]
 name = "grin_keychain"
 version = "3.0.0-alpha.1"
-source = "git+https://github.com/mimblewimble/grin#52ea906b6128b554848f62f8c234bfd681d4a8ee"
+source = "git+https://github.com/mimblewimble/grin#8b8f0a0abdb3f5058e452b8a550001f60e8b51fa"
 dependencies = [
  "blake2-rfc 0.2.18 (registry+https://github.com/rust-lang/crates.io-index)",
  "byteorder 1.3.2 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -807,7 +807,7 @@ dependencies = [
  "ripemd160 0.7.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde 1.0.103 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde_derive 1.0.103 (registry+https://github.com/rust-lang/crates.io-index)",
- "serde_json 1.0.42 (registry+https://github.com/rust-lang/crates.io-index)",
+ "serde_json 1.0.44 (registry+https://github.com/rust-lang/crates.io-index)",
  "sha2 0.7.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "uuid 0.6.5 (registry+https://github.com/rust-lang/crates.io-index)",
  "zeroize 0.9.3 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -816,7 +816,7 @@ dependencies = [
 [[package]]
 name = "grin_p2p"
 version = "3.0.0-alpha.1"
-source = "git+https://github.com/mimblewimble/grin#52ea906b6128b554848f62f8c234bfd681d4a8ee"
+source = "git+https://github.com/mimblewimble/grin#8b8f0a0abdb3f5058e452b8a550001f60e8b51fa"
 dependencies = [
  "bitflags 1.2.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "bytes 0.4.12 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -839,7 +839,7 @@ dependencies = [
 [[package]]
 name = "grin_pool"
 version = "3.0.0-alpha.1"
-source = "git+https://github.com/mimblewimble/grin#52ea906b6128b554848f62f8c234bfd681d4a8ee"
+source = "git+https://github.com/mimblewimble/grin#8b8f0a0abdb3f5058e452b8a550001f60e8b51fa"
 dependencies = [
  "blake2-rfc 0.2.18 (registry+https://github.com/rust-lang/crates.io-index)",
  "chrono 0.4.10 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -861,19 +861,19 @@ version = "0.7.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "arrayvec 0.3.25 (registry+https://github.com/rust-lang/crates.io-index)",
- "cc 1.0.47 (registry+https://github.com/rust-lang/crates.io-index)",
+ "cc 1.0.48 (registry+https://github.com/rust-lang/crates.io-index)",
  "libc 0.2.66 (registry+https://github.com/rust-lang/crates.io-index)",
  "rand 0.5.6 (registry+https://github.com/rust-lang/crates.io-index)",
  "rustc-serialize 0.3.24 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde 1.0.103 (registry+https://github.com/rust-lang/crates.io-index)",
- "serde_json 1.0.42 (registry+https://github.com/rust-lang/crates.io-index)",
+ "serde_json 1.0.44 (registry+https://github.com/rust-lang/crates.io-index)",
  "zeroize 0.9.3 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
 name = "grin_store"
 version = "3.0.0-alpha.1"
-source = "git+https://github.com/mimblewimble/grin#52ea906b6128b554848f62f8c234bfd681d4a8ee"
+source = "git+https://github.com/mimblewimble/grin#8b8f0a0abdb3f5058e452b8a550001f60e8b51fa"
 dependencies = [
  "bit-vec 0.6.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "byteorder 1.3.2 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -895,7 +895,7 @@ dependencies = [
 [[package]]
 name = "grin_util"
 version = "3.0.0-alpha.1"
-source = "git+https://github.com/mimblewimble/grin#52ea906b6128b554848f62f8c234bfd681d4a8ee"
+source = "git+https://github.com/mimblewimble/grin#8b8f0a0abdb3f5058e452b8a550001f60e8b51fa"
 dependencies = [
  "backtrace 0.3.40 (registry+https://github.com/rust-lang/crates.io-index)",
  "base64 0.9.3 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -915,7 +915,7 @@ dependencies = [
 
 [[package]]
 name = "grin_wallet"
-version = "3.0.0-alpha.1"
+version = "3.0.0-beta.1"
 dependencies = [
  "built 0.3.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "clap 2.33.0 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -923,12 +923,12 @@ dependencies = [
  "easy-jsonrpc 0.5.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "failure 0.1.6 (registry+https://github.com/rust-lang/crates.io-index)",
  "failure_derive 0.1.6 (registry+https://github.com/rust-lang/crates.io-index)",
- "grin_wallet_api 3.0.0-alpha.1",
- "grin_wallet_config 3.0.0-alpha.1",
- "grin_wallet_controller 3.0.0-alpha.1",
- "grin_wallet_impls 3.0.0-alpha.1",
- "grin_wallet_libwallet 3.0.0-alpha.1",
- "grin_wallet_util 3.0.0-alpha.1",
+ "grin_wallet_api 3.0.0-beta.1",
+ "grin_wallet_config 3.0.0-beta.1",
+ "grin_wallet_controller 3.0.0-beta.1",
+ "grin_wallet_impls 3.0.0-beta.1",
+ "grin_wallet_libwallet 3.0.0-beta.1",
+ "grin_wallet_util 3.0.0-beta.1",
  "linefeed 0.5.4 (registry+https://github.com/rust-lang/crates.io-index)",
  "log 0.4.8 (registry+https://github.com/rust-lang/crates.io-index)",
  "prettytable-rs 0.7.0 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -936,13 +936,13 @@ dependencies = [
  "semver 0.9.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde 1.0.103 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde_derive 1.0.103 (registry+https://github.com/rust-lang/crates.io-index)",
- "serde_json 1.0.42 (registry+https://github.com/rust-lang/crates.io-index)",
+ "serde_json 1.0.44 (registry+https://github.com/rust-lang/crates.io-index)",
  "url 1.7.2 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
 name = "grin_wallet_api"
-version = "3.0.0-alpha.1"
+version = "3.0.0-beta.1"
 dependencies = [
  "base64 0.9.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "chrono 0.4.10 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -950,26 +950,26 @@ dependencies = [
  "ed25519-dalek 1.0.0-pre.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "failure 0.1.6 (registry+https://github.com/rust-lang/crates.io-index)",
  "failure_derive 0.1.6 (registry+https://github.com/rust-lang/crates.io-index)",
- "grin_wallet_config 3.0.0-alpha.1",
- "grin_wallet_impls 3.0.0-alpha.1",
- "grin_wallet_libwallet 3.0.0-alpha.1",
- "grin_wallet_util 3.0.0-alpha.1",
+ "grin_wallet_config 3.0.0-beta.1",
+ "grin_wallet_impls 3.0.0-beta.1",
+ "grin_wallet_libwallet 3.0.0-beta.1",
+ "grin_wallet_util 3.0.0-beta.1",
  "log 0.4.8 (registry+https://github.com/rust-lang/crates.io-index)",
  "rand 0.5.6 (registry+https://github.com/rust-lang/crates.io-index)",
  "ring 0.13.5 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde 1.0.103 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde_derive 1.0.103 (registry+https://github.com/rust-lang/crates.io-index)",
- "serde_json 1.0.42 (registry+https://github.com/rust-lang/crates.io-index)",
+ "serde_json 1.0.44 (registry+https://github.com/rust-lang/crates.io-index)",
  "tempfile 3.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "uuid 0.7.4 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
 name = "grin_wallet_config"
-version = "3.0.0-alpha.1"
+version = "3.0.0-beta.1"
 dependencies = [
  "dirs 1.0.5 (registry+https://github.com/rust-lang/crates.io-index)",
- "grin_wallet_util 3.0.0-alpha.1",
+ "grin_wallet_util 3.0.0-beta.1",
  "pretty_assertions 0.5.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "rand 0.5.6 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde 1.0.103 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -979,18 +979,18 @@ dependencies = [
 
 [[package]]
 name = "grin_wallet_controller"
-version = "3.0.0-alpha.1"
+version = "3.0.0-beta.1"
 dependencies = [
  "chrono 0.4.10 (registry+https://github.com/rust-lang/crates.io-index)",
  "easy-jsonrpc-mw 0.5.4 (registry+https://github.com/rust-lang/crates.io-index)",
  "failure 0.1.6 (registry+https://github.com/rust-lang/crates.io-index)",
  "failure_derive 0.1.6 (registry+https://github.com/rust-lang/crates.io-index)",
  "futures 0.1.29 (registry+https://github.com/rust-lang/crates.io-index)",
- "grin_wallet_api 3.0.0-alpha.1",
- "grin_wallet_config 3.0.0-alpha.1",
- "grin_wallet_impls 3.0.0-alpha.1",
- "grin_wallet_libwallet 3.0.0-alpha.1",
- "grin_wallet_util 3.0.0-alpha.1",
+ "grin_wallet_api 3.0.0-beta.1",
+ "grin_wallet_config 3.0.0-beta.1",
+ "grin_wallet_impls 3.0.0-beta.1",
+ "grin_wallet_libwallet 3.0.0-beta.1",
+ "grin_wallet_util 3.0.0-beta.1",
  "hyper 0.12.19 (registry+https://github.com/rust-lang/crates.io-index)",
  "lazy_static 1.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "log 0.4.8 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -999,7 +999,7 @@ dependencies = [
  "ring 0.13.5 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde 1.0.103 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde_derive 1.0.103 (registry+https://github.com/rust-lang/crates.io-index)",
- "serde_json 1.0.42 (registry+https://github.com/rust-lang/crates.io-index)",
+ "serde_json 1.0.44 (registry+https://github.com/rust-lang/crates.io-index)",
  "term 0.5.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "tokio 0.1.11 (registry+https://github.com/rust-lang/crates.io-index)",
  "tokio-core 0.1.17 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -1010,7 +1010,7 @@ dependencies = [
 
 [[package]]
 name = "grin_wallet_impls"
-version = "3.0.0-alpha.1"
+version = "3.0.0-beta.1"
 dependencies = [
  "blake2-rfc 0.2.18 (registry+https://github.com/rust-lang/crates.io-index)",
  "byteorder 1.3.2 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -1020,9 +1020,9 @@ dependencies = [
  "failure 0.1.6 (registry+https://github.com/rust-lang/crates.io-index)",
  "failure_derive 0.1.6 (registry+https://github.com/rust-lang/crates.io-index)",
  "futures 0.1.29 (registry+https://github.com/rust-lang/crates.io-index)",
- "grin_wallet_config 3.0.0-alpha.1",
- "grin_wallet_libwallet 3.0.0-alpha.1",
- "grin_wallet_util 3.0.0-alpha.1",
+ "grin_wallet_config 3.0.0-beta.1",
+ "grin_wallet_libwallet 3.0.0-beta.1",
+ "grin_wallet_util 3.0.0-beta.1",
  "http 0.1.21 (registry+https://github.com/rust-lang/crates.io-index)",
  "hyper 0.12.19 (registry+https://github.com/rust-lang/crates.io-index)",
  "hyper-rustls 0.14.0 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -1034,7 +1034,7 @@ dependencies = [
  "semver 0.9.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde 1.0.103 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde_derive 1.0.103 (registry+https://github.com/rust-lang/crates.io-index)",
- "serde_json 1.0.42 (registry+https://github.com/rust-lang/crates.io-index)",
+ "serde_json 1.0.44 (registry+https://github.com/rust-lang/crates.io-index)",
  "sysinfo 0.9.6 (registry+https://github.com/rust-lang/crates.io-index)",
  "timer 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "tokio 0.1.11 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -1047,7 +1047,7 @@ dependencies = [
 
 [[package]]
 name = "grin_wallet_libwallet"
-version = "3.0.0-alpha.1"
+version = "3.0.0-beta.1"
 dependencies = [
  "blake2-rfc 0.2.18 (registry+https://github.com/rust-lang/crates.io-index)",
  "byteorder 1.3.2 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -1056,14 +1056,14 @@ dependencies = [
  "ed25519-dalek 1.0.0-pre.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "failure 0.1.6 (registry+https://github.com/rust-lang/crates.io-index)",
  "failure_derive 0.1.6 (registry+https://github.com/rust-lang/crates.io-index)",
- "grin_wallet_config 3.0.0-alpha.1",
- "grin_wallet_util 3.0.0-alpha.1",
+ "grin_wallet_config 3.0.0-beta.1",
+ "grin_wallet_util 3.0.0-beta.1",
  "lazy_static 1.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "log 0.4.8 (registry+https://github.com/rust-lang/crates.io-index)",
  "rand 0.5.6 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde 1.0.103 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde_derive 1.0.103 (registry+https://github.com/rust-lang/crates.io-index)",
- "serde_json 1.0.42 (registry+https://github.com/rust-lang/crates.io-index)",
+ "serde_json 1.0.44 (registry+https://github.com/rust-lang/crates.io-index)",
  "sha3 0.8.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "strum 0.15.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "strum_macros 0.15.0 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -1072,7 +1072,7 @@ dependencies = [
 
 [[package]]
 name = "grin_wallet_util"
-version = "3.0.0-alpha.1"
+version = "3.0.0-beta.1"
 dependencies = [
  "dirs 1.0.5 (registry+https://github.com/rust-lang/crates.io-index)",
  "grin_api 3.0.0-alpha.1 (git+https://github.com/mimblewimble/grin)",
@@ -1174,7 +1174,7 @@ dependencies = [
  "tokio-io 0.1.12 (registry+https://github.com/rust-lang/crates.io-index)",
  "tokio-reactor 0.1.11 (registry+https://github.com/rust-lang/crates.io-index)",
  "tokio-tcp 0.1.3 (registry+https://github.com/rust-lang/crates.io-index)",
- "tokio-threadpool 0.1.16 (registry+https://github.com/rust-lang/crates.io-index)",
+ "tokio-threadpool 0.1.17 (registry+https://github.com/rust-lang/crates.io-index)",
  "tokio-timer 0.2.12 (registry+https://github.com/rust-lang/crates.io-index)",
  "want 0.0.6 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
@@ -1271,7 +1271,7 @@ dependencies = [
  "log 0.4.8 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde 1.0.103 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde_derive 1.0.103 (registry+https://github.com/rust-lang/crates.io-index)",
- "serde_json 1.0.42 (registry+https://github.com/rust-lang/crates.io-index)",
+ "serde_json 1.0.44 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -1303,7 +1303,7 @@ name = "libgit2-sys"
 version = "0.9.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "cc 1.0.47 (registry+https://github.com/rust-lang/crates.io-index)",
+ "cc 1.0.48 (registry+https://github.com/rust-lang/crates.io-index)",
  "libc 0.2.66 (registry+https://github.com/rust-lang/crates.io-index)",
  "libz-sys 1.0.25 (registry+https://github.com/rust-lang/crates.io-index)",
  "pkg-config 0.3.17 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -1323,7 +1323,7 @@ name = "libloading"
 version = "0.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "cc 1.0.47 (registry+https://github.com/rust-lang/crates.io-index)",
+ "cc 1.0.48 (registry+https://github.com/rust-lang/crates.io-index)",
  "winapi 0.3.8 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
@@ -1332,7 +1332,7 @@ name = "libz-sys"
 version = "1.0.25"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "cc 1.0.47 (registry+https://github.com/rust-lang/crates.io-index)",
+ "cc 1.0.48 (registry+https://github.com/rust-lang/crates.io-index)",
  "libc 0.2.66 (registry+https://github.com/rust-lang/crates.io-index)",
  "pkg-config 0.3.17 (registry+https://github.com/rust-lang/crates.io-index)",
  "vcpkg 0.2.8 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -1412,7 +1412,7 @@ dependencies = [
  "serde 1.0.103 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde-value 0.5.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde_derive 1.0.103 (registry+https://github.com/rust-lang/crates.io-index)",
- "serde_json 1.0.42 (registry+https://github.com/rust-lang/crates.io-index)",
+ "serde_json 1.0.44 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde_yaml 0.8.11 (registry+https://github.com/rust-lang/crates.io-index)",
  "thread-id 3.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "typemap 0.3.3 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -1558,7 +1558,7 @@ version = "0.14.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "bitflags 1.2.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "cc 1.0.47 (registry+https://github.com/rust-lang/crates.io-index)",
+ "cc 1.0.48 (registry+https://github.com/rust-lang/crates.io-index)",
  "cfg-if 0.1.10 (registry+https://github.com/rust-lang/crates.io-index)",
  "libc 0.2.66 (registry+https://github.com/rust-lang/crates.io-index)",
  "void 1.0.2 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -2183,7 +2183,7 @@ name = "ring"
 version = "0.13.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "cc 1.0.47 (registry+https://github.com/rust-lang/crates.io-index)",
+ "cc 1.0.48 (registry+https://github.com/rust-lang/crates.io-index)",
  "lazy_static 1.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "libc 0.2.66 (registry+https://github.com/rust-lang/crates.io-index)",
  "untrusted 0.6.2 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -2347,7 +2347,7 @@ dependencies = [
 
 [[package]]
 name = "serde_json"
-version = "1.0.42"
+version = "1.0.44"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "itoa 0.4.4 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -2630,7 +2630,7 @@ dependencies = [
  "tokio-io 0.1.12 (registry+https://github.com/rust-lang/crates.io-index)",
  "tokio-reactor 0.1.11 (registry+https://github.com/rust-lang/crates.io-index)",
  "tokio-tcp 0.1.3 (registry+https://github.com/rust-lang/crates.io-index)",
- "tokio-threadpool 0.1.16 (registry+https://github.com/rust-lang/crates.io-index)",
+ "tokio-threadpool 0.1.17 (registry+https://github.com/rust-lang/crates.io-index)",
  "tokio-timer 0.2.12 (registry+https://github.com/rust-lang/crates.io-index)",
  "tokio-udp 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)",
  "tokio-uds 0.2.5 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -2689,7 +2689,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "futures 0.1.29 (registry+https://github.com/rust-lang/crates.io-index)",
  "tokio-io 0.1.12 (registry+https://github.com/rust-lang/crates.io-index)",
- "tokio-threadpool 0.1.16 (registry+https://github.com/rust-lang/crates.io-index)",
+ "tokio-threadpool 0.1.17 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -2784,7 +2784,7 @@ dependencies = [
 
 [[package]]
 name = "tokio-threadpool"
-version = "0.1.16"
+version = "0.1.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "crossbeam-deque 0.7.2 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -3166,7 +3166,7 @@ dependencies = [
 "checksum byteorder 1.3.2 (registry+https://github.com/rust-lang/crates.io-index)" = "a7c3dd8985a7111efc5c80b44e23ecdd8c007de8ade3b96595387e812b957cf5"
 "checksum bytes 0.4.12 (registry+https://github.com/rust-lang/crates.io-index)" = "206fdffcfa2df7cbe15601ef46c813fce0965eb3286db6b56c583b814b51c81c"
 "checksum c2-chacha 0.2.3 (registry+https://github.com/rust-lang/crates.io-index)" = "214238caa1bf3a496ec3392968969cab8549f96ff30652c9e56885329315f6bb"
-"checksum cc 1.0.47 (registry+https://github.com/rust-lang/crates.io-index)" = "aa87058dce70a3ff5621797f1506cb837edd02ac4c0ae642b4542dce802908b8"
+"checksum cc 1.0.48 (registry+https://github.com/rust-lang/crates.io-index)" = "f52a465a666ca3d838ebbf08b241383421412fe7ebb463527bba275526d89f76"
 "checksum cexpr 0.2.3 (registry+https://github.com/rust-lang/crates.io-index)" = "42aac45e9567d97474a834efdee3081b3c942b2205be932092f53354ce503d6c"
 "checksum cfg-if 0.1.10 (registry+https://github.com/rust-lang/crates.io-index)" = "4785bdd1c96b2a846b2bd7cc02e86b6b3dbf14e7e53446c4f54c92a361040822"
 "checksum chrono 0.4.10 (registry+https://github.com/rust-lang/crates.io-index)" = "31850b4a4d6bae316f7a09e691c944c28299298837edc0a03f755618c23cbc01"
@@ -3369,7 +3369,7 @@ dependencies = [
 "checksum serde 1.0.103 (registry+https://github.com/rust-lang/crates.io-index)" = "1217f97ab8e8904b57dd22eb61cde455fa7446a9c1cf43966066da047c1f3702"
 "checksum serde-value 0.5.3 (registry+https://github.com/rust-lang/crates.io-index)" = "7a663f873dedc4eac1a559d4c6bc0d0b2c34dc5ac4702e105014b8281489e44f"
 "checksum serde_derive 1.0.103 (registry+https://github.com/rust-lang/crates.io-index)" = "a8c6faef9a2e64b0064f48570289b4bf8823b7581f1d6157c1b52152306651d0"
-"checksum serde_json 1.0.42 (registry+https://github.com/rust-lang/crates.io-index)" = "1a3351dcbc1f067e2c92ab7c3c1f288ad1a4cffc470b5aaddb4c2e0a3ae80043"
+"checksum serde_json 1.0.44 (registry+https://github.com/rust-lang/crates.io-index)" = "48c575e0cc52bdd09b47f330f646cf59afc586e9c4e3ccd6fc1f625b8ea1dad7"
 "checksum serde_yaml 0.8.11 (registry+https://github.com/rust-lang/crates.io-index)" = "691b17f19fc1ec9d94ec0b5864859290dff279dbd7b03f017afda54eb36c3c35"
 "checksum sha2 0.7.1 (registry+https://github.com/rust-lang/crates.io-index)" = "9eb6be24e4c23a84d7184280d2722f7f2731fcdd4a9d886efbfe4413e4847ea0"
 "checksum sha2 0.8.0 (registry+https://github.com/rust-lang/crates.io-index)" = "7b4d8bfd0e469f417657573d8451fb33d16cfe0989359b93baf3a1ffc639543d"
@@ -3414,7 +3414,7 @@ dependencies = [
 "checksum tokio-service 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)" = "24da22d077e0f15f55162bdbdc661228c1581892f52074fb242678d015b45162"
 "checksum tokio-sync 0.1.7 (registry+https://github.com/rust-lang/crates.io-index)" = "d06554cce1ae4a50f42fba8023918afa931413aded705b560e29600ccf7c6d76"
 "checksum tokio-tcp 0.1.3 (registry+https://github.com/rust-lang/crates.io-index)" = "1d14b10654be682ac43efee27401d792507e30fd8d26389e1da3b185de2e4119"
-"checksum tokio-threadpool 0.1.16 (registry+https://github.com/rust-lang/crates.io-index)" = "2bd2c6a3885302581f4401c82af70d792bb9df1700e7437b0aeb4ada94d5388c"
+"checksum tokio-threadpool 0.1.17 (registry+https://github.com/rust-lang/crates.io-index)" = "f0c32ffea4827978e9aa392d2f743d973c1dfa3730a2ed3f22ce1e6984da848c"
 "checksum tokio-timer 0.2.12 (registry+https://github.com/rust-lang/crates.io-index)" = "1739638e364e558128461fc1ad84d997702c8e31c2e6b18fb99842268199e827"
 "checksum tokio-udp 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)" = "f02298505547f73e60f568359ef0d016d5acd6e830ab9bc7c4a5b3403440121b"
 "checksum tokio-uds 0.2.5 (registry+https://github.com/rust-lang/crates.io-index)" = "037ffc3ba0e12a0ab4aca92e5234e0dedeb48fddf6ccd260f1f150a36a9f2445"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "grin_wallet"
-version = "3.0.0-alpha.1"
+version = "3.0.0-beta.1"
 authors = ["Grin Developers <mimblewimble@lists.launchpad.net>"]
 description = "Simple, private and scalable cryptocurrency implementation based on the MimbleWimble chain format."
 license = "Apache-2.0"
@@ -30,13 +30,13 @@ log = "0.4"
 linefeed = "0.5"
 semver = "0.9"
 
-grin_wallet_api = { path = "./api", version = "3.0.0-alpha.1" }
-grin_wallet_impls = { path = "./impls", version = "3.0.0-alpha.1" }
-grin_wallet_libwallet = { path = "./libwallet", version = "3.0.0-alpha.1" }
-grin_wallet_controller = { path = "./controller", version = "3.0.0-alpha.1" }
-grin_wallet_config = { path = "./config", version = "3.0.0-alpha.1" }
+grin_wallet_api = { path = "./api", version = "3.0.0-beta.1" }
+grin_wallet_impls = { path = "./impls", version = "3.0.0-beta.1" }
+grin_wallet_libwallet = { path = "./libwallet", version = "3.0.0-beta.1" }
+grin_wallet_controller = { path = "./controller", version = "3.0.0-beta.1" }
+grin_wallet_config = { path = "./config", version = "3.0.0-beta.1" }
 
-grin_wallet_util = { path = "./util", version = "3.0.0-alpha.1" }
+grin_wallet_util = { path = "./util", version = "3.0.0-beta.1" }
 
 [build-dependencies]
 built = "0.3"

--- a/api/Cargo.toml
+++ b/api/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "grin_wallet_api"
-version = "3.0.0-alpha.1"
+version = "3.0.0-beta.1"
 authors = ["Grin Developers <mimblewimble@lists.launchpad.net>"]
 description = "Grin Wallet API"
 license = "Apache-2.0"
@@ -24,10 +24,10 @@ ring = "0.13"
 base64 = "0.9"
 ed25519-dalek = "1.0.0-pre.1"
 
-grin_wallet_libwallet = { path = "../libwallet", version = "3.0.0-alpha.1" }
-grin_wallet_config = { path = "../config", version = "3.0.0-alpha.1" }
-grin_wallet_impls = { path = "../impls", version = "3.0.0-alpha.1" }
-grin_wallet_util = { path = "../util", version = "3.0.0-alpha.1" }
+grin_wallet_libwallet = { path = "../libwallet", version = "3.0.0-beta.1" }
+grin_wallet_config = { path = "../config", version = "3.0.0-beta.1" }
+grin_wallet_impls = { path = "../impls", version = "3.0.0-beta.1" }
+grin_wallet_util = { path = "../util", version = "3.0.0-beta.1" }
 
 [dev-dependencies]
 serde_json = "1"

--- a/api/src/owner_rpc.rs
+++ b/api/src/owner_rpc.rs
@@ -411,7 +411,7 @@ pub trait OwnerRpc: Sync + Send {
 		  "version_info": {
 				"orig_version": 3,
 				"version": 3,
-				"block_header_version": 1
+				"block_header_version": 2
 		  }
 		}
 	  }
@@ -493,7 +493,7 @@ pub trait OwnerRpc: Sync + Send {
 					"version_info": {
 						"orig_version": 3,
 						"version": 3,
-						"block_header_version": 1
+						"block_header_version": 2
 					}
 				}
 			}

--- a/api/src/owner_rpc_s.rs
+++ b/api/src/owner_rpc_s.rs
@@ -443,7 +443,7 @@ pub trait OwnerRpcS {
 		  "version_info": {
 				"orig_version": 3,
 				"version": 3,
-				"block_header_version": 1
+				"block_header_version": 2
 		  }
 		}
 	  }
@@ -526,7 +526,7 @@ pub trait OwnerRpcS {
 					"version_info": {
 						"orig_version": 3,
 						"version": 3,
-						"block_header_version": 1
+						"block_header_version": 2
 					}
 				}
 			}

--- a/config/Cargo.toml
+++ b/config/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "grin_wallet_config"
-version = "3.0.0-alpha.1"
+version = "3.0.0-beta.1"
 authors = ["Grin Developers <mimblewimble@lists.launchpad.net>"]
 description = "Configuration for grin wallet , a simple, private and scalable cryptocurrency implementation based on the MimbleWimble chain format."
 license = "Apache-2.0"
@@ -16,7 +16,7 @@ serde_derive = "1"
 toml = "0.4"
 dirs = "1.0.3"
 
-grin_wallet_util = { path = "../util", version = "3.0.0-alpha.1" }
+grin_wallet_util = { path = "../util", version = "3.0.0-beta.1" }
 
 [dev-dependencies]
 pretty_assertions = "0.5.1"

--- a/controller/Cargo.toml
+++ b/controller/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "grin_wallet_controller"
-version = "3.0.0-alpha.1"
+version = "3.0.0-beta.1"
 authors = ["Grin Developers <mimblewimble@lists.launchpad.net>"]
 description = "Controllers for grin wallet instantiation"
 license = "Apache-2.0"
@@ -32,9 +32,9 @@ chrono = { version = "0.4.4", features = ["serde"] }
 easy-jsonrpc-mw = "0.5.3"
 lazy_static = "1"
 
-grin_wallet_util = { path = "../util", version = "3.0.0-alpha.1" }
+grin_wallet_util = { path = "../util", version = "3.0.0-beta.1" }
 
-grin_wallet_api = { path = "../api", version = "3.0.0-alpha.1" }
-grin_wallet_impls = { path = "../impls", version = "3.0.0-alpha.1" }
-grin_wallet_libwallet = { path = "../libwallet", version = "3.0.0-alpha.1" }
-grin_wallet_config = { path = "../config", version = "3.0.0-alpha.1" }
+grin_wallet_api = { path = "../api", version = "3.0.0-beta.1" }
+grin_wallet_impls = { path = "../impls", version = "3.0.0-beta.1" }
+grin_wallet_libwallet = { path = "../libwallet", version = "3.0.0-beta.1" }
+grin_wallet_config = { path = "../config", version = "3.0.0-beta.1" }

--- a/impls/Cargo.toml
+++ b/impls/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "grin_wallet_impls"
-version = "3.0.0-alpha.1"
+version = "3.0.0-beta.1"
 authors = ["Grin Developers <mimblewimble@lists.launchpad.net>"]
 description = "Concrete types derived from libwallet traits"
 license = "Apache-2.0"
@@ -46,6 +46,6 @@ regex = "1.3"
 timer = "0.2"
 sysinfo = "0.9"
 
-grin_wallet_util = { path = "../util", version = "3.0.0-alpha.1" }
-grin_wallet_config = { path = "../config", version = "3.0.0-alpha.1" }
-grin_wallet_libwallet = { path = "../libwallet", version = "3.0.0-alpha.1" }
+grin_wallet_util = { path = "../util", version = "3.0.0-beta.1" }
+grin_wallet_config = { path = "../config", version = "3.0.0-beta.1" }
+grin_wallet_libwallet = { path = "../libwallet", version = "3.0.0-beta.1" }

--- a/libwallet/Cargo.toml
+++ b/libwallet/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "grin_wallet_libwallet"
-version = "3.0.0-alpha.1"
+version = "3.0.0-beta.1"
 authors = ["Grin Developers <mimblewimble@lists.launchpad.net>"]
 description = "Simple, private and scalable cryptocurrency implementation based on the MimbleWimble chain format."
 license = "Apache-2.0"
@@ -29,5 +29,5 @@ sha3 = "0.8"
 byteorder = "1"
 data-encoding = "2"
 
-grin_wallet_util = { path = "../util", version = "3.0.0-alpha.1" }
-grin_wallet_config = { path = "../config", version = "3.0.0-alpha.1" }
+grin_wallet_util = { path = "../util", version = "3.0.0-beta.1" }
+grin_wallet_config = { path = "../config", version = "3.0.0-beta.1" }

--- a/util/Cargo.toml
+++ b/util/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "grin_wallet_util"
-version = "3.0.0-alpha.1"
+version = "3.0.0-beta.1"
 authors = ["Grin Developers <mimblewimble@lists.launchpad.net>"]
 description = "Util, for generic utilities and to re-export grin crates"
 license = "Apache-2.0"
@@ -26,12 +26,12 @@ dirs = "1.0.3"
 
 # For beta release
 
-# grin_core = { git = "https://github.com/mimblewimble/grin", tag = "v2.1.0-beta.3"}
-# grin_keychain = { git = "https://github.com/mimblewimble/grin", tag = "v2.1.0-beta.3" }
-# grin_chain = { git = "https://github.com/mimblewimble/grin", tag = "v2.1.0-beta.3" }
-# grin_util = { git = "https://github.com/mimblewimble/grin", tag = "v2.1.0-beta.3" }
-# grin_api = { git = "https://github.com/mimblewimble/grin", tag = "v2.1.0-beta.3" }
-# grin_store = { git = "https://github.com/mimblewimble/grin", tag = "v2.1.0-beta.3" }
+# grin_core = { git = "https://github.com/mimblewimble/grin", tag = "3.0.0-beta.1"}
+# grin_keychain = { git = "https://github.com/mimblewimble/grin", tag = "3.0.0-beta.1" }
+# grin_chain = { git = "https://github.com/mimblewimble/grin", tag = "3.0.0-beta.1" }
+# grin_util = { git = "https://github.com/mimblewimble/grin", tag = "3.0.0-beta.1" }
+# grin_api = { git = "https://github.com/mimblewimble/grin", tag = "3.0.0-beta.1" }
+# grin_store = { git = "https://github.com/mimblewimble/grin", tag = "3.0.0-beta.1" }
 
 # For bleeding edge
 grin_core = { git = "https://github.com/mimblewimble/grin", branch = "master" }

--- a/util/Cargo.toml
+++ b/util/Cargo.toml
@@ -26,20 +26,20 @@ dirs = "1.0.3"
 
 # For beta release
 
-# grin_core = { git = "https://github.com/mimblewimble/grin", tag = "3.0.0-beta.1"}
-# grin_keychain = { git = "https://github.com/mimblewimble/grin", tag = "3.0.0-beta.1" }
-# grin_chain = { git = "https://github.com/mimblewimble/grin", tag = "3.0.0-beta.1" }
-# grin_util = { git = "https://github.com/mimblewimble/grin", tag = "3.0.0-beta.1" }
-# grin_api = { git = "https://github.com/mimblewimble/grin", tag = "3.0.0-beta.1" }
-# grin_store = { git = "https://github.com/mimblewimble/grin", tag = "3.0.0-beta.1" }
+grin_core = { git = "https://github.com/mimblewimble/grin", tag = "v3.0.0-beta.1"}
+grin_keychain = { git = "https://github.com/mimblewimble/grin", tag = "v3.0.0-beta.1" }
+grin_chain = { git = "https://github.com/mimblewimble/grin", tag = "v3.0.0-beta.1" }
+grin_util = { git = "https://github.com/mimblewimble/grin", tag = "v3.0.0-beta.1" }
+grin_api = { git = "https://github.com/mimblewimble/grin", tag = "v3.0.0-beta.1" }
+grin_store = { git = "https://github.com/mimblewimble/grin", tag = "v3.0.0-beta.1" }
 
 # For bleeding edge
-grin_core = { git = "https://github.com/mimblewimble/grin", branch = "master" }
-grin_keychain = { git = "https://github.com/mimblewimble/grin", branch = "master" }
-grin_chain = { git = "https://github.com/mimblewimble/grin", branch = "master" }
-grin_util = { git = "https://github.com/mimblewimble/grin", branch = "master" }
-grin_api = { git = "https://github.com/mimblewimble/grin", branch = "master" }
-grin_store = { git = "https://github.com/mimblewimble/grin", branch = "master" }
+# grin_core = { git = "https://github.com/mimblewimble/grin", branch = "master" }
+# grin_keychain = { git = "https://github.com/mimblewimble/grin", branch = "master" }
+# grin_chain = { git = "https://github.com/mimblewimble/grin", branch = "master" }
+# grin_util = { git = "https://github.com/mimblewimble/grin", branch = "master" }
+# grin_api = { git = "https://github.com/mimblewimble/grin", branch = "master" }
+# grin_store = { git = "https://github.com/mimblewimble/grin", branch = "master" }
 
 # For local testing
 # grin_core = { path = "../../grin/core"}


### PR DESCRIPTION
Versioning + Cargo.lock changes for 3.0.0. Will update with tag of Grin 3.0.0-beta.1 when it's tagged