### PR TITLE
Remove height field from Slate and SlateV4

### DIFF
--- a/impls/src/adapters/file.rs
+++ b/impls/src/adapters/file.rs
@@ -28,6 +28,7 @@ impl SlatePutter for PathToSlate {
 		let mut pub_tx = File::create(&self.0)?;
 		// TODO:
 		// * Will need to set particpant id to 1 manually if this is invoice
+		// * Set slate height manually
 		let _r: crate::adapters::Reminder;
 		let out_slate = {
 			// TODO: This will need to be filled with any incompatibilities in the V4 Slate

--- a/impls/src/adapters/http.rs
+++ b/impls/src/adapters/http.rs
@@ -183,6 +183,7 @@ impl SlateSender for HttpSlateSender {
 				let _r: crate::adapters::Reminder;
 				//TODO: Fill out with Slate V4 incompatibilities
 				// * Will need to set particpant id to 1 manually if this is invoice
+				// * Set slate height manually
 				if false {
 					return Err(ErrorKind::ClientCallback("feature x requested, but other wallet does not support feature x. Please urge other user to upgrade, or re-send tx without feature x".into()).into());
 				}

--- a/libwallet/src/api_impl/foreign.rs
+++ b/libwallet/src/api_impl/foreign.rs
@@ -95,10 +95,13 @@ where
 		ret_slate.tx = Some(Transaction::empty());
 	}
 
+	let height = w.last_confirmed_height()?;
+
 	tx::add_output_to_slate(
 		&mut *w,
 		keychain_mask,
 		&mut ret_slate,
+		height,
 		&parent_key_id,
 		false,
 		use_test_rng,

--- a/libwallet/src/api_impl/owner.rs
+++ b/libwallet/src/api_impl/owner.rs
@@ -336,10 +336,12 @@ where
 		return Ok(slate);
 	}
 
+	let height = w.w2n_client().get_chain_tip()?.0;
 	let mut context = tx::add_inputs_to_slate(
 		&mut *w,
 		keychain_mask,
 		&mut slate,
+		height,
 		args.minimum_confirmations,
 		args.max_outputs as usize,
 		args.num_change_outputs as usize,
@@ -408,10 +410,12 @@ where
 	};
 
 	let mut slate = tx::new_tx_slate(&mut *w, args.amount, 2, use_test_rng, None)?;
+	let height = w.w2n_client().get_chain_tip()?.0;
 	let mut context = tx::add_output_to_slate(
 		&mut *w,
 		keychain_mask,
 		&mut slate,
+		height,
 		&parent_key_id,
 		true,
 		use_test_rng,
@@ -472,12 +476,11 @@ where
 		}
 	}
 
-	// update slate current height
-	ret_slate.height = w.w2n_client().get_chain_tip()?.0;
+	let height = w.w2n_client().get_chain_tip()?.0;
 
 	// update ttl if desired
 	if let Some(b) = args.ttl_blocks {
-		ret_slate.ttl_cutoff_height = Some(ret_slate.height + b);
+		ret_slate.ttl_cutoff_height = Some(height + b);
 	}
 
 	// if this is compact mode, we need to create the transaction now
@@ -492,6 +495,7 @@ where
 		&mut *w,
 		keychain_mask,
 		&mut ret_slate,
+		height,
 		args.minimum_confirmations,
 		args.max_outputs as usize,
 		args.num_change_outputs as usize,
@@ -544,7 +548,8 @@ where
 		sl.tx = Some(Transaction::empty());
 		selection::repopulate_tx(&mut *w, keychain_mask, &mut sl, &context)?;
 	}
-	selection::lock_tx_context(&mut *w, keychain_mask, &sl, &context)
+	let height = w.w2n_client().get_chain_tip()?.0;
+	selection::lock_tx_context(&mut *w, keychain_mask, &sl, height, &context)
 }
 
 /// Finalize slate

--- a/libwallet/src/internal/tx.rs
+++ b/libwallet/src/internal/tx.rs
@@ -67,7 +67,6 @@ where
 		*SLATE_COUNTER.lock() += 1;
 	}
 	slate.amount = amount;
-	slate.height = current_height;
 
 	if valid_header_version(current_height, HeaderVersion(1)) {
 		slate.version_info.block_header_version = 1;
@@ -140,6 +139,7 @@ pub fn add_inputs_to_slate<'a, T: ?Sized, C, K>(
 	wallet: &mut T,
 	keychain_mask: Option<&SecretKey>,
 	slate: &mut Slate,
+	current_height: u64,
 	minimum_confirmations: u64,
 	max_outputs: usize,
 	num_change_outputs: usize,
@@ -168,6 +168,7 @@ where
 		&wallet.keychain(keychain_mask)?,
 		keychain_mask,
 		slate,
+		current_height,
 		minimum_confirmations,
 		max_outputs,
 		num_change_outputs,
@@ -206,6 +207,7 @@ pub fn add_output_to_slate<'a, T: ?Sized, C, K>(
 	wallet: &mut T,
 	keychain_mask: Option<&SecretKey>,
 	slate: &mut Slate,
+	current_height: u64,
 	parent_key_id: &Identifier,
 	is_initiator: bool,
 	use_test_rng: bool,
@@ -221,6 +223,7 @@ where
 		wallet,
 		keychain_mask,
 		slate,
+		current_height,
 		parent_key_id.clone(),
 		is_initiator,
 		use_test_rng,

--- a/libwallet/src/slate.rs
+++ b/libwallet/src/slate.rs
@@ -28,7 +28,6 @@ use crate::grin_util::secp::key::{PublicKey, SecretKey};
 use crate::grin_util::secp::pedersen::Commitment;
 use crate::grin_util::secp::Signature;
 use crate::grin_util::{secp, static_secp_instance, RwLock};
-use crate::slate_versions::ser;
 use ed25519_dalek::PublicKey as DalekPublicKey;
 use ed25519_dalek::Signature as DalekSignature;
 use rand::rngs::mock::StepRng;
@@ -47,18 +46,18 @@ use crate::slate_versions::VersionedSlate;
 use crate::slate_versions::{CURRENT_SLATE_VERSION, GRIN_BLOCK_HEADER_VERSION};
 use crate::types::CbData;
 
-#[derive(Deserialize, Debug, Clone)]
+#[derive(Debug, Clone)]
 pub struct PaymentInfo {
-	#[serde(deserialize_with = "ser::dalek_pubkey_serde::deserialize")]
+	/// Sender address
 	pub sender_address: DalekPublicKey,
-	#[serde(deserialize_with = "ser::dalek_pubkey_serde::deserialize")]
+	/// Receiver address
 	pub receiver_address: DalekPublicKey,
-	#[serde(deserialize_with = "ser::option_dalek_sig_serde::deserialize")]
+	/// Receiver signature
 	pub receiver_signature: Option<DalekSignature>,
 }
 
 /// Public data for each participant in the slate
-#[derive(Deserialize, Debug, Clone)]
+#[derive(Debug, Clone)]
 pub struct ParticipantData {
 	/// Public key corresponding to private blinding factor
 	pub public_blind_excess: PublicKey,
@@ -90,7 +89,7 @@ impl ParticipantData {
 /// the slate around by whatever means they choose, (but we can provide some
 /// binary or JSON serialization helpers here).
 
-#[derive(Deserialize, Debug, Clone)]
+#[derive(Debug, Clone)]
 pub struct Slate {
 	/// Versioning info
 	pub version_info: VersionCompatInfo,
@@ -107,8 +106,6 @@ pub struct Slate {
 	pub amount: u64,
 	/// fee amount
 	pub fee: u64,
-	/// Block height for the transaction
-	pub height: u64,
 	/// Lock height
 	pub lock_height: Option<u64>,
 	/// TTL, the block height at which wallets
@@ -130,7 +127,7 @@ impl fmt::Display for Slate {
 }
 
 /// Versioning and compatibility info about this slate
-#[derive(Serialize, Deserialize, Debug, Clone)]
+#[derive(Debug, Clone)]
 pub struct VersionCompatInfo {
 	/// The current version of the slate format
 	pub version: u16,
@@ -209,7 +206,6 @@ impl Slate {
 			tx: Some(Transaction::empty()),
 			amount: 0,
 			fee: 0,
-			height: 0,
 			lock_height: None,
 			ttl_cutoff_height: None,
 			participant_data: vec![],
@@ -621,7 +617,6 @@ impl From<Slate> for SlateV4 {
 			tx: _,
 			amount,
 			fee,
-			height,
 			lock_height,
 			ttl_cutoff_height,
 			participant_data,
@@ -640,7 +635,6 @@ impl From<Slate> for SlateV4 {
 			coms: (&slate).into(),
 			amt: amount,
 			fee,
-			height,
 			lock_height,
 			ttl_cutoff_height,
 			sigs: participant_data,
@@ -658,7 +652,6 @@ impl From<&Slate> for SlateV4 {
 			tx: _,
 			amount,
 			fee,
-			height,
 			lock_height,
 			ttl_cutoff_height,
 			participant_data,
@@ -669,7 +662,6 @@ impl From<&Slate> for SlateV4 {
 		let id = *id;
 		let amount = *amount;
 		let fee = *fee;
-		let height = *height;
 		let lock_height = *lock_height;
 		let ttl_cutoff_height = *ttl_cutoff_height;
 		let participant_data = map_vec!(participant_data, |data| ParticipantDataV4::from(data));
@@ -685,7 +677,6 @@ impl From<&Slate> for SlateV4 {
 			coms: slate.into(),
 			amt: amount,
 			fee,
-			height,
 			lock_height,
 			ttl_cutoff_height,
 			sigs: participant_data,
@@ -858,7 +849,6 @@ impl From<SlateV4> for Slate {
 			coms: _,
 			amt: amount,
 			fee,
-			height,
 			lock_height,
 			ttl_cutoff_height,
 			sigs: participant_data,
@@ -877,7 +867,6 @@ impl From<SlateV4> for Slate {
 			tx: (&slate).into(),
 			amount,
 			fee,
-			height,
 			lock_height,
 			ttl_cutoff_height,
 			participant_data,

--- a/libwallet/src/slate_versions/v4.rs
+++ b/libwallet/src/slate_versions/v4.rs
@@ -78,9 +78,6 @@ pub struct SlateV4 {
 	#[serde(default = "default_u64")]
 	#[serde(skip_serializing_if = "u64_is_blank")]
 	pub fee: u64,
-	/// Block height for the transaction
-	#[serde(with = "secp_ser::string_or_u64")]
-	pub height: u64,
 	/// Lock height
 	#[serde(with = "secp_ser::opt_string_or_u64")]
 	#[serde(skip_serializing_if = "Option::is_none")]
@@ -383,7 +380,7 @@ impl From<SlateV3> for SlateV4 {
 			tx: _,
 			amount,
 			fee,
-			height,
+			height: _,
 			lock_height,
 			ttl_cutoff_height,
 			participant_data,
@@ -403,7 +400,6 @@ impl From<SlateV3> for SlateV4 {
 			coms: (&slate).into(),
 			amt: amount,
 			fee,
-			height,
 			lock_height: Some(lock_height),
 			ttl_cutoff_height,
 			sigs: participant_data,
@@ -562,7 +558,6 @@ impl TryFrom<&SlateV4> for SlateV3 {
 			coms,
 			amt: amount,
 			fee,
-			height,
 			lock_height,
 			ttl_cutoff_height,
 			sigs: participant_data,
@@ -576,7 +571,6 @@ impl TryFrom<&SlateV4> for SlateV3 {
 		let id = *id;
 		let amount = *amount;
 		let fee = *fee;
-		let height = *height;
 		let lock_height = match *lock_height {
 			Some(l) => l,
 			None => 0,
@@ -605,7 +599,7 @@ impl TryFrom<&SlateV4> for SlateV3 {
 			tx,
 			amount,
 			fee,
-			height,
+			height: 0,
 			lock_height,
 			ttl_cutoff_height,
 			participant_data,


### PR DESCRIPTION
* Remove height field from Slate and Slate V4
* Retrieve height from tip where required for coin selection
* Remove all direct ser/deser derivations from Slate