### PR TITLE
Compact transaction object and Base64 binary fields

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1188,6 +1188,7 @@ dependencies = [
 name = "grin_wallet_libwallet"
 version = "4.0.0-alpha.1"
 dependencies = [
+ "base64 0.9.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "blake2-rfc 0.2.18 (registry+https://github.com/rust-lang/crates.io-index)",
  "byteorder 1.3.4 (registry+https://github.com/rust-lang/crates.io-index)",
  "chrono 0.4.11 (registry+https://github.com/rust-lang/crates.io-index)",

--- a/api/src/foreign_rpc.rs
+++ b/api/src/foreign_rpc.rs
@@ -130,19 +130,19 @@ pub trait ForeignRpc {
 		"id": 1,
 		"params": [
 			{
-			"ver": "4.3",
-			"id": "0436430c-2b02-624c-2032-570501212b00",
-			"amount": "60000000000",
-			"fee": "7000000",
-			"height": "5",
-			"participant_data": [
-				{
-					"public_blind_excess": "033ac2158fa0077f087de60c19d8e431753baa5b63b6e1477f05a2a6e7190d4592",
-					"public_nonce": "031b84c5567b126440995d3ed5aaba0565d71e1834604819ff9c17f5e9d5dd078f"
-				}
-			]
-		},
-		null
+				"ver": "4.2",
+				"id": "0436430c-2b02-624c-2032-570501212b00",
+				"amt": "60000000000",
+				"fee": "7000000",
+				"height": "5",
+				"sigs": [
+					{
+						"xs": "AzrCFY+gB38IfeYMGdjkMXU7qltjtuFHfwWipucZDUWS",
+						"nonce": "AxuExVZ7EmRAmV0+1aq6BWXXHhg0YEgZ/5wX9enV3QeP"
+					}
+				]
+			},
+			null
 		]
 	}
 	# "#

--- a/controller/tests/file.rs
+++ b/controller/tests/file.rs
@@ -185,5 +185,5 @@ fn wallet_file_exchange() {
 	if let Err(e) = file_exchange_test_impl(test_dir) {
 		panic!("Libwallet Error: {} - {}", e, e.backtrace().unwrap());
 	}
-	//clean_output_dir(test_dir);
+	clean_output_dir(test_dir);
 }

--- a/libwallet/Cargo.toml
+++ b/libwallet/Cargo.toml
@@ -26,6 +26,7 @@ strum = "0.15"
 strum_macros = "0.15"
 ed25519-dalek = "1.0.0-pre.1"
 byteorder = "1"
+base64 = "0.9"
 
 grin_wallet_util = { path = "../util", version = "4.0.0-alpha.1" }
 grin_wallet_config = { path = "../config", version = "4.0.0-alpha.1" }

--- a/libwallet/src/slate.rs
+++ b/libwallet/src/slate.rs
@@ -648,12 +648,12 @@ impl From<Slate> for SlateV4 {
 			num_participants,
 			id,
 			tx,
-			amount,
+			amt: amount,
 			fee,
 			height,
 			lock_height,
 			ttl_cutoff_height,
-			participant_data,
+			sigs: participant_data,
 			ver,
 			payment_proof,
 		}
@@ -696,12 +696,12 @@ impl From<&Slate> for SlateV4 {
 			num_participants,
 			id,
 			tx,
-			amount,
+			amt: amount,
 			fee,
 			height,
 			lock_height,
 			ttl_cutoff_height,
-			participant_data,
+			sigs: participant_data,
 			ver,
 			payment_proof,
 		}
@@ -719,9 +719,9 @@ impl From<&ParticipantData> for ParticipantDataV4 {
 		let public_nonce = *public_nonce;
 		let part_sig = *part_sig;
 		ParticipantDataV4 {
-			public_blind_excess,
-			public_nonce,
-			part_sig,
+			xs: public_blind_excess,
+			nonce: public_nonce,
+			part: part_sig,
 		}
 	}
 }
@@ -788,9 +788,9 @@ impl From<&TransactionBody> for TransactionBodyV4 {
 		let outputs = map_vec!(outputs, |out| OutputV4::from(out));
 		let kernels = map_vec!(kernels, |kern| TxKernelV4::from(kern));
 		TransactionBodyV4 {
-			inputs,
-			outputs,
-			kernels,
+			ins: inputs,
+			outs: outputs,
+			kers: kernels,
 		}
 	}
 }
@@ -811,8 +811,8 @@ impl From<&Output> for OutputV4 {
 		} = *output;
 		OutputV4 {
 			features,
-			commit,
-			proof,
+			com: commit,
+			prf: proof,
 		}
 	}
 }
@@ -843,12 +843,12 @@ impl From<SlateV4> for Slate {
 			num_participants,
 			id,
 			tx,
-			amount,
+			amt: amount,
 			fee,
 			height,
 			lock_height,
 			ttl_cutoff_height,
-			participant_data,
+			sigs: participant_data,
 			ver,
 			payment_proof,
 		} = slate;
@@ -881,9 +881,9 @@ impl From<SlateV4> for Slate {
 impl From<&ParticipantDataV4> for ParticipantData {
 	fn from(data: &ParticipantDataV4) -> ParticipantData {
 		let ParticipantDataV4 {
-			public_blind_excess,
-			public_nonce,
-			part_sig,
+			xs: public_blind_excess,
+			nonce: public_nonce,
+			part: part_sig,
 		} = data;
 		let public_blind_excess = *public_blind_excess;
 		let public_nonce = *public_nonce;
@@ -939,15 +939,11 @@ impl From<TransactionV4> for Transaction {
 
 impl From<&TransactionBodyV4> for TransactionBody {
 	fn from(body: &TransactionBodyV4) -> TransactionBody {
-		let TransactionBodyV4 {
-			inputs,
-			outputs,
-			kernels,
-		} = body;
+		let TransactionBodyV4 { ins, outs, kers } = body;
 
-		let inputs = map_vec!(inputs, |inp| Input::from(inp));
-		let outputs = map_vec!(outputs, |out| Output::from(out));
-		let kernels = map_vec!(kernels, |kern| TxKernel::from(kern));
+		let inputs = map_vec!(ins, |inp| Input::from(inp));
+		let outputs = map_vec!(outs, |out| Output::from(out));
+		let kernels = map_vec!(kers, |kern| TxKernel::from(kern));
 		TransactionBody {
 			inputs,
 			outputs,
@@ -967,8 +963,8 @@ impl From<&OutputV4> for Output {
 	fn from(output: &OutputV4) -> Output {
 		let OutputV4 {
 			features,
-			commit,
-			proof,
+			com: commit,
+			prf: proof,
 		} = *output;
 		Output {
 			features,

--- a/libwallet/src/slate_versions/ser.rs
+++ b/libwallet/src/slate_versions/ser.rs
@@ -13,6 +13,138 @@
 // limitations under the License.
 //! Sane serialization & deserialization of cryptographic structs into hex
 
+use crate::grin_util::secp::pedersen::{Commitment, RangeProof};
+use crate::grin_util::secp::PublicKey;
+use base64;
+use serde::{Deserialize, Deserializer, Serializer};
+
+/// Seralizes a byte string into base64
+pub fn as_base64<T, S>(bytes: T, serializer: S) -> Result<S::Ok, S::Error>
+where
+	T: AsRef<[u8]>,
+	S: Serializer,
+{
+	serializer.serialize_str(&base64::encode(&bytes))
+}
+
+/// Creates a RangeProof from a hex string
+pub fn rangeproof_from_base64<'de, D>(deserializer: D) -> Result<RangeProof, D::Error>
+where
+	D: Deserializer<'de>,
+{
+	use serde::de::{Error, IntoDeserializer};
+
+	let val = String::deserialize(deserializer)
+		.and_then(|string| base64::decode(&string).map_err(|err| Error::custom(err.to_string())))?;
+	RangeProof::deserialize(val.into_deserializer())
+}
+
+/// Creates a RangeProof from a hex string
+pub fn commitment_from_base64<'de, D>(deserializer: D) -> Result<Commitment, D::Error>
+where
+	D: Deserializer<'de>,
+{
+	use serde::de::{Error, IntoDeserializer};
+
+	let val = String::deserialize(deserializer)
+		.and_then(|string| base64::decode(&string).map_err(|err| Error::custom(err.to_string())))?;
+	Commitment::deserialize(val.into_deserializer())
+}
+
+/// Creates a PublicKey from a hex string
+pub fn pubkey_from_base64<'de, D>(deserializer: D) -> Result<PublicKey, D::Error>
+where
+	D: Deserializer<'de>,
+{
+	use serde::de::{Error, IntoDeserializer};
+
+	let val = String::deserialize(deserializer)
+		.and_then(|string| base64::decode(&string).map_err(|err| Error::custom(err.to_string())))?;
+	PublicKey::deserialize(val.into_deserializer())
+}
+
+/// Serializes an secp256k1 pubkey to base64
+pub mod pubkey_base64 {
+	use crate::grin_util::secp::PublicKey;
+	use crate::grin_util::static_secp_instance;
+	use base64;
+	use serde::{Deserialize, Deserializer, Serializer};
+
+	///
+	pub fn serialize<S>(key: &PublicKey, serializer: S) -> Result<S::Ok, S::Error>
+	where
+		S: Serializer,
+	{
+		let static_secp = static_secp_instance();
+		let static_secp = static_secp.lock();
+		serializer.serialize_str(&base64::encode(
+			&key.serialize_vec(&static_secp, true).to_vec(),
+		))
+	}
+
+	///
+	pub fn deserialize<'de, D>(deserializer: D) -> Result<PublicKey, D::Error>
+	where
+		D: Deserializer<'de>,
+	{
+		use serde::de::Error;
+		let static_secp = static_secp_instance();
+		let static_secp = static_secp.lock();
+		String::deserialize(deserializer)
+			.and_then(|string| {
+				base64::decode(&string).map_err(|err| Error::custom(err.to_string()))
+			})
+			.and_then(|bytes: Vec<u8>| {
+				PublicKey::from_slice(&static_secp, &bytes)
+					.map_err(|err| Error::custom(err.to_string()))
+			})
+	}
+}
+
+/// Serializes an Option<secp::Signature> to and from hex
+pub mod option_sig_base64 {
+	use crate::grin_util::{secp, static_secp_instance};
+	use base64;
+	use serde::de::Error;
+	use serde::{Deserialize, Deserializer, Serializer};
+
+	///
+	pub fn serialize<S>(sig: &Option<secp::Signature>, serializer: S) -> Result<S::Ok, S::Error>
+	where
+		S: Serializer,
+	{
+		let static_secp = static_secp_instance();
+		let static_secp = static_secp.lock();
+		match sig {
+			Some(sig) => serializer.serialize_str(&base64::encode(
+				&sig.serialize_compact(&static_secp).to_vec(),
+			)),
+			None => serializer.serialize_none(),
+		}
+	}
+
+	///
+	pub fn deserialize<'de, D>(deserializer: D) -> Result<Option<secp::Signature>, D::Error>
+	where
+		D: Deserializer<'de>,
+	{
+		let static_secp = static_secp_instance();
+		let static_secp = static_secp.lock();
+		Option::<String>::deserialize(deserializer).and_then(|res| match res {
+			Some(string) => base64::decode(&string)
+				.map_err(|err| Error::custom(err.to_string()))
+				.and_then(|bytes: Vec<u8>| {
+					let mut b = [0u8; 64];
+					b.copy_from_slice(&bytes[0..64]);
+					secp::Signature::from_compact(&static_secp, &b)
+						.map(Some)
+						.map_err(|err| Error::custom(err.to_string()))
+				}),
+			None => Ok(None),
+		})
+	}
+}
+
 /// Serializes an OnionV3Address to and from hex
 pub mod option_ov3_serde {
 	use serde::de::Error;


### PR DESCRIPTION
* Serializes all binary fields in SlateV4 and TransactionV4 as base64 instead of hex encoding
* Rename `amount` -> `amt`
* Rename `participant_data` -> `sigs`
* Rename `sigs` fields ->
   * `public_blind_excess` -> `xs`
   * `public_blind_nonce` -> `nonce`
   * `part_sig` -> `part`
* Compacts the TransactionV4 struct within the slate:
   * skip serializing `offset` if blank
   * skip serializing `body.inputs` if empty
   * rename `body.inputs` to `body.ins`
   * skip serializing `body.outputs` if empty
   * rename `body.outputs` to `body.outs`jjkk
   * skip serializing Inputs and Outputs 'features` if the types is `OutputFeatures.Plain`
   * skip serializing kernel features if the type is `CompatKernelFeatures.Plain`
   * skip serializing kernel `fee` if 0
   * skip serializing kernel `lock_height` if 0
   * skip serializing kernel `excess_sig` if blank