### PR TITLE
Payment Proof export + validation

### DIFF
--- a/api/src/owner.rs
+++ b/api/src/owner.rs
@@ -2037,6 +2037,16 @@ where
 			tx_slate_id,
 		)
 	}
+
+	pub fn verify_payment_proof(
+		&self,
+		proof: &PaymentProof
+	) -> Result<(), Error> {
+		owner::verify_payment_proof(
+			self.wallet_inst.clone(),
+			proof
+		)
+	}
 }
 
 #[doc(hidden)]

--- a/api/src/owner.rs
+++ b/api/src/owner.rs
@@ -2131,9 +2131,10 @@ where
 	/// }
 	/// ```
 
-	pub fn verify_payment_proof(&self, 
+	pub fn verify_payment_proof(
+		&self,
 		keychain_mask: Option<&SecretKey>,
-		proof: &PaymentProof
+		proof: &PaymentProof,
 	) -> Result<(bool, bool), Error> {
 		owner::verify_payment_proof(self.wallet_inst.clone(), keychain_mask, proof)
 	}

--- a/api/src/owner.rs
+++ b/api/src/owner.rs
@@ -2038,14 +2038,8 @@ where
 		)
 	}
 
-	pub fn verify_payment_proof(
-		&self,
-		proof: &PaymentProof
-	) -> Result<(), Error> {
-		owner::verify_payment_proof(
-			self.wallet_inst.clone(),
-			proof
-		)
+	pub fn verify_payment_proof(&self, proof: &PaymentProof) -> Result<(), Error> {
+		owner::verify_payment_proof(self.wallet_inst.clone(), proof)
 	}
 }
 

--- a/api/src/owner.rs
+++ b/api/src/owner.rs
@@ -2017,7 +2017,7 @@ where
 	/// from a completed transaction within the wallet.
 	///
 	/// The transaction must have been created with a payment proof, and the transaction must be
-	/// complete in order for a payment proof to be returned. Either the `tx_id` or `tx_slate_id` 
+	/// complete in order for a payment proof to be returned. Either the `tx_id` or `tx_slate_id`
 	/// argument must be provided, or the function will return an error.
 	///
 	/// # Arguments
@@ -2087,9 +2087,9 @@ where
 	///
 	/// * Ensuring the kernel identified by the proof's stored excess commitment exists in the UTXO set
 	/// * Reproducing the signed message `amount|kernel_commitment|sender_address`
-	/// * Validating the proof's `recipient_sig` against the message using the recipient's 
+	/// * Validating the proof's `recipient_sig` against the message using the recipient's
 	/// address as the public key and
-	/// * Validating the proof's `sender_sig` against the message using the senders's 
+	/// * Validating the proof's `sender_sig` against the message using the senders's
 	/// address as the public key
 	///
 	/// # Arguments

--- a/api/src/owner.rs
+++ b/api/src/owner.rs
@@ -2085,18 +2085,26 @@ where
 	/// Verifies a [PaymentProof](../grin_wallet_libwallet/api_impl/types/struct.PaymentProof.html)
 	/// This process entails:
 	///
-	/// * Ensuring the kernel identified by the proof's stored excess commitment exists in the UTXO set
+	/// * Ensuring the kernel identified by the proof's stored excess commitment exists in the kernel set
 	/// * Reproducing the signed message `amount|kernel_commitment|sender_address`
 	/// * Validating the proof's `recipient_sig` against the message using the recipient's
 	/// address as the public key and
 	/// * Validating the proof's `sender_sig` against the message using the senders's
 	/// address as the public key
 	///
+	/// This function also checks whether the sender or recipient address belongs to the currently
+	/// open wallet, and returns 2 booleans indicating whether the address belongs to the sender and
+	/// whether the address belongs to the recipient respectively
+	///
 	/// # Arguments
+	/// * `keychain_mask` - Wallet secret mask to XOR against the stored wallet seed before using, if
+	/// being used.
 	/// * `proof` A [PaymentProof](../grin_wallet_libwallet/api_impl/types/struct.PaymentProof.html))
 	///
 	/// # Returns
-	/// * Ok(()) if the proof is valid
+	/// * Ok((bool, bool)) if the proof is valid. The first boolean indicates whether the sender
+	/// address belongs to this wallet, the second whether the recipient address belongs to this
+	/// wallet
 	/// * or [`libwallet::Error`](../grin_wallet_libwallet/struct.Error.html) if an error is encountered
 	/// or the proof is not present or complete
 	///
@@ -2116,15 +2124,18 @@ where
 	/// // The proof will likely be exported as JSON to be provided to another party
 	///
 	/// if let Ok(p) = result {
-	///		let valid = api_owner.verify_payment_proof(&p);
+	///		let valid = api_owner.verify_payment_proof(None, &p);
 	///		if let Ok(_) = valid {
 	///		  //...
 	///		}
 	/// }
 	/// ```
 
-	pub fn verify_payment_proof(&self, proof: &PaymentProof) -> Result<(), Error> {
-		owner::verify_payment_proof(self.wallet_inst.clone(), proof)
+	pub fn verify_payment_proof(&self, 
+		keychain_mask: Option<&SecretKey>,
+		proof: &PaymentProof
+	) -> Result<(bool, bool), Error> {
+		owner::verify_payment_proof(self.wallet_inst.clone(), keychain_mask, proof)
 	}
 }
 

--- a/api/src/owner_rpc.rs
+++ b/api/src/owner_rpc.rs
@@ -23,7 +23,7 @@ use crate::libwallet::{
 	OutputCommitMapping, Slate, SlateVersion, TxLogEntry, VersionedSlate, WalletInfo,
 	WalletLCProvider,
 };
-use crate::util::Mutex;
+use crate::util::{from_hex, Mutex};
 use crate::{Owner, OwnerRpcS};
 use easy_jsonrpc_mw;
 use std::sync::Arc;
@@ -64,7 +64,7 @@ pub trait OwnerRpc: Sync + Send {
 		"id": 1
 	}
 	# "#
-	# , false, 4, false, false, false);
+	# , false, 4, false, false, false, false);
 	```
 	*/
 	#[deprecated(
@@ -98,7 +98,7 @@ pub trait OwnerRpc: Sync + Send {
 		"id": 1
 	}
 	# "#
-	# ,false, 4, false, false, false);
+	# ,false, 4, false, false, false, false);
 	```
 	 */
 	fn create_account_path(&self, label: &String) -> Result<Identifier, ErrorKind>;
@@ -128,7 +128,7 @@ pub trait OwnerRpc: Sync + Send {
 		"id": 1
 	}
 	# "#
-	# , false, 4, false, false, false);
+	# , false, 4, false, false, false, false);
 	```
 	 */
 	fn set_active_account(&self, label: &String) -> Result<(), ErrorKind>;
@@ -194,7 +194,7 @@ pub trait OwnerRpc: Sync + Send {
 		}
 	}
 	# "#
-	# , false, 2, false, false, false);
+	# , false, 2, false, false, false, false);
 	```
 	*/
 	fn retrieve_outputs(
@@ -273,7 +273,7 @@ pub trait OwnerRpc: Sync + Send {
 	  }
 	}
 	# "#
-	# , false, 2, false, false, false);
+	# , false, 2, false, false, false, false);
 	```
 	*/
 
@@ -319,7 +319,7 @@ pub trait OwnerRpc: Sync + Send {
 		}
 	}
 	# "#
-	# ,false, 4, false, false, false);
+	# ,false, 4, false, false, false, false);
 	```
 	 */
 
@@ -417,7 +417,7 @@ pub trait OwnerRpc: Sync + Send {
 	  }
 	}
 		# "#
-		# ,false, 4, false, false, false);
+		# ,false, 4, false, false, false, false);
 	```
 	*/
 
@@ -499,7 +499,7 @@ pub trait OwnerRpc: Sync + Send {
 			}
 		}
 		# "#
-		# ,false, 4, false, false, false);
+		# ,false, 4, false, false, false, false);
 	```
 	*/
 
@@ -653,7 +653,7 @@ pub trait OwnerRpc: Sync + Send {
 		}
 	}
 	# "#
-	# ,false, 4, false, false, false);
+	# ,false, 4, false, false, false, false);
 	```
 	*/
 
@@ -739,7 +739,7 @@ pub trait OwnerRpc: Sync + Send {
 		}
 	}
 	# "#
-	# ,false, 5 ,true, false, false);
+	# ,false, 5 ,true, false, false, false);
 
 	```
 	 */
@@ -910,7 +910,7 @@ pub trait OwnerRpc: Sync + Send {
 		}
 	}
 	# "#
-	# , false, 5, true, true, false);
+	# , false, 5, true, true, false, false);
 	```
 	 */
 	fn finalize_tx(&self, slate: VersionedSlate) -> Result<VersionedSlate, ErrorKind>;
@@ -976,7 +976,7 @@ pub trait OwnerRpc: Sync + Send {
 		}
 	}
 	# "#
-	# , false, 5, true, true, true);
+	# , false, 5, true, true, true, false);
 	```
 	 */
 
@@ -1006,7 +1006,7 @@ pub trait OwnerRpc: Sync + Send {
 		}
 	}
 	# "#
-	# , false, 5, true, true, false);
+	# , false, 5, true, true, false, false);
 	```
 	 */
 	fn cancel_tx(&self, tx_id: Option<u32>, tx_slate_id: Option<Uuid>) -> Result<(), ErrorKind>;
@@ -1103,7 +1103,7 @@ pub trait OwnerRpc: Sync + Send {
 		}
 	}
 	# "#
-	# , false, 5, true, true, false);
+	# , false, 5, true, true, false, false);
 	```
 	 */
 	fn get_stored_tx(&self, tx: &TxLogEntry) -> Result<Option<TransactionV3>, ErrorKind>;
@@ -1183,7 +1183,7 @@ pub trait OwnerRpc: Sync + Send {
 		}
 	}
 	# "#
-	# ,false, 0 ,false, false, false);
+	# ,false, 0 ,false, false, false, false);
 	```
 	*/
 	fn verify_slate_messages(&self, slate: VersionedSlate) -> Result<(), ErrorKind>;
@@ -1212,7 +1212,7 @@ pub trait OwnerRpc: Sync + Send {
 		}
 	}
 	# "#
-	# , false, 1, false, false, false);
+	# , false, 1, false, false, false, false);
 	```
 	 */
 	fn scan(&self, start_height: Option<u64>, delete_unconfirmed: bool) -> Result<(), ErrorKind>;
@@ -1245,7 +1245,7 @@ pub trait OwnerRpc: Sync + Send {
 		}
 	}
 	# "#
-	# , false, 5, false, false, false);
+	# , false, 5, false, false, false, false);
 	```
 	 */
 	fn node_height(&self) -> Result<NodeHeightResult, ErrorKind>;
@@ -1372,12 +1372,15 @@ pub fn run_doctest_owner(
 	perform_tx: bool,
 	lock_tx: bool,
 	finalize_tx: bool,
+	payment_proof: bool,
 ) -> Result<Option<serde_json::Value>, String> {
 	use easy_jsonrpc_mw::Handler;
 	use grin_wallet_impls::test_framework::{self, LocalWalletClient, WalletProxy};
 	use grin_wallet_impls::{DefaultLCProvider, DefaultWalletImpl};
 	use grin_wallet_libwallet::{api_impl, WalletInst};
 	use grin_wallet_util::grin_keychain::ExtKeychain;
+
+	use ed25519_dalek::PublicKey as DalekPublicKey;
 
 	use crate::core::global;
 	use crate::core::global::ChainTypes;
@@ -1503,6 +1506,15 @@ pub fn run_doctest_owner(
 		let amount = 60_000_000_000;
 		let mut w_lock = wallet1.lock();
 		let w = w_lock.lc_provider().unwrap().wallet_inst().unwrap();
+		let proof_address = match payment_proof {
+			true => {
+				let bytes = from_hex("783f6528669742a990e0faf0a5fca5d5b3330e37bbb9cd5c628696d03ce4e810".to_string()).unwrap();
+					let mut b = [0u8; 32];
+					b.copy_from_slice(&bytes[0..32]);
+					Some(DalekPublicKey::from_bytes(&b).unwrap())
+			},
+			false => None,
+		};
 		let args = InitTxArgs {
 			src_acct_name: None,
 			amount,
@@ -1510,6 +1522,7 @@ pub fn run_doctest_owner(
 			max_outputs: 500,
 			num_change_outputs: 1,
 			selection_strategy_is_use_all: true,
+			payment_proof_recipient_address: proof_address,
 			..Default::default()
 		};
 		let mut slate =
@@ -1570,7 +1583,7 @@ pub fn run_doctest_owner(
 #[doc(hidden)]
 #[macro_export]
 macro_rules! doctest_helper_json_rpc_owner_assert_response {
-	($request:expr, $expected_response:expr, $use_token:expr, $blocks_to_mine:expr, $perform_tx:expr, $lock_tx:expr, $finalize_tx:expr) => {
+	($request:expr, $expected_response:expr, $use_token:expr, $blocks_to_mine:expr, $perform_tx:expr, $lock_tx:expr, $finalize_tx:expr, $payment_proof:expr) => {
 		// create temporary wallet, run jsonrpc request on owner api of wallet, delete wallet, return
 		// json response.
 		// In order to prevent leaking tempdirs, This function should not panic.
@@ -1603,6 +1616,7 @@ macro_rules! doctest_helper_json_rpc_owner_assert_response {
 				$perform_tx,
 				$lock_tx,
 				$finalize_tx,
+				$payment_proof,
 				)
 			.unwrap()
 			.unwrap();

--- a/api/src/owner_rpc.rs
+++ b/api/src/owner_rpc.rs
@@ -1437,6 +1437,8 @@ pub fn run_doctest_owner(
 		mask1.clone(),
 	);
 
+	let mut slate_outer = Slate::blank(2);
+
 	let rec_phrase_2 = util::ZeroingString::from(
 		"hour kingdom ripple lunch razor inquiry coyote clay stamp mean \
 		 sell finish magic kid tiny wage stand panther inside settle feed song hole exile",
@@ -1557,6 +1559,11 @@ pub fn run_doctest_owner(
 			error!("FINALIZED TX SLATE");
 			println!("{}", serde_json::to_string_pretty(&slate).unwrap());
 		}
+		slate_outer = slate;
+	}
+
+	if payment_proof {
+		let _ = api_impl::owner::post_tx(&client1, &slate_outer.tx, true).unwrap();
 	}
 
 	if perform_tx && lock_tx && finalize_tx {

--- a/api/src/owner_rpc.rs
+++ b/api/src/owner_rpc.rs
@@ -1508,11 +1508,14 @@ pub fn run_doctest_owner(
 		let w = w_lock.lc_provider().unwrap().wallet_inst().unwrap();
 		let proof_address = match payment_proof {
 			true => {
-				let bytes = from_hex("783f6528669742a990e0faf0a5fca5d5b3330e37bbb9cd5c628696d03ce4e810".to_string()).unwrap();
-					let mut b = [0u8; 32];
-					b.copy_from_slice(&bytes[0..32]);
-					Some(DalekPublicKey::from_bytes(&b).unwrap())
-			},
+				let bytes = from_hex(
+					"783f6528669742a990e0faf0a5fca5d5b3330e37bbb9cd5c628696d03ce4e810".to_string(),
+				)
+				.unwrap();
+				let mut b = [0u8; 32];
+				b.copy_from_slice(&bytes[0..32]);
+				Some(DalekPublicKey::from_bytes(&b).unwrap())
+			}
 			false => None,
 		};
 		let args = InitTxArgs {

--- a/api/src/owner_rpc_s.rs
+++ b/api/src/owner_rpc_s.rs
@@ -22,8 +22,8 @@ use crate::keychain::{Identifier, Keychain};
 use crate::libwallet::slate_versions::v3::TransactionV3;
 use crate::libwallet::{
 	AcctPathMapping, ErrorKind, InitTxArgs, IssueInvoiceTxArgs, NodeClient, NodeHeightResult,
-	OutputCommitMapping, PaymentProof, Slate, SlateVersion, StatusMessage, TxLogEntry, VersionedSlate,
-	WalletInfo, WalletLCProvider,
+	OutputCommitMapping, PaymentProof, Slate, SlateVersion, StatusMessage, TxLogEntry,
+	VersionedSlate, WalletInfo, WalletLCProvider,
 };
 use crate::util::logger::LoggingConfig;
 use crate::util::secp::key::{PublicKey, SecretKey};
@@ -1895,7 +1895,8 @@ pub trait OwnerRpcS {
 	```
 	*/
 
-	fn retrieve_payment_proof(&self,
+	fn retrieve_payment_proof(
+		&self,
 		token: Token,
 		refresh_from_node: bool,
 		tx_id: Option<u32>,
@@ -2253,7 +2254,8 @@ where
 		Ok(PubAddress { address })
 	}
 
-	fn retrieve_payment_proof(&self,
+	fn retrieve_payment_proof(
+		&self,
 		token: Token,
 		refresh_from_node: bool,
 		tx_id: Option<u32>,

--- a/api/src/owner_rpc_s.rs
+++ b/api/src/owner_rpc_s.rs
@@ -1881,11 +1881,9 @@ pub trait OwnerRpcS {
 			"Ok": {
 				"amount": "60000000000",
 				"excess": "09bac6083b05a32a9d9b37710c70dd0a1ef9329fde0848558976b6f1b81d80ceed",
-				"recipient_address": "783f6528669742a990e0faf0a5fca5d5b3330e37bbb9cd5c628696d03ce4e810",
-				"recipient_ov3_address": "pa7wkkdgs5bkteha7lykl7ff2wztgdrxxo442xdcq2lnaphe5aidd4id",
+				"recipient_address": "pa7wkkdgs5bkteha7lykl7ff2wztgdrxxo442xdcq2lnaphe5aidd4id",
 				"recipient_sig": "42b6f2bbcee432185993867d1a338e260454ead536bf728f4dcc8f535508715e92a0695486ba3c9945d8ecb2cf7f703a955780253b12d0048f02d318c8f08702",
-				"sender_address": "32cdd63928854f8b2628b1dce4626ddcdf35d56cb7cfdf7d64cca5822b78d4d3",
-				"sender_ov3_address": "glg5mojiqvhywjriwhooiytn3tptlvlmw7h567lezssyek3y2tjzznad",
+				"sender_address": "glg5mojiqvhywjriwhooiytn3tptlvlmw7h567lezssyek3y2tjzznad",
 				"sender_sig": "5e3f5596852e83f6db7152fc51c41b4ed8742eb8045fa85a6965c52d09fcb46ba67d4f86660c9f3dc55ab84faea79d11c3831aa77934f7e90695e63d523f8604"
 			}
 		}
@@ -1916,11 +1914,9 @@ pub trait OwnerRpcS {
 			"proof": {
 				"amount": "60000000000",
 				"excess": "09bac6083b05a32a9d9b37710c70dd0a1ef9329fde0848558976b6f1b81d80ceed",
-				"recipient_address": "783f6528669742a990e0faf0a5fca5d5b3330e37bbb9cd5c628696d03ce4e810",
-				"recipient_ov3_address": "pa7wkkdgs5bkteha7lykl7ff2wztgdrxxo442xdcq2lnaphe5aidd4id",
+				"recipient_address": "pa7wkkdgs5bkteha7lykl7ff2wztgdrxxo442xdcq2lnaphe5aidd4id",
 				"recipient_sig": "42b6f2bbcee432185993867d1a338e260454ead536bf728f4dcc8f535508715e92a0695486ba3c9945d8ecb2cf7f703a955780253b12d0048f02d318c8f08702",
-				"sender_address": "32cdd63928854f8b2628b1dce4626ddcdf35d56cb7cfdf7d64cca5822b78d4d3",
-				"sender_ov3_address": "glg5mojiqvhywjriwhooiytn3tptlvlmw7h567lezssyek3y2tjzznad",
+				"sender_address": "glg5mojiqvhywjriwhooiytn3tptlvlmw7h567lezssyek3y2tjzznad",
 				"sender_sig": "5e3f5596852e83f6db7152fc51c41b4ed8742eb8045fa85a6965c52d09fcb46ba67d4f86660c9f3dc55ab84faea79d11c3831aa77934f7e90695e63d523f8604"
 			}
 		},

--- a/api/src/owner_rpc_s.rs
+++ b/api/src/owner_rpc_s.rs
@@ -1879,7 +1879,7 @@ pub trait OwnerRpcS {
 		"jsonrpc": "2.0",
 		"result": {
 			"Ok": {
-				"amount": 60000000000,
+				"amount": "60000000000",
 				"excess": "09bac6083b05a32a9d9b37710c70dd0a1ef9329fde0848558976b6f1b81d80ceed",
 				"recipient_address": "783f6528669742a990e0faf0a5fca5d5b3330e37bbb9cd5c628696d03ce4e810",
 				"recipient_ov3_address": "pa7wkkdgs5bkteha7lykl7ff2wztgdrxxo442xdcq2lnaphe5aidd4id",
@@ -1902,6 +1902,48 @@ pub trait OwnerRpcS {
 		tx_id: Option<u32>,
 		tx_slate_id: Option<Uuid>,
 	) -> Result<PaymentProof, ErrorKind>;
+
+	/**
+	Networked version of [Owner::verify_payment_proof](struct.Owner.html#method.verify_payment_proof).
+	```
+	# grin_wallet_api::doctest_helper_json_rpc_owner_assert_response!(
+	# r#"
+	{
+		"jsonrpc": "2.0",
+		"method": "verify_payment_proof",
+		"params": {
+			"proof": {
+				"amount": "60000000000",
+				"excess": "09bac6083b05a32a9d9b37710c70dd0a1ef9329fde0848558976b6f1b81d80ceed",
+				"recipient_address": "783f6528669742a990e0faf0a5fca5d5b3330e37bbb9cd5c628696d03ce4e810",
+				"recipient_ov3_address": "pa7wkkdgs5bkteha7lykl7ff2wztgdrxxo442xdcq2lnaphe5aidd4id",
+				"recipient_sig": "42b6f2bbcee432185993867d1a338e260454ead536bf728f4dcc8f535508715e92a0695486ba3c9945d8ecb2cf7f703a955780253b12d0048f02d318c8f08702",
+				"sender_address": "32cdd63928854f8b2628b1dce4626ddcdf35d56cb7cfdf7d64cca5822b78d4d3",
+				"sender_ov3_address": "glg5mojiqvhywjriwhooiytn3tptlvlmw7h567lezssyek3y2tjzznad",
+				"sender_sig": "5e3f5596852e83f6db7152fc51c41b4ed8742eb8045fa85a6965c52d09fcb46ba67d4f86660c9f3dc55ab84faea79d11c3831aa77934f7e90695e63d523f8604"
+			}
+		},
+		"id": 1
+	}
+	# "#
+	# ,
+	# r#"
+	{
+		"id": 1,
+		"jsonrpc": "2.0",
+		"result": {
+			"Ok": null
+		}
+	}
+	# "#
+	# , true, 5, true, true, true, true);
+	```
+	*/
+
+	fn verify_payment_proof(
+		&self,
+		proof: PaymentProof,
+	) -> Result<(), ErrorKind>;
 
 	/**
 	Networked version of [Owner::set_tor_config](struct.Owner.html#method.set_tor_config).
@@ -2267,6 +2309,17 @@ where
 			refresh_from_node,
 			tx_id,
 			tx_slate_id,
+		)
+		.map_err(|e| e.kind())
+	}
+
+	fn verify_payment_proof(
+		&self,
+		proof: PaymentProof,
+	) -> Result<(), ErrorKind> {
+		Owner::verify_payment_proof(
+			self,
+			&proof
 		)
 		.map_err(|e| e.kind())
 	}

--- a/api/src/owner_rpc_s.rs
+++ b/api/src/owner_rpc_s.rs
@@ -1912,6 +1912,7 @@ pub trait OwnerRpcS {
 		"jsonrpc": "2.0",
 		"method": "verify_payment_proof",
 		"params": {
+			"token": "d202964900000000d302964900000000d402964900000000d502964900000000",
 			"proof": {
 				"amount": "60000000000",
 				"excess": "09bac6083b05a32a9d9b37710c70dd0a1ef9329fde0848558976b6f1b81d80ceed",
@@ -1932,7 +1933,10 @@ pub trait OwnerRpcS {
 		"id": 1,
 		"jsonrpc": "2.0",
 		"result": {
-			"Ok": null
+			"Ok": [
+				true,
+				false
+			]
 		}
 	}
 	# "#
@@ -1940,7 +1944,7 @@ pub trait OwnerRpcS {
 	```
 	*/
 
-	fn verify_payment_proof(&self, proof: PaymentProof) -> Result<(), ErrorKind>;
+	fn verify_payment_proof(&self, token: Token, proof: PaymentProof) -> Result<(bool, bool), ErrorKind>;
 
 	/**
 	Networked version of [Owner::set_tor_config](struct.Owner.html#method.set_tor_config).
@@ -2310,8 +2314,8 @@ where
 		.map_err(|e| e.kind())
 	}
 
-	fn verify_payment_proof(&self, proof: PaymentProof) -> Result<(), ErrorKind> {
-		Owner::verify_payment_proof(self, &proof).map_err(|e| e.kind())
+	fn verify_payment_proof(&self, token: Token, proof: PaymentProof) -> Result<(bool, bool), ErrorKind> {
+		Owner::verify_payment_proof(self, (&token.keychain_mask).as_ref(), &proof).map_err(|e| e.kind())
 	}
 
 	fn proof_address_from_onion_v3(&self, address_v3: String) -> Result<PubAddress, ErrorKind> {

--- a/api/src/owner_rpc_s.rs
+++ b/api/src/owner_rpc_s.rs
@@ -1944,7 +1944,11 @@ pub trait OwnerRpcS {
 	```
 	*/
 
-	fn verify_payment_proof(&self, token: Token, proof: PaymentProof) -> Result<(bool, bool), ErrorKind>;
+	fn verify_payment_proof(
+		&self,
+		token: Token,
+		proof: PaymentProof,
+	) -> Result<(bool, bool), ErrorKind>;
 
 	/**
 	Networked version of [Owner::set_tor_config](struct.Owner.html#method.set_tor_config).
@@ -2314,8 +2318,13 @@ where
 		.map_err(|e| e.kind())
 	}
 
-	fn verify_payment_proof(&self, token: Token, proof: PaymentProof) -> Result<(bool, bool), ErrorKind> {
-		Owner::verify_payment_proof(self, (&token.keychain_mask).as_ref(), &proof).map_err(|e| e.kind())
+	fn verify_payment_proof(
+		&self,
+		token: Token,
+		proof: PaymentProof,
+	) -> Result<(bool, bool), ErrorKind> {
+		Owner::verify_payment_proof(self, (&token.keychain_mask).as_ref(), &proof)
+			.map_err(|e| e.kind())
 	}
 
 	fn proof_address_from_onion_v3(&self, address_v3: String) -> Result<PubAddress, ErrorKind> {

--- a/api/src/owner_rpc_s.rs
+++ b/api/src/owner_rpc_s.rs
@@ -22,7 +22,7 @@ use crate::keychain::{Identifier, Keychain};
 use crate::libwallet::slate_versions::v3::TransactionV3;
 use crate::libwallet::{
 	AcctPathMapping, ErrorKind, InitTxArgs, IssueInvoiceTxArgs, NodeClient, NodeHeightResult,
-	OutputCommitMapping, Slate, SlateVersion, StatusMessage, TxLogEntry, VersionedSlate,
+	OutputCommitMapping, PaymentProof, Slate, SlateVersion, StatusMessage, TxLogEntry, VersionedSlate,
 	WalletInfo, WalletLCProvider,
 };
 use crate::util::logger::LoggingConfig;
@@ -72,7 +72,7 @@ pub trait OwnerRpcS {
 		"id": 1
 	}
 	# "#
-	# , true, 4, false, false, false);
+	# , true, 4, false, false, false, false);
 	```
 	*/
 	fn accounts(&self, token: Token) -> Result<Vec<AcctPathMapping>, ErrorKind>;
@@ -105,7 +105,7 @@ pub trait OwnerRpcS {
 		"id": 1
 	}
 	# "#
-	# ,true, 4, false, false, false);
+	# ,true, 4, false, false, false, false);
 	```
 	 */
 	fn create_account_path(&self, token: Token, label: &String) -> Result<Identifier, ErrorKind>;
@@ -138,7 +138,7 @@ pub trait OwnerRpcS {
 		"id": 1
 	}
 	# "#
-	# , true, 4, false, false, false);
+	# , true, 4, false, false, false, false);
 	```
 	 */
 	fn set_active_account(&self, token: Token, label: &String) -> Result<(), ErrorKind>;
@@ -209,7 +209,7 @@ pub trait OwnerRpcS {
 		}
 	}
 	# "#
-	# , true, 2, false, false, false);
+	# , true, 2, false, false, false, false);
 	```
 	*/
 	fn retrieve_outputs(
@@ -294,7 +294,7 @@ pub trait OwnerRpcS {
 	  }
 	}
 	# "#
-	# , true, 2, false, false, false);
+	# , true, 2, false, false, false, false);
 	```
 	*/
 
@@ -345,7 +345,7 @@ pub trait OwnerRpcS {
 		}
 	}
 	# "#
-	# ,true, 4, false, false, false);
+	# ,true, 4, false, false, false, false);
 	```
 	 */
 
@@ -449,7 +449,7 @@ pub trait OwnerRpcS {
 	  }
 	}
 		# "#
-		# ,true, 4, false, false, false);
+		# ,true, 4, false, false, false, false);
 	```
 	*/
 
@@ -532,7 +532,7 @@ pub trait OwnerRpcS {
 			}
 		}
 		# "#
-		# ,true, 4, false, false, false);
+		# ,true, 4, false, false, false, false);
 	```
 	*/
 
@@ -691,7 +691,7 @@ pub trait OwnerRpcS {
 		}
 	}
 	# "#
-	# ,true, 4, false, false, false);
+	# ,true, 4, false, false, false, false);
 	```
 	*/
 
@@ -780,7 +780,7 @@ pub trait OwnerRpcS {
 		}
 	}
 	# "#
-	# ,true, 5 ,true, false, false);
+	# ,true, 5 ,true, false, false, false);
 
 	```
 	 */
@@ -953,7 +953,7 @@ pub trait OwnerRpcS {
 		}
 	}
 	# "#
-	# , true, 5, true, true, false);
+	# , true, 5, true, true, false, false);
 	```
 	 */
 	fn finalize_tx(&self, token: Token, slate: VersionedSlate)
@@ -1021,7 +1021,7 @@ pub trait OwnerRpcS {
 		}
 	}
 	# "#
-	# , true, 5, true, true, true);
+	# , true, 5, true, true, true, false);
 	```
 	 */
 
@@ -1055,7 +1055,7 @@ pub trait OwnerRpcS {
 		}
 	}
 	# "#
-	# , true, 5, true, true, false);
+	# , true, 5, true, true, false, false);
 	```
 	 */
 	fn cancel_tx(
@@ -1158,7 +1158,7 @@ pub trait OwnerRpcS {
 		}
 	}
 	# "#
-	# , true, 5, true, true, false);
+	# , true, 5, true, true, false, false);
 	```
 	 */
 	fn get_stored_tx(
@@ -1244,7 +1244,7 @@ pub trait OwnerRpcS {
 		}
 	}
 	# "#
-	# ,true, 0 ,false, false, false);
+	# ,true, 0 ,false, false, false, false);
 	```
 	*/
 	fn verify_slate_messages(&self, token: Token, slate: VersionedSlate) -> Result<(), ErrorKind>;
@@ -1277,7 +1277,7 @@ pub trait OwnerRpcS {
 		}
 	}
 	# "#
-	# , true, 1, false, false, false);
+	# , true, 1, false, false, false, false);
 	```
 	 */
 	fn scan(
@@ -1316,7 +1316,7 @@ pub trait OwnerRpcS {
 		}
 	}
 	# "#
-	# , true, 5, false, false, false);
+	# , true, 5, false, false, false, false);
 	```
 	 */
 	fn node_height(&self, token: Token) -> Result<NodeHeightResult, ErrorKind>;
@@ -1399,7 +1399,7 @@ pub trait OwnerRpcS {
 		}
 	}
 	# "#
-	# , true, 5, false, false, false);
+	# , true, 5, false, false, false, false);
 	```
 	*/
 
@@ -1429,7 +1429,7 @@ pub trait OwnerRpcS {
 		}
 	}
 	# "#
-	# , true, 5, false, false, false);
+	# , true, 5, false, false, false, false);
 	```
 	*/
 
@@ -1495,7 +1495,7 @@ pub trait OwnerRpcS {
 		}
 	}
 	# "#
-	# , true, 5, false, false, false);
+	# , true, 5, false, false, false, false);
 	```
 	*/
 	fn create_config(
@@ -1533,7 +1533,7 @@ pub trait OwnerRpcS {
 		}
 	}
 	# "#
-	# , true, 0, false, false, false);
+	# , true, 0, false, false, false, false);
 	```
 	*/
 
@@ -1570,7 +1570,7 @@ pub trait OwnerRpcS {
 		}
 	}
 	# "#
-	# , true, 0, false, false, false);
+	# , true, 0, false, false, false, false);
 	```
 	*/
 
@@ -1600,7 +1600,7 @@ pub trait OwnerRpcS {
 		}
 	}
 	# "#
-	# , true, 0, false, false, false);
+	# , true, 0, false, false, false, false);
 	```
 	*/
 
@@ -1631,7 +1631,7 @@ pub trait OwnerRpcS {
 		}
 	}
 	# "#
-	# , true, 0, false, false, false);
+	# , true, 0, false, false, false, false);
 	```
 	*/
 
@@ -1663,7 +1663,7 @@ pub trait OwnerRpcS {
 		}
 	}
 	# "#
-	# , true, 0, false, false, false);
+	# , true, 0, false, false, false, false);
 	```
 	*/
 	fn change_password(
@@ -1697,7 +1697,7 @@ pub trait OwnerRpcS {
 		}
 	}
 	# "#
-	# , true, 0, false, false, false);
+	# , true, 0, false, false, false, false);
 	```
 	*/
 	fn delete_wallet(&self, name: Option<String>) -> Result<(), ErrorKind>;
@@ -1727,7 +1727,7 @@ pub trait OwnerRpcS {
 		}
 	}
 	# "#
-	# , true, 0, false, false, false);
+	# , true, 0, false, false, false, false);
 	```
 	*/
 
@@ -1755,7 +1755,7 @@ pub trait OwnerRpcS {
 		}
 	}
 	# "#
-	# , true, 0, false, false, false);
+	# , true, 0, false, false, false, false);
 	```
 	*/
 	fn stop_updater(&self) -> Result<(), ErrorKind>;
@@ -1784,7 +1784,7 @@ pub trait OwnerRpcS {
 		}
 	}
 	# "#
-	# , true, 0, false, false, false);
+	# , true, 0, false, false, false, false);
 	```
 	*/
 
@@ -1815,7 +1815,7 @@ pub trait OwnerRpcS {
 		}
 	}
 	# "#
-	# , true, 0, false, false, false);
+	# , true, 0, false, false, false, false);
 	```
 	*/
 
@@ -1849,11 +1849,58 @@ pub trait OwnerRpcS {
 		}
 	}
 	# "#
-	# , true, 0, false, false, false);
+	# , true, 0, false, false, false, false);
 	```
 	*/
 
 	fn proof_address_from_onion_v3(&self, address_v3: String) -> Result<PubAddress, ErrorKind>;
+
+	/**
+	Networked version of [Owner::retrieve_payment_proof](struct.Owner.html#method.retrieve_payment_proof).
+	```
+	# grin_wallet_api::doctest_helper_json_rpc_owner_assert_response!(
+	# r#"
+	{
+		"jsonrpc": "2.0",
+		"method": "retrieve_payment_proof",
+		"params": {
+			"token": "d202964900000000d302964900000000d402964900000000d502964900000000",
+			"refresh_from_node": true,
+			"tx_id": null,
+			"tx_slate_id": "0436430c-2b02-624c-2032-570501212b00"
+		},
+		"id": 1
+	}
+	# "#
+	# ,
+	# r#"
+	{
+		"id": 1,
+		"jsonrpc": "2.0",
+		"result": {
+			"Ok": {
+				"amount": 60000000000,
+				"excess": "09bac6083b05a32a9d9b37710c70dd0a1ef9329fde0848558976b6f1b81d80ceed",
+				"recipient_address": "783f6528669742a990e0faf0a5fca5d5b3330e37bbb9cd5c628696d03ce4e810",
+				"recipient_ov3_address": "pa7wkkdgs5bkteha7lykl7ff2wztgdrxxo442xdcq2lnaphe5aidd4id",
+				"recipient_sig": "42b6f2bbcee432185993867d1a338e260454ead536bf728f4dcc8f535508715e92a0695486ba3c9945d8ecb2cf7f703a955780253b12d0048f02d318c8f08702",
+				"sender_address": "32cdd63928854f8b2628b1dce4626ddcdf35d56cb7cfdf7d64cca5822b78d4d3",
+				"sender_ov3_address": "glg5mojiqvhywjriwhooiytn3tptlvlmw7h567lezssyek3y2tjzznad",
+				"sender_sig": "5e3f5596852e83f6db7152fc51c41b4ed8742eb8045fa85a6965c52d09fcb46ba67d4f86660c9f3dc55ab84faea79d11c3831aa77934f7e90695e63d523f8604"
+			}
+		}
+	}
+	# "#
+	# , true, 5, true, true, true, true);
+	```
+	*/
+
+	fn retrieve_payment_proof(&self,
+		token: Token,
+		refresh_from_node: bool,
+		tx_id: Option<u32>,
+		tx_slate_id: Option<Uuid>,
+	) -> Result<PaymentProof, ErrorKind>;
 
 	/**
 	Networked version of [Owner::set_tor_config](struct.Owner.html#method.set_tor_config).
@@ -1883,7 +1930,7 @@ pub trait OwnerRpcS {
 		}
 	}
 	# "#
-	# , true, 0, false, false, false);
+	# , true, 0, false, false, false, false);
 	```
 	*/
 	fn set_tor_config(&self, tor_config: Option<TorConfig>) -> Result<(), ErrorKind>;
@@ -2204,6 +2251,22 @@ where
 		)
 		.map_err(|e| e.kind())?;
 		Ok(PubAddress { address })
+	}
+
+	fn retrieve_payment_proof(&self,
+		token: Token,
+		refresh_from_node: bool,
+		tx_id: Option<u32>,
+		tx_slate_id: Option<Uuid>,
+	) -> Result<PaymentProof, ErrorKind> {
+		Owner::retrieve_payment_proof(
+			self,
+			(&token.keychain_mask).as_ref(),
+			refresh_from_node,
+			tx_id,
+			tx_slate_id,
+		)
+		.map_err(|e| e.kind())
 	}
 
 	fn proof_address_from_onion_v3(&self, address_v3: String) -> Result<PubAddress, ErrorKind> {

--- a/api/src/owner_rpc_s.rs
+++ b/api/src/owner_rpc_s.rs
@@ -1940,10 +1940,7 @@ pub trait OwnerRpcS {
 	```
 	*/
 
-	fn verify_payment_proof(
-		&self,
-		proof: PaymentProof,
-	) -> Result<(), ErrorKind>;
+	fn verify_payment_proof(&self, proof: PaymentProof) -> Result<(), ErrorKind>;
 
 	/**
 	Networked version of [Owner::set_tor_config](struct.Owner.html#method.set_tor_config).
@@ -2313,15 +2310,8 @@ where
 		.map_err(|e| e.kind())
 	}
 
-	fn verify_payment_proof(
-		&self,
-		proof: PaymentProof,
-	) -> Result<(), ErrorKind> {
-		Owner::verify_payment_proof(
-			self,
-			&proof
-		)
-		.map_err(|e| e.kind())
+	fn verify_payment_proof(&self, proof: PaymentProof) -> Result<(), ErrorKind> {
+		Owner::verify_payment_proof(self, &proof).map_err(|e| e.kind())
 	}
 
 	fn proof_address_from_onion_v3(&self, address_v3: String) -> Result<PubAddress, ErrorKind> {

--- a/controller/src/command.rs
+++ b/controller/src/command.rs
@@ -22,14 +22,14 @@ use crate::impls::{create_sender, KeybaseAllChannels, SlateGetter as _, SlateRec
 use crate::impls::{PathToSlate, SlatePutter};
 use crate::keychain;
 use crate::libwallet::{
-	address, InitTxArgs, IssueInvoiceTxArgs, NodeClient, WalletInst, WalletLCProvider,
+	self, address, InitTxArgs, IssueInvoiceTxArgs, PaymentProof, NodeClient, WalletInst, WalletLCProvider,
 };
 use crate::util::secp::key::SecretKey;
 use crate::util::{to_hex, Mutex, ZeroingString};
 use crate::{controller, display};
 use serde_json as json;
 use std::fs::File;
-use std::io::Write;
+use std::io::{Read, Write};
 use std::sync::Arc;
 use std::thread;
 use std::time::Duration;
@@ -913,6 +913,94 @@ where
 			Err(e) => {
 				error!("Addres retrieval failed: {}", e);
 				error!("Backtrace: {}", e.backtrace().unwrap());
+				Err(e)
+			}
+		}
+	})?;
+	Ok(())
+}
+
+/// Proof Export Args
+pub struct ProofExportArgs {
+	pub output_file: String,
+	pub id: Option<u32>,
+	pub tx_slate_id: Option<Uuid>,
+}
+
+pub fn proof_export<L, C, K>(
+	wallet: Arc<Mutex<Box<dyn WalletInst<'static, L, C, K>>>>,
+	keychain_mask: Option<&SecretKey>,
+	args: ProofExportArgs,
+) -> Result<(), Error>
+where
+	L: WalletLCProvider<'static, C, K> + 'static,
+	C: NodeClient + 'static,
+	K: keychain::Keychain + 'static,
+{
+	controller::owner_single_use(wallet.clone(), keychain_mask, |api, m| {
+		let result = api.retrieve_payment_proof(m, true, args.id, args.tx_slate_id);
+		match result {
+			Ok(p) => {
+				// actually export proof
+				let mut proof_file = File::create(args.output_file.clone())?;
+				proof_file.write_all(json::to_string_pretty(&p).unwrap().as_bytes())?;
+				proof_file.sync_all()?;
+				warn!("Payment proof exported to {}", args.output_file);
+				Ok(())
+			}
+			Err(e) => {
+				error!("Proof export failed: {}", e);
+				Err(e)
+			}
+		}
+	})?;
+	Ok(())
+}
+
+/// Proof Verify Args
+pub struct ProofVerifyArgs {
+	pub input_file: String,
+}
+
+pub fn proof_verify<L, C, K>(
+	wallet: Arc<Mutex<Box<dyn WalletInst<'static, L, C, K>>>>,
+	keychain_mask: Option<&SecretKey>,
+	args: ProofVerifyArgs,
+) -> Result<(), Error>
+where
+	L: WalletLCProvider<'static, C, K> + 'static,
+	C: NodeClient + 'static,
+	K: keychain::Keychain + 'static,
+{
+	controller::owner_single_use(wallet.clone(), keychain_mask, |api, _| {
+		let mut proof_f = match File::open(&args.input_file){
+			Ok(p) => p,
+			Err(e) => {
+				let msg = format!("{}", e);
+				error!("Unable to open payment proof file at {}: {}", args.input_file, e);
+				return Err(libwallet::ErrorKind::PaymentProofParsing(msg).into());
+			}
+
+		};
+		let mut proof = String::new();
+		proof_f.read_to_string(&mut proof)?;
+		// read
+		let proof:PaymentProof = match json::from_str(&proof) {
+			Ok(p) => p,
+			Err(e) => {
+				let msg = format!("{}", e);
+				error!("Unable to parse payment proof file: {}", e);
+				return Err(libwallet::ErrorKind::PaymentProofParsing(msg).into());
+			}
+		};
+		let result = api.verify_payment_proof(&proof);
+		match result {
+			Ok(_) => {
+				warn!("Payment proof is valid.");
+				Ok(())
+			}
+			Err(e) => {
+				error!("Proof not valid: {}", e);
 				Err(e)
 			}
 		}

--- a/controller/src/command.rs
+++ b/controller/src/command.rs
@@ -22,7 +22,8 @@ use crate::impls::{create_sender, KeybaseAllChannels, SlateGetter as _, SlateRec
 use crate::impls::{PathToSlate, SlatePutter};
 use crate::keychain;
 use crate::libwallet::{
-	self, address, InitTxArgs, IssueInvoiceTxArgs, PaymentProof, NodeClient, WalletInst, WalletLCProvider,
+	self, address, InitTxArgs, IssueInvoiceTxArgs, NodeClient, PaymentProof, WalletInst,
+	WalletLCProvider,
 };
 use crate::util::secp::key::SecretKey;
 use crate::util::{to_hex, Mutex, ZeroingString};
@@ -973,19 +974,21 @@ where
 	K: keychain::Keychain + 'static,
 {
 	controller::owner_single_use(wallet.clone(), keychain_mask, |api, _| {
-		let mut proof_f = match File::open(&args.input_file){
+		let mut proof_f = match File::open(&args.input_file) {
 			Ok(p) => p,
 			Err(e) => {
 				let msg = format!("{}", e);
-				error!("Unable to open payment proof file at {}: {}", args.input_file, e);
+				error!(
+					"Unable to open payment proof file at {}: {}",
+					args.input_file, e
+				);
 				return Err(libwallet::ErrorKind::PaymentProofParsing(msg).into());
 			}
-
 		};
 		let mut proof = String::new();
 		proof_f.read_to_string(&mut proof)?;
 		// read
-		let proof:PaymentProof = match json::from_str(&proof) {
+		let proof: PaymentProof = match json::from_str(&proof) {
 			Ok(p) => p,
 			Err(e) => {
 				let msg = format!("{}", e);

--- a/controller/src/command.rs
+++ b/controller/src/command.rs
@@ -1007,7 +1007,9 @@ where
 					println!("The proof's recipient address belongs to this wallet.");
 				}
 				if !iam_recipient && !iam_sender {
-					println!("Neither the proof's sender nor recipient address belongs to this wallet.");
+					println!(
+						"Neither the proof's sender nor recipient address belongs to this wallet."
+					);
 				}
 				Ok(())
 			}

--- a/controller/tests/payment_proofs.rs
+++ b/controller/tests/payment_proofs.rs
@@ -145,7 +145,6 @@ fn payment_proofs_test_impl(test_dir: &'static str) -> Result<(), libwallet::Err
 		let res = sender_api.verify_payment_proof(&pp);
 		assert!(res.is_err());
 
-
 		Ok(())
 	})?;
 

--- a/controller/tests/payment_proofs.rs
+++ b/controller/tests/payment_proofs.rs
@@ -144,11 +144,12 @@ fn payment_proofs_test_impl(test_dir: &'static str) -> Result<(), libwallet::Err
 		println!("{:?}", pp);
 
 		// verify, should be good
-		sender_api.verify_payment_proof(&pp)?;
+		let res = sender_api.verify_payment_proof(m, &pp)?;
+		assert_eq!(res, (true, false));
 
 		// Modify values, should not be good
 		pp.amount = 20;
-		let res = sender_api.verify_payment_proof(&pp);
+		let res = sender_api.verify_payment_proof(m, &pp);
 		assert!(res.is_err());
 		Ok(())
 	})?;

--- a/controller/tests/payment_proofs.rs
+++ b/controller/tests/payment_proofs.rs
@@ -126,13 +126,16 @@ fn payment_proofs_test_impl(test_dir: &'static str) -> Result<(), libwallet::Err
 		assert_eq!(pp.sender_address_path, 0);
 		assert_eq!(pp.sender_signature, None);
 
+		// check we should get an error at this point since proof is not complete
+		let pp = sender_api.retrieve_payment_proof(m, true, None, Some(slate.id));
+		assert!(pp.is_err());
+
 		slate = sender_api.finalize_tx(m, &slate)?;
 
 		// Check payment proof here
-		let (_, txs) = sender_api.retrieve_txs(m, true, None, Some(slate.id))?;
-		let tx = txs[0].clone();
+		let pp = sender_api.retrieve_payment_proof(m, true, None, Some(slate.id))?;
 
-		println!("{:?}", tx);
+		println!("{:?}", pp);
 
 		Ok(())
 	})?;

--- a/controller/tests/payment_proofs.rs
+++ b/controller/tests/payment_proofs.rs
@@ -133,9 +133,18 @@ fn payment_proofs_test_impl(test_dir: &'static str) -> Result<(), libwallet::Err
 		slate = sender_api.finalize_tx(m, &slate)?;
 
 		// Check payment proof here
-		let pp = sender_api.retrieve_payment_proof(m, true, None, Some(slate.id))?;
+		let mut pp = sender_api.retrieve_payment_proof(m, true, None, Some(slate.id))?;
+
+		// verify, should be good
+		sender_api.verify_payment_proof(&pp)?;
 
 		println!("{:?}", pp);
+
+		// Modify values, should not be good
+		pp.amount = 20;
+		let res = sender_api.verify_payment_proof(&pp);
+		assert!(res.is_err());
+
 
 		Ok(())
 	})?;

--- a/controller/tests/payment_proofs.rs
+++ b/controller/tests/payment_proofs.rs
@@ -135,8 +135,7 @@ fn payment_proofs_test_impl(test_dir: &'static str) -> Result<(), libwallet::Err
 		Ok(())
 	})?;
 
-	let _ =
-		test_framework::award_blocks_to_wallet(&chain, wallet1.clone(), mask1, 2, false);
+	let _ = test_framework::award_blocks_to_wallet(&chain, wallet1.clone(), mask1, 2, false);
 
 	wallet::controller::owner_single_use(wallet1.clone(), mask1, |sender_api, m| {
 		// Check payment proof here
@@ -146,7 +145,6 @@ fn payment_proofs_test_impl(test_dir: &'static str) -> Result<(), libwallet::Err
 
 		// verify, should be good
 		sender_api.verify_payment_proof(&pp)?;
-
 
 		// Modify values, should not be good
 		pp.amount = 20;

--- a/controller/tests/payment_proofs.rs
+++ b/controller/tests/payment_proofs.rs
@@ -131,20 +131,27 @@ fn payment_proofs_test_impl(test_dir: &'static str) -> Result<(), libwallet::Err
 		assert!(pp.is_err());
 
 		slate = sender_api.finalize_tx(m, &slate)?;
+		sender_api.post_tx(m, &slate.tx, true)?;
+		Ok(())
+	})?;
 
+	let _ =
+		test_framework::award_blocks_to_wallet(&chain, wallet1.clone(), mask1, 2, false);
+
+	wallet::controller::owner_single_use(wallet1.clone(), mask1, |sender_api, m| {
 		// Check payment proof here
 		let mut pp = sender_api.retrieve_payment_proof(m, true, None, Some(slate.id))?;
+
+		println!("{:?}", pp);
 
 		// verify, should be good
 		sender_api.verify_payment_proof(&pp)?;
 
-		println!("{:?}", pp);
 
 		// Modify values, should not be good
 		pp.amount = 20;
 		let res = sender_api.verify_payment_proof(&pp);
 		assert!(res.is_err());
-
 		Ok(())
 	})?;
 

--- a/impls/src/test_framework/testclient.rs
+++ b/impls/src/test_framework/testclient.rs
@@ -525,12 +525,12 @@ impl NodeClient for LocalWalletClient {
 		if let Some(h) = min_height {
 			query += &format!("{},", h);
 		} else {
-			query += "0,"
+			query += "1,"
 		}
 		if let Some(h) = max_height {
 			query += &format!("{}", h);
 		} else {
-			query += "0"
+			query += "1"
 		}
 
 		let m = WalletProxyMessage {

--- a/impls/src/test_framework/testclient.rs
+++ b/impls/src/test_framework/testclient.rs
@@ -353,7 +353,15 @@ where
 		let max = split[2].parse::<u64>().unwrap();
 		let commit_bytes = util::from_hex(excess).unwrap();
 		let commit = pedersen::Commitment::from_vec(commit_bytes);
-		let k = super::get_kernel_local(self.chain.clone(), &commit, Some(min), Some(max));
+		let min = match min {
+			0 => None,
+			m => Some(m),
+		};
+		let max = match max {
+			0 => None,
+			m => Some(m),
+		};
+		let k = super::get_kernel_local(self.chain.clone(), &commit, min, max);
 		Ok(WalletProxyMessage {
 			sender_id: "node".to_owned(),
 			dest: m.sender_id,
@@ -525,12 +533,12 @@ impl NodeClient for LocalWalletClient {
 		if let Some(h) = min_height {
 			query += &format!("{},", h);
 		} else {
-			query += "1,"
+			query += "0,"
 		}
 		if let Some(h) = max_height {
 			query += &format!("{}", h);
 		} else {
-			query += "1"
+			query += "0"
 		}
 
 		let m = WalletProxyMessage {

--- a/libwallet/src/api_impl/owner.rs
+++ b/libwallet/src/api_impl/owner.rs
@@ -881,18 +881,14 @@ where
 /// Verify/validate arbitrary payment proof
 pub fn verify_payment_proof<'a, L, C, K>(
 	wallet_inst: Arc<Mutex<Box<dyn WalletInst<'a, L, C, K>>>>,
-	proof: &PaymentProof
+	proof: &PaymentProof,
 ) -> Result<(), Error>
 where
 	L: WalletLCProvider<'a, C, K>,
 	C: NodeClient + 'a,
 	K: Keychain + 'a,
 {
-	let msg = tx::payment_proof_message(
-		proof.amount,
-		&proof.excess,
-		proof.sender_address,
-	)?;
+	let msg = tx::payment_proof_message(proof.amount, &proof.excess, proof.sender_address)?;
 
 	// Check Sigs
 
@@ -915,9 +911,7 @@ where
 
 	// Check kernel exists
 	if let Err(_) = client.get_kernel(&proof.excess, None, None) {
-		return Err(ErrorKind::PaymentProof(
-			"Kernel not found".to_owned(),
-		))?;
+		return Err(ErrorKind::PaymentProof("Kernel not found".to_owned()))?;
 	};
 
 	Ok(())

--- a/libwallet/src/api_impl/owner.rs
+++ b/libwallet/src/api_impl/owner.rs
@@ -895,7 +895,11 @@ where
 
 	let (mut client, parent_key_id, keychain) = {
 		wallet_lock!(wallet_inst, w);
-		(w.w2n_client().clone(), w.parent_key_id(), w.keychain(keychain_mask)?)
+		(
+			w.w2n_client().clone(),
+			w.parent_key_id(),
+			w.keychain(keychain_mask)?,
+		)
 	};
 
 	// Check kernel exists
@@ -931,8 +935,7 @@ where
 	};
 
 	// for now, simple test as to whether one of the addresses belongs to this wallet
-	let sec_key =
-		address::address_from_derivation_path(&keychain, &parent_key_id, 0)?;
+	let sec_key = address::address_from_derivation_path(&keychain, &parent_key_id, 0)?;
 	let d_skey = match DalekSecretKey::from_bytes(&sec_key.0) {
 		Ok(k) => k,
 		Err(e) => {

--- a/libwallet/src/api_impl/owner.rs
+++ b/libwallet/src/api_impl/owner.rs
@@ -29,8 +29,8 @@ use crate::internal::{keys, scan, selection, tx, updater};
 use crate::slate::{PaymentInfo, Slate};
 use crate::types::{AcctPathMapping, NodeClient, TxLogEntry, TxWrapper, WalletBackend, WalletInfo};
 use crate::{
-	address, wallet_lock, InitTxArgs, IssueInvoiceTxArgs, NodeHeightResult, OutputCommitMapping, PaymentProof,
-	ScannedBlockInfo, TxLogEntryType, WalletInitStatus, WalletInst, WalletLCProvider,
+	address, wallet_lock, InitTxArgs, IssueInvoiceTxArgs, NodeHeightResult, OutputCommitMapping,
+	PaymentProof, ScannedBlockInfo, TxLogEntryType, WalletInitStatus, WalletInst, WalletLCProvider,
 };
 use crate::{Error, ErrorKind};
 use ed25519_dalek::PublicKey as DalekPublicKey;
@@ -209,8 +209,9 @@ where
 {
 	if tx_id.is_none() && tx_slate_id.is_none() {
 		return Err(ErrorKind::PaymentProofRetrieval(
-			"Transaction ID or Slate UUID must be specified".into()
-		).into());
+			"Transaction ID or Slate UUID must be specified".into(),
+		)
+		.into());
 	}
 	let mut _validated = false;
 	if refresh_from_node {
@@ -230,9 +231,7 @@ where
 		tx_slate_id,
 	)?;
 	if txs.1.len() != 1 {
-		return Err(ErrorKind::PaymentProofRetrieval(
-			"Transaction doesn't exist".into()
-		).into());
+		return Err(ErrorKind::PaymentProofRetrieval("Transaction doesn't exist".into()).into());
 	}
 	// Pull out all needed fields, returning an error if they're not present
 	let tx = txs.1[0].clone();
@@ -240,17 +239,17 @@ where
 		Some(p) => p,
 		None => {
 			return Err(ErrorKind::PaymentProofRetrieval(
-				"Transaction does not contain a payment proof".into()
-			).into());
+				"Transaction does not contain a payment proof".into(),
+			)
+			.into());
 		}
-
 	};
 	let amount = if tx.amount_credited >= tx.amount_debited {
 		tx.amount_credited - tx.amount_debited
 	} else {
 		let fee = match tx.fee {
 			Some(f) => f,
-			None => 0
+			None => 0,
 		};
 		tx.amount_debited - tx.amount_credited - fee
 	};
@@ -258,24 +257,27 @@ where
 		Some(e) => e,
 		None => {
 			return Err(ErrorKind::PaymentProofRetrieval(
-				"Transaction does not contain kernel excess".into()
-			).into());
+				"Transaction does not contain kernel excess".into(),
+			)
+			.into());
 		}
 	};
 	let r_sig = match proof.receiver_signature {
 		Some(e) => e,
 		None => {
 			return Err(ErrorKind::PaymentProofRetrieval(
-				"Proof does not contain receiver signature ".into()
-			).into());
+				"Proof does not contain receiver signature ".into(),
+			)
+			.into());
 		}
 	};
 	let s_sig = match proof.sender_signature {
 		Some(e) => e,
 		None => {
 			return Err(ErrorKind::PaymentProofRetrieval(
-				"Proof does not contain sender signature ".into()
-			).into());
+				"Proof does not contain sender signature ".into(),
+			)
+			.into());
 		}
 	};
 	Ok(PaymentProof {

--- a/libwallet/src/api_impl/owner.rs
+++ b/libwallet/src/api_impl/owner.rs
@@ -898,12 +898,20 @@ where
 	// Check kernel exists
 	match client.get_kernel(&proof.excess, None, None) {
 		Err(e) => {
-			return Err(ErrorKind::PaymentProof(format!("Error retrieving kernel from chain: {}", e).to_owned()))?;
-		},
+			return Err(ErrorKind::PaymentProof(
+				format!("Error retrieving kernel from chain: {}", e).to_owned(),
+			))?;
+		}
 		Ok(None) => {
-			return Err(ErrorKind::PaymentProof(format!("Transaction kernel with excess {:?} not found on chain", proof.excess).to_owned()))?;
-		},
-		Ok(Some(_)) => {},
+			return Err(ErrorKind::PaymentProof(
+				format!(
+					"Transaction kernel with excess {:?} not found on chain",
+					proof.excess
+				)
+				.to_owned(),
+			))?;
+		}
+		Ok(Some(_)) => {}
 	};
 
 	// Check Sigs

--- a/libwallet/src/api_impl/owner.rs
+++ b/libwallet/src/api_impl/owner.rs
@@ -889,7 +889,6 @@ where
 	C: NodeClient + 'a,
 	K: Keychain + 'a,
 {
-
 	let sender_pubkey = address::pubkey_from_onion_v3(&proof.sender_address)?;
 	let msg = tx::payment_proof_message(proof.amount, &proof.excess, sender_pubkey)?;
 

--- a/libwallet/src/api_impl/types.rs
+++ b/libwallet/src/api_impl/types.rs
@@ -228,6 +228,7 @@ pub struct VersionInfo {
 #[derive(Serialize, Deserialize, Debug, Clone)]
 pub struct PaymentProof {
 	/// Amount
+	#[serde(with = "secp_ser::string_or_u64")]
 	pub amount: u64,
 	/// Kernel Excess
 	#[serde(

--- a/libwallet/src/api_impl/types.rs
+++ b/libwallet/src/api_impl/types.rs
@@ -22,6 +22,7 @@ use crate::slate_versions::SlateVersion;
 use crate::types::OutputData;
 
 use ed25519_dalek::PublicKey as DalekPublicKey;
+use ed25519_dalek::Signature as DalekSignature;
 
 /// Send TX API Args
 // TODO: This is here to ensure the legacy V1 API remains intact
@@ -222,3 +223,33 @@ pub struct VersionInfo {
 	/// Slate version
 	pub supported_slate_versions: Vec<SlateVersion>,
 }
+
+/// Packaged Payment Proof
+#[derive(Serialize, Deserialize, Debug, Clone)]
+pub struct PaymentProof {
+	/// Amount
+	pub amount: u64,
+	/// Kernel Excess
+	#[serde(
+		serialize_with = "secp_ser::as_hex",
+		deserialize_with = "secp_ser::commitment_from_hex"
+	)]
+	pub excess: pedersen::Commitment,
+	/// Recipient Wallet Address
+	#[serde(with = "dalek_ser::dalek_pubkey_serde")]
+	pub recipient_address: DalekPublicKey,
+	/// Onion V3 Adddress of recipient
+	pub recipient_ov3_address: String,
+	/// Recipient Signature
+	#[serde(with = "dalek_ser::dalek_sig_serde")]
+	pub recipient_sig: DalekSignature,
+	/// Sender Wallet Address
+	#[serde(with = "dalek_ser::dalek_pubkey_serde")]
+	pub sender_address: DalekPublicKey,
+	/// Onion V3 Adddress of sender
+	pub sender_ov3_address: String,
+	/// Sender Signature
+	#[serde(with = "dalek_ser::dalek_sig_serde")]
+	pub sender_sig: DalekSignature,
+}
+

--- a/libwallet/src/api_impl/types.rs
+++ b/libwallet/src/api_impl/types.rs
@@ -236,19 +236,13 @@ pub struct PaymentProof {
 		deserialize_with = "secp_ser::commitment_from_hex"
 	)]
 	pub excess: pedersen::Commitment,
-	/// Recipient Wallet Address
-	#[serde(with = "dalek_ser::dalek_pubkey_serde")]
-	pub recipient_address: DalekPublicKey,
-	/// Onion V3 Adddress of recipient
-	pub recipient_ov3_address: String,
+	/// Recipient Wallet Address (Onion V3)
+	pub recipient_address: String,
 	/// Recipient Signature
 	#[serde(with = "dalek_ser::dalek_sig_serde")]
 	pub recipient_sig: DalekSignature,
-	/// Sender Wallet Address
-	#[serde(with = "dalek_ser::dalek_pubkey_serde")]
-	pub sender_address: DalekPublicKey,
-	/// Onion V3 Adddress of sender
-	pub sender_ov3_address: String,
+	/// Sender Wallet Address (Onion V3)
+	pub sender_address: String,
 	/// Sender Signature
 	#[serde(with = "dalek_ser::dalek_sig_serde")]
 	pub sender_sig: DalekSignature,

--- a/libwallet/src/api_impl/types.rs
+++ b/libwallet/src/api_impl/types.rs
@@ -252,4 +252,3 @@ pub struct PaymentProof {
 	#[serde(with = "dalek_ser::dalek_sig_serde")]
 	pub sender_sig: DalekSignature,
 }
-

--- a/libwallet/src/error.rs
+++ b/libwallet/src/error.rs
@@ -229,6 +229,10 @@ pub enum ErrorKind {
 	#[fail(display = "Payment Proof generation error: {}", _0)]
 	PaymentProof(String),
 
+	/// Retrieving Payment Proof
+	#[fail(display = "Payment Proof retrieval error: {}", _0)]
+	PaymentProofRetrieval(String),
+
 	/// Decoding OnionV3 addresses to payment proof addresses
 	#[fail(display = "Proof Address decoding: {}", _0)]
 	AddressDecoding(String),

--- a/libwallet/src/error.rs
+++ b/libwallet/src/error.rs
@@ -233,6 +233,10 @@ pub enum ErrorKind {
 	#[fail(display = "Payment Proof retrieval error: {}", _0)]
 	PaymentProofRetrieval(String),
 
+	/// Retrieving Payment Proof
+	#[fail(display = "Payment Proof parsing error: {}", _0)]
+	PaymentProofParsing(String),
+
 	/// Decoding OnionV3 addresses to payment proof addresses
 	#[fail(display = "Proof Address decoding: {}", _0)]
 	AddressDecoding(String),

--- a/libwallet/src/internal/tx.rs
+++ b/libwallet/src/internal/tx.rs
@@ -461,8 +461,8 @@ pub fn create_payment_proof_signature(
 	Ok(keypair.sign(&msg))
 }
 
-/// Verify all aspects of a completed payment proof
-pub fn verify_payment_proof<'a, T: ?Sized, C, K>(
+/// Verify all aspects of a completed payment proof on the current slate
+pub fn verify_slate_payment_proof<'a, T: ?Sized, C, K>(
 	wallet: &mut T,
 	keychain_mask: Option<&SecretKey>,
 	parent_key_id: &Identifier,

--- a/libwallet/src/lib.rs
+++ b/libwallet/src/lib.rs
@@ -61,7 +61,7 @@ pub use crate::slate_versions::{
 pub use api_impl::owner_updater::StatusMessage;
 pub use api_impl::types::{
 	BlockFees, InitTxArgs, InitTxSendArgs, IssueInvoiceTxArgs, NodeHeightResult,
-	OutputCommitMapping, SendTXArgs, VersionInfo,
+	OutputCommitMapping, PaymentProof, SendTXArgs, VersionInfo,
 };
 pub use internal::scan::scan;
 pub use slate_versions::ser as dalek_ser;

--- a/libwallet/src/slate_versions/ser.rs
+++ b/libwallet/src/slate_versions/ser.rs
@@ -105,10 +105,9 @@ pub mod dalek_sig_serde {
 		String::deserialize(deserializer)
 			.and_then(|string| from_hex(string).map_err(|err| Error::custom(err.to_string())))
 			.and_then(|bytes: Vec<u8>| {
-					let mut b = [0u8; 64];
-					b.copy_from_slice(&bytes[0..64]);
-					DalekSignature::from_bytes(&b)
-						.map_err(|err| Error::custom(err.to_string()))
+				let mut b = [0u8; 64];
+				b.copy_from_slice(&bytes[0..64]);
+				DalekSignature::from_bytes(&b).map_err(|err| Error::custom(err.to_string()))
 			})
 	}
 }

--- a/src/bin/grin-wallet.yml
+++ b/src/bin/grin-wallet.yml
@@ -364,3 +364,25 @@ subcommands:
             long: start_height
             default_value: "1"
             takes_value: true
+  - export_proof:
+      about: Export a payment proof from a completed transaction
+      args:
+          - output:
+              help: Output proof file
+              index: 1
+          - id:
+              help: If specified, retrieve the proof for the given transaction ID
+              short: i
+              long: id
+              takes_value: true
+          - txid:
+              help: If specified, retrieve the proof for the given Slate ID
+              short: t
+              long: txid
+              takes_value: true
+  - verify_proof:
+      about: Verify a payment proof
+      args:
+          - input:
+              help: Filename of a proof file
+              index: 1


### PR DESCRIPTION
Aims to add functionality to the API to export payment proofs as JSON and validate an exported payment proof, as well as command-line options calling both.

Update on completion:

* Adds a `PaymentProof` struct intended for serialization into JSON for export to file or use via the API
* Adds needed serializer for payment proof struct
* Adds new API functions `retrieve_payment_proof` and `verify_payment_proof` (details in rustdoc documentation, as well as supporting internal implementations
* Adds `export_proof` and `verify_proof` command line options
* Documentation + doctests for all of the above