### PR TITLE
Version check fix + Rustfmt

### DIFF
--- a/.hooks/pre-commit
+++ b/.hooks/pre-commit
@@ -22,38 +22,29 @@ if [ $? != 0 ]; then
 	exit 1
 fi
 
-result=0
 problem_files=()
 
-printf "[pre_commit] rustfmt "
-
+# first collect all the files that need reformatting
 for file in $(git diff --name-only --cached); do
 	if [ ${file: -3} == ".rs" ]; then
-		# first collect all the files that need reformatting
 		rustfmt --check $file &>/dev/null
 		if [ $? != 0 ]; then
 			problem_files+=($file)
-			result=1
 		fi
 	fi
 done
 
-# now reformat all the files that need reformatting
-for file in ${problem_files[@]}; do
-	rustfmt $file
-done
-
-# and let the user know what just happened (and which files were affected)
-printf "\033[0;32mok\033[0m \n"
-if [ $result != 0 ]; then
-	# printf "\033[0;31mrustfmt\033[0m \n"
-	printf "[pre_commit] the following files were rustfmt'd (not yet committed): \n"
-
-	for file in ${problem_files[@]}; do
-		printf "\033[0;31m    $file\033[0m \n"
-	done
+if [ ${#problem_files[@]} == 0 ]; then
+  # nothing to do
+  printf "[pre_commit] rustfmt \033[0;32mok\033[0m \n"
+else
+  # reformat the files that need it and re-stage them.
+	printf "[pre_commit] the following files were rustfmt'd before commit: \n"
+  for file in ${problem_files[@]}; do
+    rustfmt $file
+    git add $file
+		printf "\033[0;32m    $file\033[0m \n"
+  done
 fi
 
 exit 0
-# to actually fail the build on rustfmt failure -
-# exit $result

--- a/src/cmd/wallet.rs
+++ b/src/cmd/wallet.rs
@@ -44,7 +44,10 @@ where
 	if let Some(v) = node_client.clone().get_version_info() {
 		if Version::parse(&v.node_version) < Version::parse(MIN_COMPAT_NODE_VERSION) {
 			println!("The Grin Node in use (version {}) is outdated and incompatible with this wallet version.", v.node_version);
-			println!("Please update the node to version {} or later and try again.", MIN_COMPAT_NODE_VERSION);
+			println!(
+				"Please update the node to version {} or later and try again.",
+				MIN_COMPAT_NODE_VERSION
+			);
 			return 1;
 		}
 	}

--- a/src/cmd/wallet.rs
+++ b/src/cmd/wallet.rs
@@ -20,7 +20,7 @@ use semver::Version;
 use std::thread;
 use std::time::Duration;
 
-const MIN_COMPAT_NODE_VERSION: &str = "2.0.0-beta.1";
+const MIN_COMPAT_NODE_VERSION: &str = "3.0.0";
 
 pub fn wallet_command<C>(
 	wallet_args: &ArgMatches<'_>,
@@ -36,24 +36,15 @@ where
 	let tor_config = config.members.unwrap().tor;
 
 	// Check the node version info, and exit with report if we're not compatible
-	//let mut node_client = HTTPNodeClient::new(&wallet_config.check_node_api_http_addr, None);
 	let global_wallet_args = wallet_args::parse_global_args(&wallet_config, &wallet_args)
 		.expect("Can't read configuration file");
 	node_client.set_node_api_secret(global_wallet_args.node_api_secret.clone());
 
 	// This will also cache the node version info for calls to foreign API check middleware
 	if let Some(v) = node_client.clone().get_version_info() {
-		// Isn't going to happen just yet (as of 2.0.0) but keep this here for
-		// the future. the nodeclient's get_version_info will return 1.0 if
-		// it gets a 404 for the version function
 		if Version::parse(&v.node_version) < Version::parse(MIN_COMPAT_NODE_VERSION) {
-			let version = if v.node_version == "1.0.0" {
-				"1.x.x series"
-			} else {
-				&v.node_version
-			};
-			println!("The Grin Node in use (version {}) is outdated and incompatible with this wallet version.", version);
-			println!("Please update the node to version 2.0.0 or later and try again.");
+			println!("The Grin Node in use (version {}) is outdated and incompatible with this wallet version.", v.node_version);
+			println!("Please update the node to version {} or later and try again.", MIN_COMPAT_NODE_VERSION);
 			return 1;
 		}
 	}


### PR DESCRIPTION
Fixes node version check on startup to correctly look for a 3.0.0, which was overlooked prior to 3.0.0 release. Shouldn't be a huge problem in practice since everyone needs to update to 3.0.0 anyhow, but included for correctness.

Also updates the pre-commit hook to the version in grin, which rustfmts on commit instead of needed to perform a separate commit.

To be cherrypicked to master