### PR TITLE
Secure API JSON RPC ID can be integer or string

### DIFF
--- a/api/src/types.rs
+++ b/api/src/types.rs
@@ -142,14 +142,15 @@ pub struct EncryptedRequest {
 	/// method
 	pub method: String,
 	/// id
-	pub id: u32,
+	#[serde(with = "secp_ser::string_or_u64")]
+	pub id: u64,
 	/// Body params, which includes nonce and encrypted request
 	pub params: EncryptedBody,
 }
 
 impl EncryptedRequest {
 	/// from json
-	pub fn from_json(id: u32, json_in: &Value, enc_key: &SecretKey) -> Result<Self, Error> {
+	pub fn from_json(id: u64, json_in: &Value, enc_key: &SecretKey) -> Result<Self, Error> {
 		Ok(EncryptedRequest {
 			jsonrpc: "2.0".to_owned(),
 			method: "encrypted_request_v3".to_owned(),
@@ -187,14 +188,15 @@ pub struct EncryptedResponse {
 	/// JSON RPC response
 	pub jsonrpc: String,
 	/// id
-	pub id: u32,
+	#[serde(with = "secp_ser::string_or_u64")]
+	pub id: u64,
 	/// result
 	pub result: HashMap<String, EncryptedBody>,
 }
 
 impl EncryptedResponse {
 	/// from json
-	pub fn from_json(id: u32, json_in: &Value, enc_key: &SecretKey) -> Result<Self, Error> {
+	pub fn from_json(id: u64, json_in: &Value, enc_key: &SecretKey) -> Result<Self, Error> {
 		let mut result_set = HashMap::new();
 		result_set.insert(
 			"Ok".to_string(),
@@ -245,14 +247,15 @@ pub struct EncryptionErrorResponse {
 	/// JSON RPC response
 	pub jsonrpc: String,
 	/// id
-	pub id: u32,
+	#[serde(with = "secp_ser::string_or_u64")]
+	pub id: u64,
 	/// error
 	pub error: EncryptionError,
 }
 
 impl EncryptionErrorResponse {
 	/// Create new response
-	pub fn new(id: u32, code: i32, message: &str) -> Self {
+	pub fn new(id: u64, code: i32, message: &str) -> Self {
 		EncryptionErrorResponse {
 			jsonrpc: "2.0".to_owned(),
 			id: id,

--- a/controller/src/controller.rs
+++ b/controller/src/controller.rs
@@ -475,7 +475,7 @@ impl OwnerV3Helpers {
 	pub fn decrypt_request(
 		key: Arc<Mutex<Option<SecretKey>>>,
 		req: &serde_json::Value,
-	) -> Result<(u32, serde_json::Value), serde_json::Value> {
+	) -> Result<(u64, serde_json::Value), serde_json::Value> {
 		let share_key_ref = key.lock();
 		let shared_key = share_key_ref.as_ref().unwrap();
 		let enc_req: EncryptedRequest = serde_json::from_value(req.clone()).map_err(|e| {
@@ -497,7 +497,7 @@ impl OwnerV3Helpers {
 	/// Encrypt a response
 	pub fn encrypt_response(
 		key: Arc<Mutex<Option<SecretKey>>>,
-		id: u32,
+		id: u64,
 		res: &serde_json::Value,
 	) -> Result<serde_json::Value, serde_json::Value> {
 		let share_key_ref = key.lock();

--- a/tests/common/mod.rs
+++ b/tests/common/mod.rs
@@ -371,7 +371,7 @@ where
 
 #[allow(dead_code)]
 pub fn send_request_enc<OUT>(
-	sec_req_id: u32,
+	sec_req_id: u64,
 	internal_request_id: u32,
 	dest: &str,
 	req: &str,


### PR DESCRIPTION
Fixes #312 and #313.
uint64 are now serialized as string and can be deserialized either from integer or string.