### PR TITLE
Rework directory checks/setups at launch

### DIFF
--- a/config/src/config.rs
+++ b/config/src/config.rs
@@ -82,6 +82,13 @@ fn check_config_current_dir(path: &str) -> Option<PathBuf> {
 	None
 }
 
+/// Whether a config file exists at the given directory
+pub fn config_file_exists(path: &str) -> bool {
+	let mut path = PathBuf::from(path);
+	path.push(WALLET_CONFIG_FILE_NAME);
+	path.exists()
+}
+
 /// Create file with api secret
 pub fn init_api_secret(api_secret_path: &PathBuf) -> Result<(), ConfigError> {
 	let mut api_secret_file = File::create(api_secret_path)?;

--- a/config/src/lib.rs
+++ b/config/src/lib.rs
@@ -30,7 +30,9 @@ mod comments;
 pub mod config;
 pub mod types;
 
-pub use crate::config::{initial_setup_wallet, GRIN_WALLET_DIR, WALLET_CONFIG_FILE_NAME};
+pub use crate::config::{
+	config_file_exists, initial_setup_wallet, GRIN_WALLET_DIR, WALLET_CONFIG_FILE_NAME,
+};
 pub use crate::types::{
 	ConfigError, GlobalWalletConfig, GlobalWalletConfigMembers, TorConfig, WalletConfig,
 };

--- a/config/src/types.rs
+++ b/config/src/types.rs
@@ -115,6 +115,9 @@ pub enum ConfigError {
 
 	/// Error serializing config values
 	SerializationError(String),
+
+	/// Path doesn't exist
+	PathNotFoundError(String),
 }
 
 impl fmt::Display for ConfigError {
@@ -134,6 +137,7 @@ impl fmt::Display for ConfigError {
 			ConfigError::SerializationError(ref message) => {
 				write!(f, "Error serializing configuration: {}", message)
 			}
+			ConfigError::PathNotFoundError(ref message) => write!(f, "Path not found: {}", message),
 		}
 	}
 }

--- a/src/cmd/wallet_args.rs
+++ b/src/cmd/wallet_args.rs
@@ -300,6 +300,7 @@ pub fn parse_init_args<L, C, K>(
 	config: &WalletConfig,
 	g_args: &command::GlobalArgs,
 	args: &ArgMatches,
+	test_mode: bool,
 ) -> Result<command::InitArgs, ParseError>
 where
 	DefaultWalletImpl<'static, C>: WalletInst<'static, L, C, K>,
@@ -307,7 +308,7 @@ where
 	C: NodeClient + 'static,
 	K: keychain::Keychain + 'static,
 {
-	if config_file_exists(&config.data_file_dir) {
+	if config_file_exists(&config.data_file_dir) && !test_mode {
 		return Err(ParseError::WalletExists(config.data_file_dir.clone()));
 	}
 
@@ -957,7 +958,8 @@ where
 				wallet.clone(),
 				&wallet_config,
 				&global_wallet_args,
-				&args
+				&args,
+				test_mode,
 			));
 			command::init(wallet, &global_wallet_args, a)
 		}

--- a/src/cmd/wallet_args.rs
+++ b/src/cmd/wallet_args.rs
@@ -19,7 +19,7 @@ use crate::util::{Mutex, ZeroingString};
 /// Argument parsing and error handling for wallet commands
 use clap::ArgMatches;
 use failure::Fail;
-use grin_wallet_config::{TorConfig, WalletConfig};
+use grin_wallet_config::{config_file_exists, TorConfig, WalletConfig};
 use grin_wallet_controller::command;
 use grin_wallet_controller::{Error, ErrorKind};
 use grin_wallet_impls::tor::config::is_tor_address;
@@ -58,6 +58,8 @@ pub enum ParseError {
 	ArgumentError(String),
 	#[fail(display = "Parsing IO error: {}", _0)]
 	IOError(String),
+	#[fail(display = "Wallet configuration already exists: {}", _0)]
+	WalletExists(String),
 	#[fail(display = "User Cancelled")]
 	CancelledError,
 }
@@ -305,6 +307,10 @@ where
 	C: NodeClient + 'static,
 	K: keychain::Keychain + 'static,
 {
+	if config_file_exists(&config.data_file_dir) {
+		return Err(ParseError::WalletExists(config.data_file_dir.clone()));
+	}
+
 	let list_length = match args.is_present("short_wordlist") {
 		false => 32,
 		true => 16,

--- a/tests/common/mod.rs
+++ b/tests/common/mod.rs
@@ -308,7 +308,7 @@ where
 {
 	let args = app.clone().get_matches_from(arg_vec);
 	let _ = get_wallet_subcommand(test_dir, wallet_name, args.clone());
-	let config = config::initial_setup_wallet(&ChainTypes::AutomatedTesting, None).unwrap();
+	let config = config::initial_setup_wallet(&ChainTypes::AutomatedTesting, None, true).unwrap();
 	let mut wallet_config = config.clone().members.unwrap().wallet;
 	wallet_config.chain_type = None;
 	wallet_config.api_secret_path = None;


### PR DESCRIPTION
Reworks initial directory setup logic and the flow of the `init` command to:

* That the `--top-level-dir` switch is respected appropriately
* That the api secret files aren't written to default locations when using the `--top-level-dir` switch or initting a wallet in the current directory (these were erroneously being created in the `~./grin/main` dirs)
* Check for the presence of an existing configuration file *before* asking user for a password/recovery phrase, and exit if so.

Fixes #308 and #279