### PR TITLE
Change EncryptedRequest 'id' field to String

### DIFF
--- a/api/src/lib.rs
+++ b/api/src/lib.rs
@@ -57,5 +57,6 @@ pub use crate::foreign_rpc::run_doctest_foreign;
 pub use crate::owner_rpc::run_doctest_owner;
 
 pub use types::{
-	ECDHPubkey, EncryptedRequest, EncryptedResponse, EncryptionErrorResponse, PubAddress, Token,
+	ECDHPubkey, EncryptedRequest, EncryptedResponse, EncryptionErrorResponse, JsonId, PubAddress,
+	Token,
 };

--- a/api/src/types.rs
+++ b/api/src/types.rs
@@ -13,7 +13,6 @@
 
 use crate::core::libtx::secp_ser;
 use crate::libwallet::dalek_ser;
-use crate::libwallet::slate_versions::ser::u64_or_string;
 use crate::libwallet::{Error, ErrorKind};
 use crate::util::secp::key::{PublicKey, SecretKey};
 use crate::util::{from_hex, to_hex};
@@ -25,6 +24,17 @@ use rand::{thread_rng, Rng};
 use ring::aead;
 use serde_json::{self, Value};
 use std::collections::HashMap;
+
+/// Represents a compliant JSON RPC 2.0 id.
+/// Valid id: Integer, String.
+#[derive(Serialize, Deserialize, Clone, Debug, PartialEq)]
+#[serde(untagged)]
+pub enum JsonId {
+	/// Integer Id
+	IntId(u32),
+	/// String Id
+	StrId(String),
+}
 
 /// Wrapper for API Tokens
 #[derive(Serialize, Deserialize, Debug, Clone)]
@@ -143,19 +153,18 @@ pub struct EncryptedRequest {
 	/// method
 	pub method: String,
 	/// id
-	#[serde(with = "u64_or_string")]
-	pub id: String,
+	pub id: JsonId,
 	/// Body params, which includes nonce and encrypted request
 	pub params: EncryptedBody,
 }
 
 impl EncryptedRequest {
 	/// from json
-	pub fn from_json(id: &str, json_in: &Value, enc_key: &SecretKey) -> Result<Self, Error> {
+	pub fn from_json(id: &JsonId, json_in: &Value, enc_key: &SecretKey) -> Result<Self, Error> {
 		Ok(EncryptedRequest {
 			jsonrpc: "2.0".to_owned(),
 			method: "encrypted_request_v3".to_owned(),
-			id: id.into(),
+			id: id.clone(),
 			params: EncryptedBody::from_json(json_in, enc_key)?,
 		})
 	}
@@ -189,15 +198,14 @@ pub struct EncryptedResponse {
 	/// JSON RPC response
 	pub jsonrpc: String,
 	/// id
-	#[serde(with = "u64_or_string")]
-	pub id: String,
+	pub id: JsonId,
 	/// result
 	pub result: HashMap<String, EncryptedBody>,
 }
 
 impl EncryptedResponse {
 	/// from json
-	pub fn from_json(id: &str, json_in: &Value, enc_key: &SecretKey) -> Result<Self, Error> {
+	pub fn from_json(id: &JsonId, json_in: &Value, enc_key: &SecretKey) -> Result<Self, Error> {
 		let mut result_set = HashMap::new();
 		result_set.insert(
 			"Ok".to_string(),
@@ -205,7 +213,7 @@ impl EncryptedResponse {
 		);
 		Ok(EncryptedResponse {
 			jsonrpc: "2.0".to_owned(),
-			id: id.into(),
+			id: id.clone(),
 			result: result_set,
 		})
 	}
@@ -308,12 +316,13 @@ fn encrypted_request() -> Result<(), Error> {
 			"token": "d202964900000000d302964900000000d402964900000000d502964900000000"
 		}
 	});
-	let enc_req = EncryptedRequest::from_json("1", &req, &shared_key)?;
+	let enc_req =
+		EncryptedRequest::from_json(&JsonId::StrId(String::from("1")), &req, &shared_key)?;
 	println!("{:?}", enc_req);
 	let dec_req = enc_req.decrypt(&shared_key)?;
 	println!("{:?}", dec_req);
 	assert_eq!(req, dec_req);
-	let enc_res = EncryptedResponse::from_json("1", &req, &shared_key)?;
+	let enc_res = EncryptedResponse::from_json(&JsonId::IntId(1), &req, &shared_key)?;
 	println!("{:?}", enc_res);
 	println!("{:?}", enc_res.as_json_str()?);
 	let dec_res = enc_res.decrypt(&shared_key)?;

--- a/controller/src/controller.rs
+++ b/controller/src/controller.rs
@@ -26,6 +26,7 @@ use crate::util::{from_hex, static_secp_instance, to_base64, Mutex};
 use failure::ResultExt;
 use futures::future::{err, ok};
 use futures::{Future, Stream};
+use grin_wallet_api::JsonId;
 use grin_wallet_util::OnionV3Address;
 use hyper::header::HeaderValue;
 use hyper::{Body, Request, Response, StatusCode};
@@ -497,7 +498,7 @@ impl OwnerV3Helpers {
 	pub fn decrypt_request(
 		key: Arc<Mutex<Option<SecretKey>>>,
 		req: &serde_json::Value,
-	) -> Result<(String, serde_json::Value), serde_json::Value> {
+	) -> Result<(JsonId, serde_json::Value), serde_json::Value> {
 		let share_key_ref = key.lock();
 		let shared_key = share_key_ref.as_ref().unwrap();
 		let enc_req: EncryptedRequest = serde_json::from_value(req.clone()).map_err(|e| {
@@ -519,7 +520,7 @@ impl OwnerV3Helpers {
 	/// Encrypt a response
 	pub fn encrypt_response(
 		key: Arc<Mutex<Option<SecretKey>>>,
-		id: &str,
+		id: &JsonId,
 		res: &serde_json::Value,
 	) -> Result<serde_json::Value, serde_json::Value> {
 		let share_key_ref = key.lock();
@@ -646,7 +647,7 @@ where
 			let owner_api_s = &*api as &dyn OwnerRpcS;
 			let mut is_init_secure_api = OwnerV3Helpers::is_init_secure_api(&val);
 			let mut was_encrypted = false;
-			let mut encrypted_req_id = String::from("");
+			let mut encrypted_req_id = JsonId::StrId(String::from(""));
 			if !is_init_secure_api {
 				if let Err(v) = OwnerV3Helpers::check_encryption_started(key.clone()) {
 					return ok(v);

--- a/libwallet/src/slate_versions/ser.rs
+++ b/libwallet/src/slate_versions/ser.rs
@@ -13,47 +13,6 @@
 // limitations under the License.
 //! Sane serialization & deserialization of cryptographic structs into hex
 
-/// Used to ensure provided u64s in Encrypted API requests are turned
-/// into Strings, for legacy reasons
-pub mod u64_or_string {
-	use std::fmt;
-
-	use serde::{de, Deserializer, Serializer};
-
-	/// serialize into a string
-	pub fn serialize<T, S>(value: &T, serializer: S) -> Result<S::Ok, S::Error>
-	where
-		T: fmt::Display,
-		S: Serializer,
-	{
-		serializer.collect_str(value)
-	}
-
-	/// deserialize from either literal or string
-	pub fn deserialize<'de, D>(deserializer: D) -> Result<String, D::Error>
-	where
-		D: Deserializer<'de>,
-	{
-		struct Visitor;
-		impl<'a> de::Visitor<'a> for Visitor {
-			type Value = String;
-			fn expecting(&self, formatter: &mut fmt::Formatter) -> fmt::Result {
-				write!(formatter, "a string or an int fitting into u64")
-			}
-			fn visit_u64<E>(self, v: u64) -> Result<Self::Value, E> {
-				Ok(format!("{}", v))
-			}
-			fn visit_str<E>(self, s: &str) -> Result<Self::Value, E>
-			where
-				E: de::Error,
-			{
-				s.parse().map_err(de::Error::custom)
-			}
-		}
-		deserializer.deserialize_any(Visitor)
-	}
-}
-
 /// Serializes an OnionV3Address to and from hex
 pub mod option_ov3_serde {
 	use serde::de::Error;

--- a/libwallet/src/slate_versions/ser.rs
+++ b/libwallet/src/slate_versions/ser.rs
@@ -11,8 +11,49 @@
 // WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 // See the License for the specific language governing permissions and
 // limitations under the License.
-
 //! Sane serialization & deserialization of cryptographic structs into hex
+
+/// Used to ensure provided u64s in Encrypted API requests are turned
+/// into Strings, for legacy reasons
+pub mod u64_or_string {
+	use std::fmt;
+
+	use serde::{de, Deserializer, Serializer};
+
+	/// serialize into a string
+	pub fn serialize<T, S>(value: &T, serializer: S) -> Result<S::Ok, S::Error>
+	where
+		T: fmt::Display,
+		S: Serializer,
+	{
+		serializer.collect_str(value)
+	}
+
+	/// deserialize from either literal or string
+	pub fn deserialize<'de, D>(deserializer: D) -> Result<String, D::Error>
+	where
+		D: Deserializer<'de>,
+	{
+		struct Visitor;
+		impl<'a> de::Visitor<'a> for Visitor {
+			type Value = String;
+			fn expecting(&self, formatter: &mut fmt::Formatter) -> fmt::Result {
+				write!(formatter, "a string or an int fitting into u64")
+			}
+			fn visit_u64<E>(self, v: u64) -> Result<Self::Value, E> {
+				Ok(format!("{}", v))
+			}
+			fn visit_str<E>(self, s: &str) -> Result<Self::Value, E>
+			where
+				E: de::Error,
+			{
+				s.parse().map_err(de::Error::custom)
+			}
+		}
+		deserializer.deserialize_any(Visitor)
+	}
+}
+
 /// Serializes an OnionV3Address to and from hex
 pub mod option_ov3_serde {
 	use serde::de::Error;

--- a/tests/common/mod.rs
+++ b/tests/common/mod.rs
@@ -24,7 +24,7 @@ use std::sync::Arc;
 use std::{env, fs};
 use util::{Mutex, ZeroingString};
 
-use grin_wallet_api::{EncryptedRequest, EncryptedResponse};
+use grin_wallet_api::{EncryptedRequest, EncryptedResponse, JsonId};
 use grin_wallet_config::{GlobalWalletConfig, WalletConfig, GRIN_WALLET_DIR};
 use grin_wallet_impls::{DefaultLCProvider, DefaultWalletImpl};
 use grin_wallet_libwallet::{NodeClient, WalletInfo, WalletInst};
@@ -371,7 +371,7 @@ where
 
 #[allow(dead_code)]
 pub fn send_request_enc<OUT>(
-	sec_req_id: &str,
+	sec_req_id: &JsonId,
 	internal_request_id: u32,
 	dest: &str,
 	req: &str,

--- a/tests/common/mod.rs
+++ b/tests/common/mod.rs
@@ -371,7 +371,7 @@ where
 
 #[allow(dead_code)]
 pub fn send_request_enc<OUT>(
-	sec_req_id: u64,
+	sec_req_id: &str,
 	internal_request_id: u32,
 	dest: &str,
 	req: &str,

--- a/tests/owner_v3_init_secure.rs
+++ b/tests/owner_v3_init_secure.rs
@@ -74,7 +74,8 @@ fn owner_v3_init_secure() -> Result<(), grin_wallet_controller::Error> {
 
 	// 1) Attempt to send an encrypted request before calling `init_secure_api`
 	let req = include_str!("data/v3_reqs/retrieve_info.req.json");
-	let res = send_request_enc::<String>(1, 1, "http://127.0.0.1:33420/v3/owner", &req, &sec_key)?;
+	let res =
+		send_request_enc::<String>("1", 1, "http://127.0.0.1:33420/v3/owner", &req, &sec_key)?;
 	println!("RES 1: {:?}", res);
 	assert!(res.is_err());
 	assert_eq!(res.unwrap_err().code, -32001);
@@ -97,7 +98,7 @@ fn owner_v3_init_secure() -> Result<(), grin_wallet_controller::Error> {
 	// 4) A normal request, correct key
 	let req = include_str!("data/v3_reqs/retrieve_info.req.json");
 	let res = send_request_enc::<RetrieveSummaryInfoResp>(
-		1,
+		"1",
 		1,
 		"http://127.0.0.1:33420/v3/owner",
 		&req,
@@ -111,7 +112,7 @@ fn owner_v3_init_secure() -> Result<(), grin_wallet_controller::Error> {
 	bad_key.0[0] = 0;
 	let req = include_str!("data/v3_reqs/retrieve_info.req.json");
 	let res = send_request_enc::<RetrieveSummaryInfoResp>(
-		1,
+		"1",
 		1,
 		"http://127.0.0.1:33420/v3/owner",
 		&req,
@@ -153,7 +154,7 @@ fn owner_v3_init_secure() -> Result<(), grin_wallet_controller::Error> {
 	// 8) Encrypted call to `init_secure_api`, followed by re-deriving key
 	let req = include_str!("data/v3_reqs/init_secure_api.req.json");
 	let res = send_request_enc(
-		1,
+		"1",
 		1,
 		"http://127.0.0.1:33420/v3/owner",
 		&req.to_string(),
@@ -167,7 +168,7 @@ fn owner_v3_init_secure() -> Result<(), grin_wallet_controller::Error> {
 	// 9) A normal request, with new correct key
 	let req = include_str!("data/v3_reqs/retrieve_info.req.json");
 	let res = send_request_enc::<RetrieveSummaryInfoResp>(
-		9,
+		"1",
 		1,
 		"http://127.0.0.1:33420/v3/owner",
 		&req,
@@ -188,7 +189,7 @@ fn owner_v3_init_secure() -> Result<(), grin_wallet_controller::Error> {
 	// 11) A normal request, correct key
 	let req = include_str!("data/v3_reqs/retrieve_info.req.json");
 	let res = send_request_enc::<RetrieveSummaryInfoResp>(
-		11,
+		"1",
 		1,
 		"http://127.0.0.1:33420/v3/owner",
 		&req,
@@ -207,16 +208,26 @@ fn owner_v3_init_secure() -> Result<(), grin_wallet_controller::Error> {
 		}
 	})
 	.to_string();
-	let res =
-		send_request_enc::<String>(12, 1, "http://127.0.0.1:33420/v3/owner", &req, &shared_key)?;
+	let res = send_request_enc::<String>(
+		"12",
+		1,
+		"http://127.0.0.1:33420/v3/owner",
+		&req,
+		&shared_key,
+	)?;
 	println!("RES 12: {:?}", res);
 	assert!(res.is_err());
 	assert_eq!(res.unwrap_err().code, -32601);
 
 	// 13) A request which triggers an internal API error (not enough funds)
 	let req = include_str!("data/v3_reqs/init_send_tx.req.json");
-	let res =
-		send_request_enc::<String>(13, 1, "http://127.0.0.1:33420/v3/owner", &req, &shared_key)?;
+	let res = send_request_enc::<String>(
+		"13",
+		1,
+		"http://127.0.0.1:33420/v3/owner",
+		&req,
+		&shared_key,
+	)?;
 	println!("RES 13: {:?}", res);
 	assert!(res.is_err());
 	assert_eq!(res.unwrap_err().code, -32099);

--- a/tests/owner_v3_init_secure.rs
+++ b/tests/owner_v3_init_secure.rs
@@ -19,7 +19,7 @@ extern crate log;
 
 extern crate grin_wallet;
 
-use grin_wallet_api::ECDHPubkey;
+use grin_wallet_api::{ECDHPubkey, JsonId};
 use grin_wallet_impls::test_framework::{self, LocalWalletClient, WalletProxy};
 
 use clap::App;
@@ -74,8 +74,13 @@ fn owner_v3_init_secure() -> Result<(), grin_wallet_controller::Error> {
 
 	// 1) Attempt to send an encrypted request before calling `init_secure_api`
 	let req = include_str!("data/v3_reqs/retrieve_info.req.json");
-	let res =
-		send_request_enc::<String>("1", 1, "http://127.0.0.1:33420/v3/owner", &req, &sec_key)?;
+	let res = send_request_enc::<String>(
+		&JsonId::IntId(1),
+		1,
+		"http://127.0.0.1:33420/v3/owner",
+		&req,
+		&sec_key,
+	)?;
 	println!("RES 1: {:?}", res);
 	assert!(res.is_err());
 	assert_eq!(res.unwrap_err().code, -32001);
@@ -98,7 +103,7 @@ fn owner_v3_init_secure() -> Result<(), grin_wallet_controller::Error> {
 	// 4) A normal request, correct key
 	let req = include_str!("data/v3_reqs/retrieve_info.req.json");
 	let res = send_request_enc::<RetrieveSummaryInfoResp>(
-		"1",
+		&JsonId::StrId(String::from("1")),
 		1,
 		"http://127.0.0.1:33420/v3/owner",
 		&req,
@@ -112,7 +117,7 @@ fn owner_v3_init_secure() -> Result<(), grin_wallet_controller::Error> {
 	bad_key.0[0] = 0;
 	let req = include_str!("data/v3_reqs/retrieve_info.req.json");
 	let res = send_request_enc::<RetrieveSummaryInfoResp>(
-		"1",
+		&JsonId::StrId(String::from("1")),
 		1,
 		"http://127.0.0.1:33420/v3/owner",
 		&req,
@@ -154,7 +159,7 @@ fn owner_v3_init_secure() -> Result<(), grin_wallet_controller::Error> {
 	// 8) Encrypted call to `init_secure_api`, followed by re-deriving key
 	let req = include_str!("data/v3_reqs/init_secure_api.req.json");
 	let res = send_request_enc(
-		"1",
+		&JsonId::StrId(String::from("1")),
 		1,
 		"http://127.0.0.1:33420/v3/owner",
 		&req.to_string(),
@@ -168,7 +173,7 @@ fn owner_v3_init_secure() -> Result<(), grin_wallet_controller::Error> {
 	// 9) A normal request, with new correct key
 	let req = include_str!("data/v3_reqs/retrieve_info.req.json");
 	let res = send_request_enc::<RetrieveSummaryInfoResp>(
-		"1",
+		&JsonId::StrId(String::from("1")),
 		1,
 		"http://127.0.0.1:33420/v3/owner",
 		&req,
@@ -189,7 +194,7 @@ fn owner_v3_init_secure() -> Result<(), grin_wallet_controller::Error> {
 	// 11) A normal request, correct key
 	let req = include_str!("data/v3_reqs/retrieve_info.req.json");
 	let res = send_request_enc::<RetrieveSummaryInfoResp>(
-		"1",
+		&JsonId::StrId(String::from("1")),
 		1,
 		"http://127.0.0.1:33420/v3/owner",
 		&req,
@@ -209,7 +214,7 @@ fn owner_v3_init_secure() -> Result<(), grin_wallet_controller::Error> {
 	})
 	.to_string();
 	let res = send_request_enc::<String>(
-		"12",
+		&JsonId::IntId(12),
 		1,
 		"http://127.0.0.1:33420/v3/owner",
 		&req,
@@ -222,7 +227,7 @@ fn owner_v3_init_secure() -> Result<(), grin_wallet_controller::Error> {
 	// 13) A request which triggers an internal API error (not enough funds)
 	let req = include_str!("data/v3_reqs/init_send_tx.req.json");
 	let res = send_request_enc::<String>(
-		"13",
+		&JsonId::StrId(String::from("13")),
 		1,
 		"http://127.0.0.1:33420/v3/owner",
 		&req,

--- a/tests/owner_v3_lifecycle.rs
+++ b/tests/owner_v3_lifecycle.rs
@@ -148,7 +148,7 @@ fn owner_v3_lifecycle() -> Result<(), grin_wallet_controller::Error> {
 	// 2) get the top level directory, should default to ~/.grin/auto
 	let req = include_str!("data/v3_reqs/get_top_level.req.json");
 	let res =
-		send_request_enc::<String>(1, 1, "http://127.0.0.1:43420/v3/owner", &req, &shared_key)?;
+		send_request_enc::<String>("1", 1, "http://127.0.0.1:43420/v3/owner", &req, &shared_key)?;
 	println!("RES 2: {:?}", res);
 	assert!(res.is_ok());
 	assert!(res.unwrap().contains("auto"));
@@ -163,7 +163,7 @@ fn owner_v3_lifecycle() -> Result<(), grin_wallet_controller::Error> {
 		}
 	});
 	let res = send_request_enc::<String>(
-		1,
+		"1",
 		1,
 		"http://127.0.0.1:43420/v3/owner",
 		&req.to_string(),
@@ -175,7 +175,7 @@ fn owner_v3_lifecycle() -> Result<(), grin_wallet_controller::Error> {
 	// 4) create a configuration file in top level directory
 	let req = include_str!("data/v3_reqs/create_config.req.json");
 	let res =
-		send_request_enc::<String>(1, 1, "http://127.0.0.1:43420/v3/owner", &req, &shared_key)?;
+		send_request_enc::<String>("1", 1, "http://127.0.0.1:43420/v3/owner", &req, &shared_key)?;
 	println!("RES 4: {:?}", res);
 	assert!(res.is_ok());
 	let pb = PathBuf::from(format!("{}/wallet1/grin-wallet.toml", test_dir));
@@ -184,28 +184,28 @@ fn owner_v3_lifecycle() -> Result<(), grin_wallet_controller::Error> {
 	// 5) Try and perform an operation without having a wallet open
 	let req = include_str!("data/v3_reqs/retrieve_info.req.json");
 	let res =
-		send_request_enc::<String>(1, 1, "http://127.0.0.1:43420/v3/owner", &req, &shared_key)?;
+		send_request_enc::<String>("1", 1, "http://127.0.0.1:43420/v3/owner", &req, &shared_key)?;
 	println!("RES 5: {:?}", res);
 	assert!(res.is_err());
 
 	// 6) Create a wallet
 	let req = include_str!("data/v3_reqs/create_wallet.req.json");
 	let res =
-		send_request_enc::<String>(1, 1, "http://127.0.0.1:43420/v3/owner", &req, &shared_key)?;
+		send_request_enc::<String>("1", 1, "http://127.0.0.1:43420/v3/owner", &req, &shared_key)?;
 	println!("RES 6: {:?}", res);
 	assert!(res.is_ok());
 
 	// 7) Try and create a wallet when one exists
 	let req = include_str!("data/v3_reqs/create_wallet.req.json");
 	let res =
-		send_request_enc::<String>(1, 1, "http://127.0.0.1:43420/v3/owner", &req, &shared_key)?;
+		send_request_enc::<String>("1", 1, "http://127.0.0.1:43420/v3/owner", &req, &shared_key)?;
 	println!("RES 7: {:?}", res);
 	assert!(res.is_err());
 
 	// 8) Open the wallet
 	let req = include_str!("data/v3_reqs/open_wallet.req.json");
 	let res =
-		send_request_enc::<String>(1, 1, "http://127.0.0.1:43420/v3/owner", &req, &shared_key)?;
+		send_request_enc::<String>("1", 1, "http://127.0.0.1:43420/v3/owner", &req, &shared_key)?;
 	println!("RES 8: {:?}", res);
 	assert!(res.is_ok());
 	let token = res.unwrap();
@@ -223,7 +223,7 @@ fn owner_v3_lifecycle() -> Result<(), grin_wallet_controller::Error> {
 	});
 
 	let res = send_request_enc::<RetrieveSummaryInfoResp>(
-		1,
+		"1",
 		1,
 		"http://127.0.0.1:43420/v3/owner",
 		&req.to_string(),
@@ -245,7 +245,7 @@ fn owner_v3_lifecycle() -> Result<(), grin_wallet_controller::Error> {
 	});
 
 	let res = send_request_enc::<RetrieveSummaryInfoResp>(
-		1,
+		"1",
 		1,
 		"http://127.0.0.1:43420/v3/owner",
 		&req.to_string(),
@@ -257,7 +257,7 @@ fn owner_v3_lifecycle() -> Result<(), grin_wallet_controller::Error> {
 	// 11) Close the wallet
 	let req = include_str!("data/v3_reqs/close_wallet.req.json");
 	let res =
-		send_request_enc::<String>(1, 1, "http://127.0.0.1:43420/v3/owner", &req, &shared_key)?;
+		send_request_enc::<String>("1", 1, "http://127.0.0.1:43420/v3/owner", &req, &shared_key)?;
 	println!("RES 11: {:?}", res);
 	assert!(res.is_ok());
 
@@ -274,7 +274,7 @@ fn owner_v3_lifecycle() -> Result<(), grin_wallet_controller::Error> {
 	});
 
 	let res = send_request_enc::<RetrieveSummaryInfoResp>(
-		1,
+		"1",
 		1,
 		"http://127.0.0.1:43420/v3/owner",
 		&req.to_string(),
@@ -286,7 +286,7 @@ fn owner_v3_lifecycle() -> Result<(), grin_wallet_controller::Error> {
 	// 13) Open the wallet again
 	let req = include_str!("data/v3_reqs/open_wallet.req.json");
 	let res =
-		send_request_enc::<String>(1, 1, "http://127.0.0.1:43420/v3/owner", &req, &shared_key)?;
+		send_request_enc::<String>("1", 1, "http://127.0.0.1:43420/v3/owner", &req, &shared_key)?;
 	println!("RES 13: {:?}", res);
 	assert!(res.is_ok());
 	let token = res.unwrap();
@@ -303,7 +303,7 @@ fn owner_v3_lifecycle() -> Result<(), grin_wallet_controller::Error> {
 		}
 	});
 	let res = send_request_enc::<RetrieveSummaryInfoResp>(
-		1,
+		"1",
 		1,
 		"http://127.0.0.1:43420/v3/owner",
 		&req.to_string(),
@@ -328,7 +328,7 @@ fn owner_v3_lifecycle() -> Result<(), grin_wallet_controller::Error> {
 		}
 	});
 	let res = send_request_enc::<VersionedSlate>(
-		1,
+		"1",
 		1,
 		"http://127.0.0.1:43420/v3/owner",
 		&req.to_string(),
@@ -380,20 +380,20 @@ fn owner_v3_lifecycle() -> Result<(), grin_wallet_controller::Error> {
 	//17) Change the password
 	let req = include_str!("data/v3_reqs/close_wallet.req.json");
 	let res =
-		send_request_enc::<String>(1, 1, "http://127.0.0.1:43420/v3/owner", &req, &shared_key)?;
+		send_request_enc::<String>("1", 1, "http://127.0.0.1:43420/v3/owner", &req, &shared_key)?;
 	println!("RES 17: {:?}", res);
 	assert!(res.is_ok());
 
 	let req = include_str!("data/v3_reqs/change_password.req.json");
 	let res =
-		send_request_enc::<String>(1, 1, "http://127.0.0.1:43420/v3/owner", &req, &shared_key)?;
+		send_request_enc::<String>("1", 1, "http://127.0.0.1:43420/v3/owner", &req, &shared_key)?;
 	println!("RES 17a: {:?}", res);
 	assert!(res.is_ok());
 
 	// 18) trying to open with old password should fail
 	let req = include_str!("data/v3_reqs/open_wallet.req.json");
 	let res =
-		send_request_enc::<String>(1, 1, "http://127.0.0.1:43420/v3/owner", &req, &shared_key)?;
+		send_request_enc::<String>("1", 1, "http://127.0.0.1:43420/v3/owner", &req, &shared_key)?;
 	println!("RES 18: {:?}", res);
 	assert!(res.is_err());
 
@@ -408,7 +408,7 @@ fn owner_v3_lifecycle() -> Result<(), grin_wallet_controller::Error> {
 		}
 	});
 	let res = send_request_enc::<String>(
-		1,
+		"1",
 		1,
 		"http://127.0.0.1:43420/v3/owner",
 		&req.to_string(),
@@ -432,7 +432,7 @@ fn owner_v3_lifecycle() -> Result<(), grin_wallet_controller::Error> {
 	});
 
 	let res = send_request_enc::<RetrieveSummaryInfoResp>(
-		1,
+		"1",
 		1,
 		"http://127.0.0.1:43420/v3/owner",
 		&req.to_string(),
@@ -455,7 +455,7 @@ fn owner_v3_lifecycle() -> Result<(), grin_wallet_controller::Error> {
 	});
 
 	let res = send_request_enc::<String>(
-		1,
+		"1",
 		1,
 		"http://127.0.0.1:43420/v3/owner",
 		&req.to_string(),
@@ -476,7 +476,7 @@ fn owner_v3_lifecycle() -> Result<(), grin_wallet_controller::Error> {
 	});
 
 	let res = send_request_enc::<String>(
-		1,
+		"1",
 		1,
 		"http://127.0.0.1:43420/v3/owner",
 		&req.to_string(),
@@ -494,7 +494,7 @@ fn owner_v3_lifecycle() -> Result<(), grin_wallet_controller::Error> {
 	});
 
 	let res = send_request_enc::<String>(
-		1,
+		"1",
 		1,
 		"http://127.0.0.1:43420/v3/owner",
 		&req.to_string(),
@@ -506,33 +506,33 @@ fn owner_v3_lifecycle() -> Result<(), grin_wallet_controller::Error> {
 	// 24) Delete the wallet (close first)
 	let req = include_str!("data/v3_reqs/close_wallet.req.json");
 	let res =
-		send_request_enc::<String>(1, 1, "http://127.0.0.1:43420/v3/owner", &req, &shared_key)?;
+		send_request_enc::<String>("1", 1, "http://127.0.0.1:43420/v3/owner", &req, &shared_key)?;
 	assert!(res.is_ok());
 
 	let req = include_str!("data/v3_reqs/delete_wallet.req.json");
 	let res =
-		send_request_enc::<String>(1, 1, "http://127.0.0.1:43420/v3/owner", &req, &shared_key)?;
+		send_request_enc::<String>("1", 1, "http://127.0.0.1:43420/v3/owner", &req, &shared_key)?;
 	println!("RES 24: {:?}", res);
 	assert!(res.is_ok());
 
 	// 25) Wallet should be gone
 	let req = include_str!("data/v3_reqs/open_wallet.req.json");
 	let res =
-		send_request_enc::<String>(1, 1, "http://127.0.0.1:43420/v3/owner", &req, &shared_key)?;
+		send_request_enc::<String>("1", 1, "http://127.0.0.1:43420/v3/owner", &req, &shared_key)?;
 	println!("RES 25: {:?}", res);
 	assert!(res.is_err());
 
 	// 26) Try to create a wallet with an invalid mnemonic
 	let req = include_str!("data/v3_reqs/create_wallet_invalid_mn.req.json");
 	let res =
-		send_request_enc::<String>(1, 1, "http://127.0.0.1:43420/v3/owner", &req, &shared_key)?;
+		send_request_enc::<String>("1", 1, "http://127.0.0.1:43420/v3/owner", &req, &shared_key)?;
 	println!("RES 26: {:?}", res);
 	assert!(res.is_err());
 
 	// 27) Try to create a wallet with an valid mnemonic
 	let req = include_str!("data/v3_reqs/create_wallet_valid_mn.req.json");
 	let res =
-		send_request_enc::<String>(1, 1, "http://127.0.0.1:43420/v3/owner", &req, &shared_key)?;
+		send_request_enc::<String>("1", 1, "http://127.0.0.1:43420/v3/owner", &req, &shared_key)?;
 	println!("RES 27: {:?}", res);
 	assert!(res.is_ok());
 

--- a/tests/owner_v3_lifecycle.rs
+++ b/tests/owner_v3_lifecycle.rs
@@ -19,7 +19,7 @@ extern crate log;
 
 extern crate grin_wallet;
 
-use grin_wallet_api::ECDHPubkey;
+use grin_wallet_api::{ECDHPubkey, JsonId};
 use grin_wallet_impls::test_framework::{self, LocalWalletClient, WalletProxy};
 
 use clap::App;
@@ -147,8 +147,13 @@ fn owner_v3_lifecycle() -> Result<(), grin_wallet_controller::Error> {
 
 	// 2) get the top level directory, should default to ~/.grin/auto
 	let req = include_str!("data/v3_reqs/get_top_level.req.json");
-	let res =
-		send_request_enc::<String>("1", 1, "http://127.0.0.1:43420/v3/owner", &req, &shared_key)?;
+	let res = send_request_enc::<String>(
+		&JsonId::StrId(String::from("1")),
+		1,
+		"http://127.0.0.1:43420/v3/owner",
+		&req,
+		&shared_key,
+	)?;
 	println!("RES 2: {:?}", res);
 	assert!(res.is_ok());
 	assert!(res.unwrap().contains("auto"));
@@ -163,7 +168,7 @@ fn owner_v3_lifecycle() -> Result<(), grin_wallet_controller::Error> {
 		}
 	});
 	let res = send_request_enc::<String>(
-		"1",
+		&JsonId::StrId(String::from("1")),
 		1,
 		"http://127.0.0.1:43420/v3/owner",
 		&req.to_string(),
@@ -174,8 +179,13 @@ fn owner_v3_lifecycle() -> Result<(), grin_wallet_controller::Error> {
 
 	// 4) create a configuration file in top level directory
 	let req = include_str!("data/v3_reqs/create_config.req.json");
-	let res =
-		send_request_enc::<String>("1", 1, "http://127.0.0.1:43420/v3/owner", &req, &shared_key)?;
+	let res = send_request_enc::<String>(
+		&JsonId::StrId(String::from("1")),
+		1,
+		"http://127.0.0.1:43420/v3/owner",
+		&req,
+		&shared_key,
+	)?;
 	println!("RES 4: {:?}", res);
 	assert!(res.is_ok());
 	let pb = PathBuf::from(format!("{}/wallet1/grin-wallet.toml", test_dir));
@@ -183,29 +193,49 @@ fn owner_v3_lifecycle() -> Result<(), grin_wallet_controller::Error> {
 
 	// 5) Try and perform an operation without having a wallet open
 	let req = include_str!("data/v3_reqs/retrieve_info.req.json");
-	let res =
-		send_request_enc::<String>("1", 1, "http://127.0.0.1:43420/v3/owner", &req, &shared_key)?;
+	let res = send_request_enc::<String>(
+		&JsonId::StrId(String::from("1")),
+		1,
+		"http://127.0.0.1:43420/v3/owner",
+		&req,
+		&shared_key,
+	)?;
 	println!("RES 5: {:?}", res);
 	assert!(res.is_err());
 
 	// 6) Create a wallet
 	let req = include_str!("data/v3_reqs/create_wallet.req.json");
-	let res =
-		send_request_enc::<String>("1", 1, "http://127.0.0.1:43420/v3/owner", &req, &shared_key)?;
+	let res = send_request_enc::<String>(
+		&JsonId::StrId(String::from("1")),
+		1,
+		"http://127.0.0.1:43420/v3/owner",
+		&req,
+		&shared_key,
+	)?;
 	println!("RES 6: {:?}", res);
 	assert!(res.is_ok());
 
 	// 7) Try and create a wallet when one exists
 	let req = include_str!("data/v3_reqs/create_wallet.req.json");
-	let res =
-		send_request_enc::<String>("1", 1, "http://127.0.0.1:43420/v3/owner", &req, &shared_key)?;
+	let res = send_request_enc::<String>(
+		&JsonId::StrId(String::from("1")),
+		1,
+		"http://127.0.0.1:43420/v3/owner",
+		&req,
+		&shared_key,
+	)?;
 	println!("RES 7: {:?}", res);
 	assert!(res.is_err());
 
 	// 8) Open the wallet
 	let req = include_str!("data/v3_reqs/open_wallet.req.json");
-	let res =
-		send_request_enc::<String>("1", 1, "http://127.0.0.1:43420/v3/owner", &req, &shared_key)?;
+	let res = send_request_enc::<String>(
+		&JsonId::StrId(String::from("1")),
+		1,
+		"http://127.0.0.1:43420/v3/owner",
+		&req,
+		&shared_key,
+	)?;
 	println!("RES 8: {:?}", res);
 	assert!(res.is_ok());
 	let token = res.unwrap();
@@ -223,7 +253,7 @@ fn owner_v3_lifecycle() -> Result<(), grin_wallet_controller::Error> {
 	});
 
 	let res = send_request_enc::<RetrieveSummaryInfoResp>(
-		"1",
+		&JsonId::StrId(String::from("1")),
 		1,
 		"http://127.0.0.1:43420/v3/owner",
 		&req.to_string(),
@@ -245,7 +275,7 @@ fn owner_v3_lifecycle() -> Result<(), grin_wallet_controller::Error> {
 	});
 
 	let res = send_request_enc::<RetrieveSummaryInfoResp>(
-		"1",
+		&JsonId::StrId(String::from("1")),
 		1,
 		"http://127.0.0.1:43420/v3/owner",
 		&req.to_string(),
@@ -256,8 +286,13 @@ fn owner_v3_lifecycle() -> Result<(), grin_wallet_controller::Error> {
 
 	// 11) Close the wallet
 	let req = include_str!("data/v3_reqs/close_wallet.req.json");
-	let res =
-		send_request_enc::<String>("1", 1, "http://127.0.0.1:43420/v3/owner", &req, &shared_key)?;
+	let res = send_request_enc::<String>(
+		&JsonId::StrId(String::from("1")),
+		1,
+		"http://127.0.0.1:43420/v3/owner",
+		&req,
+		&shared_key,
+	)?;
 	println!("RES 11: {:?}", res);
 	assert!(res.is_ok());
 
@@ -274,7 +309,7 @@ fn owner_v3_lifecycle() -> Result<(), grin_wallet_controller::Error> {
 	});
 
 	let res = send_request_enc::<RetrieveSummaryInfoResp>(
-		"1",
+		&JsonId::StrId(String::from("1")),
 		1,
 		"http://127.0.0.1:43420/v3/owner",
 		&req.to_string(),
@@ -285,8 +320,13 @@ fn owner_v3_lifecycle() -> Result<(), grin_wallet_controller::Error> {
 
 	// 13) Open the wallet again
 	let req = include_str!("data/v3_reqs/open_wallet.req.json");
-	let res =
-		send_request_enc::<String>("1", 1, "http://127.0.0.1:43420/v3/owner", &req, &shared_key)?;
+	let res = send_request_enc::<String>(
+		&JsonId::StrId(String::from("1")),
+		1,
+		"http://127.0.0.1:43420/v3/owner",
+		&req,
+		&shared_key,
+	)?;
 	println!("RES 13: {:?}", res);
 	assert!(res.is_ok());
 	let token = res.unwrap();
@@ -303,7 +343,7 @@ fn owner_v3_lifecycle() -> Result<(), grin_wallet_controller::Error> {
 		}
 	});
 	let res = send_request_enc::<RetrieveSummaryInfoResp>(
-		"1",
+		&JsonId::StrId(String::from("1")),
 		1,
 		"http://127.0.0.1:43420/v3/owner",
 		&req.to_string(),
@@ -328,7 +368,7 @@ fn owner_v3_lifecycle() -> Result<(), grin_wallet_controller::Error> {
 		}
 	});
 	let res = send_request_enc::<VersionedSlate>(
-		"1",
+		&JsonId::StrId(String::from("1")),
 		1,
 		"http://127.0.0.1:43420/v3/owner",
 		&req.to_string(),
@@ -379,21 +419,36 @@ fn owner_v3_lifecycle() -> Result<(), grin_wallet_controller::Error> {
 
 	//17) Change the password
 	let req = include_str!("data/v3_reqs/close_wallet.req.json");
-	let res =
-		send_request_enc::<String>("1", 1, "http://127.0.0.1:43420/v3/owner", &req, &shared_key)?;
+	let res = send_request_enc::<String>(
+		&JsonId::StrId(String::from("1")),
+		1,
+		"http://127.0.0.1:43420/v3/owner",
+		&req,
+		&shared_key,
+	)?;
 	println!("RES 17: {:?}", res);
 	assert!(res.is_ok());
 
 	let req = include_str!("data/v3_reqs/change_password.req.json");
-	let res =
-		send_request_enc::<String>("1", 1, "http://127.0.0.1:43420/v3/owner", &req, &shared_key)?;
+	let res = send_request_enc::<String>(
+		&JsonId::StrId(String::from("1")),
+		1,
+		"http://127.0.0.1:43420/v3/owner",
+		&req,
+		&shared_key,
+	)?;
 	println!("RES 17a: {:?}", res);
 	assert!(res.is_ok());
 
 	// 18) trying to open with old password should fail
 	let req = include_str!("data/v3_reqs/open_wallet.req.json");
-	let res =
-		send_request_enc::<String>("1", 1, "http://127.0.0.1:43420/v3/owner", &req, &shared_key)?;
+	let res = send_request_enc::<String>(
+		&JsonId::StrId(String::from("1")),
+		1,
+		"http://127.0.0.1:43420/v3/owner",
+		&req,
+		&shared_key,
+	)?;
 	println!("RES 18: {:?}", res);
 	assert!(res.is_err());
 
@@ -408,7 +463,7 @@ fn owner_v3_lifecycle() -> Result<(), grin_wallet_controller::Error> {
 		}
 	});
 	let res = send_request_enc::<String>(
-		"1",
+		&JsonId::StrId(String::from("1")),
 		1,
 		"http://127.0.0.1:43420/v3/owner",
 		&req.to_string(),
@@ -432,7 +487,7 @@ fn owner_v3_lifecycle() -> Result<(), grin_wallet_controller::Error> {
 	});
 
 	let res = send_request_enc::<RetrieveSummaryInfoResp>(
-		"1",
+		&JsonId::StrId(String::from("1")),
 		1,
 		"http://127.0.0.1:43420/v3/owner",
 		&req.to_string(),
@@ -455,7 +510,7 @@ fn owner_v3_lifecycle() -> Result<(), grin_wallet_controller::Error> {
 	});
 
 	let res = send_request_enc::<String>(
-		"1",
+		&JsonId::StrId(String::from("1")),
 		1,
 		"http://127.0.0.1:43420/v3/owner",
 		&req.to_string(),
@@ -476,7 +531,7 @@ fn owner_v3_lifecycle() -> Result<(), grin_wallet_controller::Error> {
 	});
 
 	let res = send_request_enc::<String>(
-		"1",
+		&JsonId::StrId(String::from("1")),
 		1,
 		"http://127.0.0.1:43420/v3/owner",
 		&req.to_string(),
@@ -494,7 +549,7 @@ fn owner_v3_lifecycle() -> Result<(), grin_wallet_controller::Error> {
 	});
 
 	let res = send_request_enc::<String>(
-		"1",
+		&JsonId::StrId(String::from("1")),
 		1,
 		"http://127.0.0.1:43420/v3/owner",
 		&req.to_string(),
@@ -505,34 +560,59 @@ fn owner_v3_lifecycle() -> Result<(), grin_wallet_controller::Error> {
 
 	// 24) Delete the wallet (close first)
 	let req = include_str!("data/v3_reqs/close_wallet.req.json");
-	let res =
-		send_request_enc::<String>("1", 1, "http://127.0.0.1:43420/v3/owner", &req, &shared_key)?;
+	let res = send_request_enc::<String>(
+		&JsonId::StrId(String::from("1")),
+		1,
+		"http://127.0.0.1:43420/v3/owner",
+		&req,
+		&shared_key,
+	)?;
 	assert!(res.is_ok());
 
 	let req = include_str!("data/v3_reqs/delete_wallet.req.json");
-	let res =
-		send_request_enc::<String>("1", 1, "http://127.0.0.1:43420/v3/owner", &req, &shared_key)?;
+	let res = send_request_enc::<String>(
+		&JsonId::StrId(String::from("1")),
+		1,
+		"http://127.0.0.1:43420/v3/owner",
+		&req,
+		&shared_key,
+	)?;
 	println!("RES 24: {:?}", res);
 	assert!(res.is_ok());
 
 	// 25) Wallet should be gone
 	let req = include_str!("data/v3_reqs/open_wallet.req.json");
-	let res =
-		send_request_enc::<String>("1", 1, "http://127.0.0.1:43420/v3/owner", &req, &shared_key)?;
+	let res = send_request_enc::<String>(
+		&JsonId::StrId(String::from("1")),
+		1,
+		"http://127.0.0.1:43420/v3/owner",
+		&req,
+		&shared_key,
+	)?;
 	println!("RES 25: {:?}", res);
 	assert!(res.is_err());
 
 	// 26) Try to create a wallet with an invalid mnemonic
 	let req = include_str!("data/v3_reqs/create_wallet_invalid_mn.req.json");
-	let res =
-		send_request_enc::<String>("1", 1, "http://127.0.0.1:43420/v3/owner", &req, &shared_key)?;
+	let res = send_request_enc::<String>(
+		&JsonId::StrId(String::from("1")),
+		1,
+		"http://127.0.0.1:43420/v3/owner",
+		&req,
+		&shared_key,
+	)?;
 	println!("RES 26: {:?}", res);
 	assert!(res.is_err());
 
 	// 27) Try to create a wallet with an valid mnemonic
 	let req = include_str!("data/v3_reqs/create_wallet_valid_mn.req.json");
-	let res =
-		send_request_enc::<String>("1", 1, "http://127.0.0.1:43420/v3/owner", &req, &shared_key)?;
+	let res = send_request_enc::<String>(
+		&JsonId::StrId(String::from("1")),
+		1,
+		"http://127.0.0.1:43420/v3/owner",
+		&req,
+		&shared_key,
+	)?;
 	println!("RES 27: {:?}", res);
 	assert!(res.is_ok());
 


### PR DESCRIPTION
(Replaces #334, with a saner commit history)

In doing some sample code for the V3 API, it became evident that the ID field in encrypted requests shouldn't be restricted to being a u64, or a string representation of a u64. It should allow all types of IDs in so long as they're strings, including UUIDs.

This changes the EncryptedRequest/Response fields to type String, and provides a custom legacy serializer to ensure anyone currently sending ids as ints won't be affected by the change.