### PR TITLE
Final Changes for compact Slate

### DIFF
--- a/controller/src/command.rs
+++ b/controller/src/command.rs
@@ -518,7 +518,6 @@ where
 
 /// Arguments for the process_invoice command
 pub struct ProcessInvoiceArgs {
-	pub message: Option<String>,
 	pub minimum_confirmations: u64,
 	pub selection_strategy: String,
 	pub method: String,
@@ -572,7 +571,6 @@ where
 				max_outputs: args.max_outputs as u32,
 				num_change_outputs: 1u32,
 				selection_strategy_is_use_all: args.selection_strategy == "all",
-				message: args.message.clone(),
 				ttl_blocks: args.ttl_blocks,
 				send_args: None,
 				..Default::default()

--- a/libwallet/src/api_impl/types.rs
+++ b/libwallet/src/api_impl/types.rs
@@ -24,31 +24,6 @@ use grin_wallet_util::OnionV3Address;
 
 use ed25519_dalek::Signature as DalekSignature;
 
-/// Send TX API Args
-// TODO: This is here to ensure the legacy V1 API remains intact
-// remove this when v1 api is removed
-#[derive(Clone, Serialize, Deserialize)]
-pub struct SendTXArgs {
-	/// amount to send
-	pub amount: u64,
-	/// minimum confirmations
-	pub minimum_confirmations: u64,
-	/// payment method
-	pub method: String,
-	/// destination url
-	pub dest: String,
-	/// Max number of outputs
-	pub max_outputs: usize,
-	/// Number of change outputs to generate
-	pub num_change_outputs: usize,
-	/// whether to use all outputs (combine)
-	pub selection_strategy_is_use_all: bool,
-	/// Optional message, that will be signed
-	pub message: Option<String>,
-	/// Optional slate version to target when sending
-	pub target_slate_version: Option<u16>,
-}
-
 /// V2 Init / Send TX API Args
 #[derive(Clone, Serialize, Deserialize)]
 pub struct InitTxArgs {
@@ -80,12 +55,6 @@ pub struct InitTxArgs {
 	/// as many outputs as are needed to meet the amount, (and no more) starting with the smallest
 	/// value outputs.
 	pub selection_strategy_is_use_all: bool,
-	/// An optional participant message to include alongside the sender's public
-	/// ParticipantData within the slate. This message will include a signature created with the
-	/// sender's private excess value, and will be publically verifiable. Note this message is for
-	/// the convenience of the participants during the exchange; it is not included in the final
-	/// transaction sent to the chain. The message will be truncated to 256 characters.
-	pub message: Option<String>,
 	/// Optionally set the output target slate version (acceptable
 	/// down to the minimum slate version compatible with the current. If `None` the slate
 	/// is generated with the latest version.
@@ -133,7 +102,6 @@ impl Default for InitTxArgs {
 			max_outputs: 500,
 			num_change_outputs: 1,
 			selection_strategy_is_use_all: true,
-			message: None,
 			target_slate_version: None,
 			ttl_blocks: None,
 			estimate_only: Some(false),

--- a/libwallet/src/lib.rs
+++ b/libwallet/src/lib.rs
@@ -63,7 +63,7 @@ pub use crate::slate_versions::{
 pub use api_impl::owner_updater::StatusMessage;
 pub use api_impl::types::{
 	BlockFees, InitTxArgs, InitTxSendArgs, IssueInvoiceTxArgs, NodeHeightResult,
-	OutputCommitMapping, PaymentProof, SendTXArgs, VersionInfo,
+	OutputCommitMapping, PaymentProof, VersionInfo,
 };
 pub use internal::scan::scan;
 pub use slate_versions::ser as dalek_ser;

--- a/libwallet/src/slate.rs
+++ b/libwallet/src/slate.rs
@@ -661,7 +661,7 @@ impl From<Slate> for SlateV4 {
 			ttl,
 			sigs: participant_data,
 			ver,
-			payment_proof,
+			proof: payment_proof,
 		}
 	}
 }
@@ -706,7 +706,7 @@ impl From<&Slate> for SlateV4 {
 			ttl,
 			sigs: participant_data,
 			ver,
-			payment_proof,
+			proof: payment_proof,
 		}
 	}
 }
@@ -795,9 +795,9 @@ impl From<&PaymentInfo> for PaymentInfoV4 {
 		let receiver_address = *receiver_address;
 		let receiver_signature = *receiver_signature;
 		PaymentInfoV4 {
-			sender_address,
-			receiver_address,
-			receiver_signature,
+			saddr: sender_address,
+			raddr: receiver_address,
+			rsig: receiver_signature,
 		}
 	}
 }
@@ -906,7 +906,7 @@ impl From<SlateV4> for Slate {
 			ttl: ttl_cutoff_height,
 			sigs: participant_data,
 			ver,
-			payment_proof,
+			proof: payment_proof,
 		} = slate.clone();
 		let participant_data = map_vec!(participant_data, |data| ParticipantData::from(data));
 		let version_info = VersionCompatInfo::from(&ver);
@@ -1040,9 +1040,9 @@ impl From<&VersionCompatInfoV4> for VersionCompatInfo {
 impl From<&PaymentInfoV4> for PaymentInfo {
 	fn from(data: &PaymentInfoV4) -> PaymentInfo {
 		let PaymentInfoV4 {
-			sender_address,
-			receiver_address,
-			receiver_signature,
+			saddr: sender_address,
+			raddr: receiver_address,
+			rsig: receiver_signature,
 		} = data;
 		let sender_address = *sender_address;
 		let receiver_address = *receiver_address;

--- a/libwallet/src/slate_versions/v4.rs
+++ b/libwallet/src/slate_versions/v4.rs
@@ -108,7 +108,7 @@ pub struct SlateV4 {
 	/// Payment Proof
 	#[serde(default = "default_payment_none")]
 	#[serde(skip_serializing_if = "Option::is_none")]
-	pub payment_proof: Option<PaymentInfoV4>,
+	pub proof: Option<PaymentInfoV4>,
 }
 
 fn default_payment_none() -> Option<PaymentInfoV4> {
@@ -180,13 +180,13 @@ fn default_part_sig_none() -> Option<Signature> {
 #[derive(Serialize, Deserialize, Debug, Clone)]
 pub struct PaymentInfoV4 {
 	#[serde(with = "ser::dalek_pubkey_serde")]
-	pub sender_address: DalekPublicKey,
+	pub saddr: DalekPublicKey,
 	#[serde(with = "ser::dalek_pubkey_serde")]
-	pub receiver_address: DalekPublicKey,
+	pub raddr: DalekPublicKey,
 	#[serde(default = "default_receiver_signature_none")]
 	#[serde(with = "ser::option_dalek_sig_serde")]
 	#[serde(skip_serializing_if = "Option::is_none")]
-	pub receiver_signature: Option<DalekSignature>,
+	pub rsig: Option<DalekSignature>,
 }
 
 fn default_receiver_signature_none() -> Option<DalekSignature> {
@@ -447,7 +447,7 @@ impl From<SlateV3> for SlateV4 {
 			lock_hgt: lock_height,
 			ttl: ttl_cutoff_height,
 			sigs: participant_data,
-			payment_proof,
+			proof: payment_proof,
 		}
 	}
 }
@@ -587,9 +587,9 @@ impl From<&PaymentInfoV3> for PaymentInfoV4 {
 			receiver_signature,
 		} = *input;
 		PaymentInfoV4 {
-			sender_address,
-			receiver_address,
-			receiver_signature,
+			saddr: sender_address,
+			raddr: receiver_address,
+			rsig: receiver_signature,
 		}
 	}
 }
@@ -610,7 +610,7 @@ impl TryFrom<&SlateV4> for SlateV3 {
 			ttl: ttl_cutoff_height,
 			sigs: participant_data,
 			ver,
-			payment_proof,
+			proof: payment_proof,
 		} = slate;
 		let num_participants = match *num_participants {
 			0 => 2,
@@ -829,9 +829,9 @@ impl From<&TxKernelV4> for TxKernelV3 {
 impl From<&PaymentInfoV4> for PaymentInfoV3 {
 	fn from(input: &PaymentInfoV4) -> PaymentInfoV3 {
 		let PaymentInfoV4 {
-			sender_address,
-			receiver_address,
-			receiver_signature,
+			saddr: sender_address,
+			raddr: receiver_address,
+			rsig: receiver_signature,
 		} = *input;
 		PaymentInfoV3 {
 			sender_address,

--- a/libwallet/src/slate_versions/v4.rs
+++ b/libwallet/src/slate_versions/v4.rs
@@ -208,6 +208,8 @@ pub struct CommitsV4 {
 	/// A proof that the commitment is in the right range
 	/// Only applies for transaction outputs
 	#[serde(with = "ser::option_rangeproof_base64")]
+	#[serde(default = "default_range_proof")]
+	#[serde(skip_serializing_if = "Option::is_none")]
 	pub p: Option<RangeProof>,
 }
 
@@ -264,6 +266,10 @@ fn outputs_are_empty(v: &Vec<OutputV4>) -> bool {
 
 fn default_outputs() -> Vec<OutputV4> {
 	vec![]
+}
+
+fn default_range_proof() -> Option<RangeProof> {
+	None
 }
 
 #[derive(Serialize, Deserialize, Debug, Clone)]

--- a/libwallet/src/slate_versions/v4.rs
+++ b/libwallet/src/slate_versions/v4.rs
@@ -179,12 +179,12 @@ fn default_part_sig_none() -> Option<Signature> {
 
 #[derive(Serialize, Deserialize, Debug, Clone)]
 pub struct PaymentInfoV4 {
-	#[serde(with = "ser::dalek_pubkey_serde")]
+	#[serde(with = "ser::dalek_pubkey_base64")]
 	pub saddr: DalekPublicKey,
-	#[serde(with = "ser::dalek_pubkey_serde")]
+	#[serde(with = "ser::dalek_pubkey_base64")]
 	pub raddr: DalekPublicKey,
 	#[serde(default = "default_receiver_signature_none")]
-	#[serde(with = "ser::option_dalek_sig_serde")]
+	#[serde(with = "ser::option_dalek_sig_base64")]
 	#[serde(skip_serializing_if = "Option::is_none")]
 	pub rsig: Option<DalekSignature>,
 }

--- a/src/cmd/wallet_args.rs
+++ b/src/cmd/wallet_args.rs
@@ -594,13 +594,6 @@ pub fn parse_process_invoice_args(
 	args: &ArgMatches,
 	prompt: bool,
 ) -> Result<command::ProcessInvoiceArgs, ParseError> {
-	// TODO: display and prompt for confirmation of what we're doing
-	// message
-	let message = match args.is_present("message") {
-		true => Some(args.value_of("message").unwrap().to_owned()),
-		false => None,
-	};
-
 	// minimum_confirmations
 	let min_c = parse_required(args, "minimum_confirmations")?;
 	let min_c = parse_u64(min_c, "minimum_confirmations")?;
@@ -663,7 +656,6 @@ pub fn parse_process_invoice_args(
 	}
 
 	Ok(command::ProcessInvoiceArgs {
-		message: message,
 		minimum_confirmations: min_c,
 		selection_strategy: selection_strategy.to_owned(),
 		estimate_selection_strategies,


### PR DESCRIPTION
Final (for now) changes for compact V4 Slate: 

* Add tests that output all types of slate as files
* Ensure `None` rangeproofs` aren't serialized for inputs
* Shorten OutputFeatures serialization (1 for CoinBase, 0 otherwise)
* Rename payment proof fields as per RFC
* Base 64 encoding of payment proof elements 