### PR TITLE
CI: no directories in checksum file

### DIFF
--- a/.ci/release.yml
+++ b/.ci/release.yml
@@ -29,7 +29,7 @@ steps:
       tarCompression: 'gz'
       archiveFile: '$(Build.ArtifactStagingDirectory)/grin-wallet-$(build.my_tag)-$(build.platform).tar.gz'
   - script: |
-      openssl sha256 $(Build.ArtifactStagingDirectory)/grin-wallet-$(build.my_tag)-$(build.platform).tar.gz > $(Build.ArtifactStagingDirectory)/grin-wallet-$(build.my_tag)-$(build.platform)-sha256sum.txt
+      cd $(Build.ArtifactStagingDirectory) && openssl sha256 grin-wallet-$(build.my_tag)-$(build.platform).tar.gz > grin-wallet-$(build.my_tag)-$(build.platform)-sha256sum.txt
     displayName: Create Checksum
     condition:  and(succeeded(), contains(variables['Build.SourceBranch'], 'refs/tags/'), eq(variables['CI_JOB'], 'release' ))
   - task: GithubRelease@0

--- a/.ci/windows-release.yml
+++ b/.ci/windows-release.yml
@@ -32,7 +32,7 @@ steps:
       archiveType: 'zip'
       archiveFile: '$(Build.ArtifactStagingDirectory)\grin-wallet-$(build.my_tag)-$(build.platform).zip'
   - script: |
-      powershell -Command "get-filehash -algorithm sha256 $(Build.ArtifactStagingDirectory)\grin-wallet-$(build.my_tag)-$(build.platform).zip | Format-List |  Out-String | ForEach-Object { $_.Trim() } > $(Build.ArtifactStagingDirectory)\grin-wallet-$(build.my_tag)-$(build.platform)-sha256sum.txt"
+      powershell -Command "cd $(Build.ArtifactStagingDirectory); get-filehash -algorithm sha256 grin-wallet-$(build.my_tag)-$(build.platform).zip | Format-List |  Out-String | ForEach-Object { $_.Trim() } > grin-wallet-$(build.my_tag)-$(build.platform)-sha256sum.txt"
     displayName: Create Checksum
     condition:  and(succeeded(), contains(variables['Build.SourceBranch'], 'refs/tags/'), eq(variables['CI_JOB'], 'release' ))
   - task: GithubRelease@0


### PR DESCRIPTION
The CI produces `*-sha256sum.txt` files that look like this:
```
SHA256(/home/vsts/work/1/a/grin-wallet-v3.1.0-linux-amd64.tar.gz)= bdc0ea8b8163bee7265ed63ee525720f3ad511b984987189a719427362b00313
```

While ideally we'd want it to look like this:
```
SHA256(grin-wallet-v3.1.0-linux-amd64.tar.gz)= bdc0ea8b8163bee7265ed63ee525720f3ad511b984987189a719427362b00313
```

This would users to compare the binary with the checksum file using `sha256sum -c`.

On Windows a similar issue exists:
```
Algorithm : SHA256
Hash      : 6C1A28FA709EBFF0F142DE41209991ED58A89170927CF698974D25ED72D920D7
Path      : D:\a\1\a\grin-wallet-v3.1.0-win-x64.zip
```

To fix this, we first `cd` to the build directory and run the checksum generation command from there.

I have to set up a test CI on my repo to make sure these commands work as expected, **please do not merge yet**.

Fixes https://github.com/mimblewimble/grin-wallet/issues/359.