### PR TITLE
Improve backend trait

### DIFF
--- a/api/src/owner.rs
+++ b/api/src/owner.rs
@@ -298,7 +298,7 @@ where
 	) -> Result<Identifier, Error> {
 		let mut w_lock = self.wallet_inst.lock();
 		let w = w_lock.lc_provider()?.wallet_inst()?;
-		owner::create_account_path(&mut **w, keychain_mask, label)
+		owner::create_account_path(&mut **w, keychain_mask, label.to_string())
 	}
 
 	/// Sets the wallet's currently active account. This sets the

--- a/libwallet/src/api_impl/foreign.rs
+++ b/libwallet/src/api_impl/foreign.rs
@@ -74,7 +74,7 @@ where
 	check_ttl(w, &ret_slate)?;
 	let parent_key_id = match dest_acct_name {
 		Some(d) => {
-			let pm = w.get_acct_path(d.to_owned())?;
+			let pm = w.get_acct_path(d)?;
 			match pm {
 				Some(p) => p.path,
 				None => w.parent_key_id(),

--- a/libwallet/src/api_impl/owner.rs
+++ b/libwallet/src/api_impl/owner.rs
@@ -56,7 +56,7 @@ where
 pub fn create_account_path<'a, T: ?Sized, C, K>(
 	w: &mut T,
 	keychain_mask: Option<&SecretKey>,
-	label: &str,
+	label: String,
 ) -> Result<Identifier, Error>
 where
 	T: WalletBackend<'a, C, K>,
@@ -311,7 +311,7 @@ where
 {
 	let parent_key_id = match args.src_acct_name {
 		Some(d) => {
-			let pm = w.get_acct_path(d)?;
+			let pm = w.get_acct_path(&d)?;
 			match pm {
 				Some(p) => p.path,
 				None => w.parent_key_id(),
@@ -411,7 +411,7 @@ where
 {
 	let parent_key_id = match args.dest_acct_name {
 		Some(d) => {
-			let pm = w.get_acct_path(d)?;
+			let pm = w.get_acct_path(&d)?;
 			match pm {
 				Some(p) => p.path,
 				None => w.parent_key_id(),
@@ -473,7 +473,7 @@ where
 	check_ttl(w, &ret_slate)?;
 	let parent_key_id = match args.src_acct_name {
 		Some(d) => {
-			let pm = w.get_acct_path(d)?;
+			let pm = w.get_acct_path(&d)?;
 			match pm {
 				Some(p) => p.path,
 				None => w.parent_key_id(),

--- a/libwallet/src/internal/selection.rs
+++ b/libwallet/src/internal/selection.rs
@@ -539,11 +539,7 @@ where
 {
 	// first find all eligible outputs based on number of confirmations
 	let mut eligible = wallet
-		.iter()
-		.filter(|out| {
-			out.root_key_id == *parent_key_id
-				&& out.eligible_to_spend(current_height, minimum_confirmations)
-		})
+		.eligible_outputs(parent_key_id, current_height, minimum_confirmations)
 		.collect::<Vec<OutputData>>();
 
 	let max_available = eligible.len();


### PR DESCRIPTION
Still WIP.

Add some of the more specific methods on the backend trait. A naive (iterating and filtering) default implementation is provided for these methods, but different types of backends can overwrite them in favour of faster methods that could make use of indices.