### PR TITLE
Remove amount and fee from Slate where not needed

### DIFF
--- a/controller/tests/invoice.rs
+++ b/controller/tests/invoice.rs
@@ -154,7 +154,6 @@ fn invoice_tx_impl(test_dir: &'static str) -> Result<(), libwallet::Error> {
 			wallet2_info.last_confirmed_height, bh
 		);
 		assert!(refreshed);
-		assert_eq!(wallet2_info.amount_currently_spendable, slate.amount);
 		Ok(())
 	})?;
 

--- a/controller/tests/payment_proofs.rs
+++ b/controller/tests/payment_proofs.rs
@@ -145,7 +145,7 @@ fn payment_proofs_test_impl(test_dir: &'static str) -> Result<(), libwallet::Err
 		// Check payment proof here
 		let mut pp = sender_api.retrieve_payment_proof(m, true, None, Some(slate.id))?;
 
-		println!("{:?}", pp);
+		println!("Payment proof: {:?}", pp);
 
 		// verify, should be good
 		let res = sender_api.verify_payment_proof(m, &pp)?;

--- a/libwallet/src/api_impl/foreign.rs
+++ b/libwallet/src/api_impl/foreign.rs
@@ -120,6 +120,11 @@ where
 
 		p.receiver_signature = Some(sig);
 	}
+	// Can remove amount and fee now
+	if ret_slate.is_compact() {
+		ret_slate.amount = 0;
+		ret_slate.fee = 0;
+	}
 
 	ret_slate.state = SlateState::Standard2;
 	Ok(ret_slate)
@@ -140,7 +145,7 @@ where
 	check_ttl(w, &sl)?;
 	let context = w.get_private_context(keychain_mask, sl.id.as_bytes())?;
 	if sl.is_compact() {
-		selection::repopulate_tx(&mut *w, keychain_mask, &mut sl, &context)?;
+		selection::repopulate_tx(&mut *w, keychain_mask, &mut sl, &context, false)?;
 	}
 	tx::complete_tx(&mut *w, keychain_mask, &mut sl, &context)?;
 	tx::update_stored_tx(&mut *w, keychain_mask, &context, &mut sl, true)?;
@@ -150,5 +155,9 @@ where
 		batch.commit()?;
 	}
 	sl.state = SlateState::Invoice3;
+	if sl.is_compact() {
+		sl.amount = 0;
+		sl.fee = 0;
+	}
 	Ok(sl)
 }

--- a/libwallet/src/slate_versions/v4.rs
+++ b/libwallet/src/slate_versions/v4.rs
@@ -74,6 +74,8 @@ pub struct SlateV4 {
 	pub num_parts: u8,
 	/// base amount (excluding fee)
 	#[serde(with = "secp_ser::string_or_u64")]
+	#[serde(skip_serializing_if = "u64_is_blank")]
+	#[serde(default = "default_u64_0")]
 	pub amt: u64,
 	/// fee amount
 	#[serde(with = "secp_ser::string_or_u64")]

--- a/libwallet/src/types.rs
+++ b/libwallet/src/types.rs
@@ -547,6 +547,9 @@ pub struct Context {
 	/// store my inputs
 	/// Id, mmr_index (if known), amount
 	pub input_ids: Vec<(Identifier, Option<u64>, u64)>,
+	/// store amount, so we can remove from slate if not
+	/// needed by the other party
+	pub amount: u64,
 	/// store the calculated fee
 	pub fee: u64,
 	/// Payment proof sender address derivation path, if needed
@@ -580,6 +583,7 @@ impl Context {
 			initial_sec_nonce: sec_nonce.clone(),
 			input_ids: vec![],
 			output_ids: vec![],
+			amount: 0,
 			fee: 0,
 			payment_proof_derivation_index: None,
 			offset: offset.clone(),


### PR DESCRIPTION
Sets amount and fee on the slate to 0 where not needed, with each participant keeping the info in their transaction context instead. 

S1 -> amount and fee specified
S2 -> amount and fee removed
S3 -> amount and fee removed
I1 -> amount specified
I2 -> amount removed, fee specified
I3 -> amount and fee removed