### PR TITLE
Shutdown runtime after task is completed

### DIFF
--- a/impls/src/client_utils/client.rs
+++ b/impls/src/client_utils/client.rs
@@ -31,7 +31,7 @@ use serde_json;
 use std::fmt::{self, Display};
 use std::net::SocketAddr;
 use std::time::Duration;
-use tokio::runtime::current_thread::Runtime;
+use tokio::runtime::Builder;
 
 /// Errors that can be returned by an ApiEndpoint implementation.
 #[derive(Debug)]
@@ -389,8 +389,12 @@ impl Client {
 
 	pub fn send_request(&self, req: Request<Body>) -> Result<String, Error> {
 		let task = self.send_request_async(req);
-		let mut rt =
-			Runtime::new().context(ErrorKind::Internal("can't create Tokio runtime".to_owned()))?;
-		Ok(rt.block_on(task)?)
+		let mut rt = Builder::new()
+			.core_threads(1)
+			.build()
+			.context(ErrorKind::Internal("can't create Tokio runtime".to_owned()))?;
+		let res = rt.block_on(task);
+		let _ = rt.shutdown_now().wait();
+		res
 	}
 }

--- a/impls/src/client_utils/client.rs
+++ b/impls/src/client_utils/client.rs
@@ -31,7 +31,7 @@ use serde_json;
 use std::fmt::{self, Display};
 use std::net::SocketAddr;
 use std::time::Duration;
-use tokio::runtime::Runtime;
+use tokio::runtime::current_thread::Runtime;
 
 /// Errors that can be returned by an ApiEndpoint implementation.
 #[derive(Debug)]

--- a/impls/src/node_clients/http.rs
+++ b/impls/src/node_clients/http.rs
@@ -20,10 +20,11 @@ use futures::{stream, Stream};
 use crate::api::{self, LocatedTxKernel};
 use crate::core::core::TxKernel;
 use crate::libwallet::{NodeClient, NodeVersionInfo, TxWrapper};
+use futures::Future;
 use semver::Version;
 use std::collections::HashMap;
 use std::env;
-use tokio::runtime::current_thread::Runtime;
+use tokio::runtime::Builder;
 
 use crate::client_utils::Client;
 use crate::libwallet;
@@ -227,8 +228,10 @@ impl NodeClient for HTTPNodeClient {
 
 		let task = stream::futures_unordered(tasks).collect();
 
-		let mut rt = Runtime::new().unwrap();
-		let results = match rt.block_on(task) {
+		let mut rt = Builder::new().core_threads(1).build().unwrap();
+		let res = rt.block_on(task);
+		let _ = rt.shutdown_now().wait();
+		let results = match res {
 			Ok(outputs) => outputs,
 			Err(e) => {
 				let report = format!("Getting outputs by id: {}", e);

--- a/impls/src/node_clients/http.rs
+++ b/impls/src/node_clients/http.rs
@@ -23,7 +23,7 @@ use crate::libwallet::{NodeClient, NodeVersionInfo, TxWrapper};
 use semver::Version;
 use std::collections::HashMap;
 use std::env;
-use tokio::runtime::Runtime;
+use tokio::runtime::current_thread::Runtime;
 
 use crate::client_utils::Client;
 use crate::libwallet;


### PR DESCRIPTION
Each request was spawning its own multithreaded runtime that kept running even after the request was done, taking up resources unnecessarily. This PR addresses that, by using a runtime that runs in the current thread.
Ideally we would have a single multithreaded runtime to spawn all requests on, but that is a larger refactor that I'm planning on doing later on.

Small side note is that the current-thread runtime is only active until the future completes and any unfinished tasks that were spawned by this future aren't polled anymore. Since we are not spawning any tasks that outlive our future this shouldn't have any effect but it is something to keep in the back of our minds.

Fixes https://github.com/mimblewimble/grin-wallet/issues/330