### PR TITLE
Ensure API `create_wallet` returns failure when provided with invalid mnemonic seeds

### DIFF
--- a/api/src/owner_rpc_s.rs
+++ b/api/src/owner_rpc_s.rs
@@ -1517,7 +1517,7 @@ pub trait OwnerRpcS {
 		"params": {
 			"name": null,
 			"mnemonic": null,
-			"mnemonic_length": 0,
+			"mnemonic_length": 32,
 			"password": "my_secret_password"
 		},
 		"id": 1

--- a/impls/src/lifecycle/default.rs
+++ b/impls/src/lifecycle/default.rs
@@ -183,10 +183,16 @@ where
 				return Err(ErrorKind::WalletSeedExists(msg))?;
 			}
 		}
-		WalletSeed::init_file(&data_dir_name, mnemonic_length, mnemonic.clone(), password)
-			.context(ErrorKind::Lifecycle(
-				"Error creating wallet seed (is mnemonic valid?)".into(),
-			))?;
+		WalletSeed::init_file(
+			&data_dir_name,
+			mnemonic_length,
+			mnemonic.clone(),
+			password,
+			test_mode,
+		)
+		.context(ErrorKind::Lifecycle(
+			"Error creating wallet seed (is mnemonic valid?)".into(),
+		))?;
 		info!("Wallet seed file created");
 		let mut wallet: LMDBBackend<'a, C, K> =
 			match LMDBBackend::new(&data_dir_name, self.node_client.clone()) {
@@ -330,6 +336,7 @@ where
 			0,
 			Some(ZeroingString::from(orig_mnemonic)),
 			new.clone(),
+			false,
 		);
 		info!("Wallet seed file created");
 

--- a/impls/src/lifecycle/default.rs
+++ b/impls/src/lifecycle/default.rs
@@ -183,7 +183,10 @@ where
 				return Err(ErrorKind::WalletSeedExists(msg))?;
 			}
 		}
-		let _ = WalletSeed::init_file(&data_dir_name, mnemonic_length, mnemonic.clone(), password);
+		WalletSeed::init_file(&data_dir_name, mnemonic_length, mnemonic.clone(), password)
+			.context(ErrorKind::Lifecycle(
+				"Error creating wallet seed (is mnemonic valid?)".into(),
+			))?;
 		info!("Wallet seed file created");
 		let mut wallet: LMDBBackend<'a, C, K> =
 			match LMDBBackend::new(&data_dir_name, self.node_client.clone()) {

--- a/impls/src/lifecycle/seed.rs
+++ b/impls/src/lifecycle/seed.rs
@@ -150,6 +150,7 @@ impl WalletSeed {
 		seed_length: usize,
 		recovery_phrase: Option<util::ZeroingString>,
 		password: util::ZeroingString,
+		test_mode: bool,
 	) -> Result<WalletSeed, Error> {
 		// create directory if it doesn't exist
 		fs::create_dir_all(data_file_dir).context(ErrorKind::IO)?;
@@ -158,8 +159,9 @@ impl WalletSeed {
 
 		warn!("Generating wallet seed file at: {}", seed_file_path);
 		let exists = WalletSeed::seed_file_exists(data_file_dir)?;
-		if exists {
+		if exists && !test_mode {
 			let msg = format!("Wallet seed already exists at: {}", data_file_dir);
+			error!("{}", msg);
 			return Err(ErrorKind::WalletSeedExists(msg))?;
 		}
 

--- a/tests/data/v3_reqs/create_wallet_invalid_mn.req.json
+++ b/tests/data/v3_reqs/create_wallet_invalid_mn.req.json
@@ -1,0 +1,11 @@
+{
+	"jsonrpc": "2.0",
+	"method": "create_wallet",
+	"params": {
+		"name": null,
+		"mnemonic": "this is not valid",
+		"mnemonic_length": 32,
+		"password": "passwoid"
+	},
+	"id": 1
+}

--- a/tests/data/v3_reqs/create_wallet_valid_mn.req.json
+++ b/tests/data/v3_reqs/create_wallet_valid_mn.req.json
@@ -1,0 +1,11 @@
+{
+	"jsonrpc": "2.0",
+	"method": "create_wallet",
+	"params": {
+		"name": null,
+		"mnemonic": "fat twenty mean degree forget shell check candy immense awful flame next during february bulb bike sun wink theory day kiwi embrace peace lunch",
+		"mnemonic_length": 32,
+		"password": "passwoid"
+	},
+	"id": 1
+}

--- a/tests/owner_v3_lifecycle.rs
+++ b/tests/owner_v3_lifecycle.rs
@@ -517,6 +517,20 @@ fn owner_v3_lifecycle() -> Result<(), grin_wallet_controller::Error> {
 	println!("RES 25: {:?}", res);
 	assert!(res.is_err());
 
+	// 26) Try to create a wallet with an invalid mnemonic
+	let req = include_str!("data/v3_reqs/create_wallet_invalid_mn.req.json");
+	let res =
+		send_request_enc::<String>(1, 1, "http://127.0.0.1:43420/v3/owner", &req, &shared_key)?;
+	println!("RES 26: {:?}", res);
+	assert!(res.is_err());
+
+	// 27) Try to create a wallet with an valid mnemonic
+	let req = include_str!("data/v3_reqs/create_wallet_valid_mn.req.json");
+	let res =
+		send_request_enc::<String>(1, 1, "http://127.0.0.1:43420/v3/owner", &req, &shared_key)?;
+	println!("RES 27: {:?}", res);
+	assert!(res.is_ok());
+
 	clean_output_dir(test_dir);
 
 	Ok(())


### PR DESCRIPTION
Fixes #292, call to `WalletSeed::init_file` was swallowing its error and continuing.

Adds explicit tests to exercise `create_wallet` with both valid and invalid seeds.