### PR TITLE
Add output query chunk size as temporary env variable

### DIFF
--- a/impls/src/node_clients/http.rs
+++ b/impls/src/node_clients/http.rs
@@ -22,6 +22,7 @@ use crate::core::core::TxKernel;
 use crate::libwallet::{NodeClient, NodeVersionInfo, TxWrapper};
 use semver::Version;
 use std::collections::HashMap;
+use std::env;
 use tokio::runtime::Runtime;
 
 use crate::client_utils::Client;
@@ -200,7 +201,28 @@ impl NodeClient for HTTPNodeClient {
 
 		let client = Client::new();
 
-		for query_chunk in query_params.chunks(200) {
+		// Using an environment variable here, as this is a temporary fix
+		// and doesn't need to be permeated throughout the application
+		// configuration
+		let chunk_default = 200;
+		let chunk_size = match env::var("GRIN_OUTPUT_QUERY_SIZE") {
+			Ok(s) => match s.parse::<usize>() {
+				Ok(c) => c,
+				Err(e) => {
+					error!(
+						"Unable to parse GRIN_OUTPUT_QUERY_SIZE, defaulting to {}",
+						chunk_default
+					);
+					error!("Reason: {}", e);
+					chunk_default
+				}
+			},
+			Err(_) => chunk_default,
+		};
+
+		trace!("Output query chunk size is: {}", chunk_size);
+
+		for query_chunk in query_params.chunks(chunk_size) {
 			let url = format!("{}/v1/chain/outputs/byids?{}", addr, query_chunk.join("&"),);
 			tasks.push(client.get_async::<Vec<api::Output>>(url.as_str(), self.node_api_secret()));
 		}


### PR DESCRIPTION
Changes the hardcoded 200 in the default node client's `get_outputs` query to optionally use an environment variable, so users have a lever with which to try to address URI length restrictions in their environments.

Note this is done as an environment variable as opposed to a configuration setting, as this is only intended to be a temporary workaround. The move to using the node's JSON-RPC API will happen on or before 4.0.0 and should address the root of this issue properly (by including the list of outputs to fetch in the body instead of as a query string).
