### PR TITLE
Remove unneeded signature data during S2 and I2 stages

### DIFF
--- a/controller/tests/file.rs
+++ b/controller/tests/file.rs
@@ -303,21 +303,21 @@ fn file_exchange_test_impl(test_dir: &'static str, use_bin: bool) -> Result<(), 
 
 #[test]
 fn wallet_file_exchange_json() {
-	let test_dir = "test_output/file_exchange_bin";
+	let test_dir = "test_output/file_exchange_json";
 	setup(test_dir);
 	// Json output
-	if let Err(e) = file_exchange_test_impl(test_dir, true) {
+	if let Err(e) = file_exchange_test_impl(test_dir, false) {
 		panic!("Libwallet Error: {} - {}", e, e.backtrace().unwrap());
 	}
-	clean_output_dir(test_dir);
+	//clean_output_dir(test_dir);
 }
 
 #[test]
 fn wallet_file_exchange_bin() {
-	let test_dir = "test_output/file_exchange_json";
+	let test_dir = "test_output/file_exchange_bin";
 	setup(test_dir);
-	if let Err(e) = file_exchange_test_impl(test_dir, false) {
+	if let Err(e) = file_exchange_test_impl(test_dir, true) {
 		panic!("Libwallet Error: {} - {}", e, e.backtrace().unwrap());
 	}
-	clean_output_dir(test_dir);
+	//clean_output_dir(test_dir);
 }

--- a/controller/tests/file.rs
+++ b/controller/tests/file.rs
@@ -309,7 +309,7 @@ fn wallet_file_exchange_json() {
 	if let Err(e) = file_exchange_test_impl(test_dir, false) {
 		panic!("Libwallet Error: {} - {}", e, e.backtrace().unwrap());
 	}
-	//clean_output_dir(test_dir);
+	clean_output_dir(test_dir);
 }
 
 #[test]
@@ -319,5 +319,5 @@ fn wallet_file_exchange_bin() {
 	if let Err(e) = file_exchange_test_impl(test_dir, true) {
 		panic!("Libwallet Error: {} - {}", e, e.backtrace().unwrap());
 	}
-	//clean_output_dir(test_dir);
+	clean_output_dir(test_dir);
 }

--- a/controller/tests/no_change.rs
+++ b/controller/tests/no_change.rs
@@ -162,7 +162,7 @@ fn no_change_test_impl(test_dir: &'static str) -> Result<(), libwallet::Error> {
 		Ok(())
 	})?;
 	wallet::controller::owner_single_use(Some(wallet2.clone()), mask1, None, |api, m| {
-		println!("Posted TX: {}", slate);
+		println!("Invoice Posted TX: {}", slate);
 		stored_excess = Some(slate.tx.as_ref().unwrap().body.kernels[0].excess);
 		api.post_tx(m, slate.tx_or_err()?, false)?;
 		Ok(())

--- a/impls/src/client_utils/json_rpc.rs
+++ b/impls/src/client_utils/json_rpc.rs
@@ -143,7 +143,7 @@ impl fmt::Display for Error {
 				write!(f, "duplicate RPC batch response ID: {}", v)
 			}
 			Error::_WrongBatchResponseId(ref v) => write!(f, "wrong RPC batch response ID: {}", v),
-			_ => f.write_str(std::error::Error::description(self)),
+			ref e => f.write_str(&format!("{}", e)),
 		}
 	}
 }

--- a/libwallet/src/api_impl/foreign.rs
+++ b/libwallet/src/api_impl/foreign.rs
@@ -147,7 +147,10 @@ where
 	check_ttl(w, &sl)?;
 	let context = w.get_private_context(keychain_mask, sl.id.as_bytes())?;
 	if sl.is_compact() {
-		selection::repopulate_tx(&mut *w, keychain_mask, &mut sl, &context, false)?;
+		let mut temp_ctx = context.clone();
+		temp_ctx.sec_key = context.initial_sec_key.clone();
+		temp_ctx.sec_nonce = context.initial_sec_nonce.clone();
+		selection::repopulate_tx(&mut *w, keychain_mask, &mut sl, &temp_ctx, false)?;
 	}
 	tx::complete_tx(&mut *w, keychain_mask, &mut sl, &context)?;
 	tx::update_stored_tx(&mut *w, keychain_mask, &context, &mut sl, true)?;

--- a/libwallet/src/api_impl/foreign.rs
+++ b/libwallet/src/api_impl/foreign.rs
@@ -97,7 +97,7 @@ where
 
 	let height = w.last_confirmed_height()?;
 
-	tx::add_output_to_slate(
+	let context = tx::add_output_to_slate(
 		&mut *w,
 		keychain_mask,
 		&mut ret_slate,
@@ -121,9 +121,11 @@ where
 		p.receiver_signature = Some(sig);
 	}
 	// Can remove amount and fee now
+	// as well as sender's sig data
 	if ret_slate.is_compact() {
 		ret_slate.amount = 0;
 		ret_slate.fee = 0;
+		ret_slate.remove_other_sigdata(&keychain, &context.sec_nonce)?;
 	}
 
 	ret_slate.state = SlateState::Standard2;

--- a/libwallet/src/api_impl/owner.rs
+++ b/libwallet/src/api_impl/owner.rs
@@ -585,6 +585,7 @@ where
 	if sl.is_compact() {
 		selection::repopulate_tx(&mut *w, keychain_mask, &mut sl, &context, true)?;
 	}
+	println!("SLATE TO FINALIZE: {}", sl);
 	tx::complete_tx(&mut *w, keychain_mask, &mut sl, &context)?;
 	tx::verify_slate_payment_proof(&mut *w, keychain_mask, &parent_key_id, &context, &sl)?;
 	tx::update_stored_tx(&mut *w, keychain_mask, &context, &sl, false)?;

--- a/libwallet/src/api_impl/owner.rs
+++ b/libwallet/src/api_impl/owner.rs
@@ -512,6 +512,11 @@ where
 		use_test_rng,
 	)?;
 
+	let keychain = w.keychain(keychain_mask)?;
+	// needs to be stored as we're removing sig data for return trip. this needs to be present
+	// when locking transaction context and updating tx log with excess later
+	context.calculated_excess = Some(ret_slate.calc_excess(keychain.secp())?);
+
 	// if self-sending, merge contexts
 	if let Ok(c) = context_res {
 		context.initial_sec_key = c.initial_sec_key;
@@ -536,9 +541,10 @@ where
 		batch.commit()?;
 	}
 
-	// Can remove amount now
+	// Can remove amount as well as other sig data now
 	if ret_slate.is_compact() {
 		ret_slate.amount = 0;
+		ret_slate.remove_other_sigdata(&keychain, &context.sec_nonce)?;
 	}
 
 	ret_slate.state = SlateState::Invoice2;
@@ -558,13 +564,24 @@ where
 {
 	let context = w.get_private_context(keychain_mask, slate.id.as_bytes())?;
 	let mut sl = slate.clone();
+	let mut excess_override = None;
 	if sl.is_compact() && sl.tx == None {
 		// attempt to repopulate if we're the initiator
 		sl.tx = Some(Transaction::empty());
 		selection::repopulate_tx(&mut *w, keychain_mask, &mut sl, &context, true)?;
+	} else if sl.participant_data.len() == 1 {
+		// purely for invoice workflow, payer needs the excess back temporarily for storage
+		excess_override = context.calculated_excess;
 	}
 	let height = w.w2n_client().get_chain_tip()?.0;
-	selection::lock_tx_context(&mut *w, keychain_mask, &sl, height, &context)
+	selection::lock_tx_context(
+		&mut *w,
+		keychain_mask,
+		&sl,
+		height,
+		&context,
+		excess_override,
+	)
 }
 
 /// Finalize slate
@@ -585,7 +602,6 @@ where
 	if sl.is_compact() {
 		selection::repopulate_tx(&mut *w, keychain_mask, &mut sl, &context, true)?;
 	}
-	println!("SLATE TO FINALIZE: {}", sl);
 	tx::complete_tx(&mut *w, keychain_mask, &mut sl, &context)?;
 	tx::verify_slate_payment_proof(&mut *w, keychain_mask, &parent_key_id, &context, &sl)?;
 	tx::update_stored_tx(&mut *w, keychain_mask, &context, &sl, false)?;

--- a/libwallet/src/internal/selection.rs
+++ b/libwallet/src/internal/selection.rs
@@ -24,6 +24,7 @@ use crate::grin_core::libtx::{
 };
 use crate::grin_keychain::{Identifier, Keychain};
 use crate::grin_util::secp::key::SecretKey;
+use crate::grin_util::secp::pedersen;
 use crate::internal::keys;
 use crate::slate::Slate;
 use crate::types::*;
@@ -111,6 +112,7 @@ pub fn lock_tx_context<'a, T: ?Sized, C, K>(
 	slate: &Slate,
 	current_height: u64,
 	context: &Context,
+	excess_override: Option<pedersen::Commitment>,
 ) -> Result<(), Error>
 where
 	T: WalletBackend<'a, C, K>,
@@ -153,6 +155,9 @@ where
 		};
 
 		if let Ok(e) = slate.calc_excess(keychain.secp()) {
+			t.kernel_excess = Some(e)
+		}
+		if let Some(e) = excess_override {
 			t.kernel_excess = Some(e)
 		}
 		t.kernel_lookup_min_height = Some(current_height);

--- a/libwallet/src/internal/selection.rs
+++ b/libwallet/src/internal/selection.rs
@@ -650,7 +650,12 @@ where
 	if update_fee {
 		slate.fee = context.fee;
 	}
+
 	let keychain = wallet.keychain(keychain_mask)?;
+
+	// restore my signature data
+	slate.add_participant_info(&keychain, &context.sec_key, &context.sec_nonce, None)?;
+
 	let mut parts = vec![];
 	for (id, _, value) in &context.get_inputs() {
 		let input = wallet.iter().find(|out| out.key_id == *id);

--- a/libwallet/src/slate.rs
+++ b/libwallet/src/slate.rs
@@ -434,13 +434,19 @@ impl Slate {
 		// Add our public key and nonce to the slate
 		let pub_key = PublicKey::from_secret_key(keychain.secp(), &sec_key)?;
 		let pub_nonce = PublicKey::from_secret_key(keychain.secp(), &sec_nonce)?;
+		let mut part_sig = part_sig;
 
 		// Remove if already here and replace
 		self.participant_data = self
 			.participant_data
 			.clone()
 			.into_iter()
-			.filter(|v| v.public_nonce != pub_nonce)
+			.filter(|v| {
+				if v.public_nonce == pub_nonce && part_sig == None {
+					part_sig = v.part_sig
+				}
+				v.public_nonce != pub_nonce
+			})
 			.collect();
 
 		self.participant_data.push(ParticipantData {

--- a/libwallet/src/slate.rs
+++ b/libwallet/src/slate.rs
@@ -240,23 +240,24 @@ impl Slate {
 			payment_proof: None,
 		}
 	}
-	/// Completes caller's part of round 2, completing signatures
-	pub fn part_data_with_secnonce<K>(
-		&self,
+	/// Removes any signature data that isn't mine, for compacting
+	/// slates for a return journey
+	pub fn remove_other_sigdata<K>(
+		&mut self,
 		keychain: &K,
 		sec_nonce: &SecretKey,
-	) -> Result<Option<ParticipantData>, Error>
+	) -> Result<(), Error>
 	where
 		K: Keychain,
 	{
 		let pub_nonce = PublicKey::from_secret_key(keychain.secp(), &sec_nonce)?;
-		for i in 0..self.num_participants() as usize {
-			// find my entry
-			if self.participant_data[i].public_nonce == pub_nonce {
-				return Ok(Some(self.participant_data[i].clone()));
-			}
-		}
-		Ok(None)
+		self.participant_data = self
+			.participant_data
+			.clone()
+			.into_iter()
+			.filter(|v| v.public_nonce == pub_nonce)
+			.collect();
+		Ok(())
 	}
 
 	/// Adds selected inputs and outputs to the slate's transaction
@@ -420,7 +421,7 @@ impl Slate {
 	/// and saves participant's transaction context
 	/// sec_key can be overridden to replace the blinding
 	/// factor (by whoever split the offset)
-	fn add_participant_info<K>(
+	pub fn add_participant_info<K>(
 		&mut self,
 		keychain: &K,
 		sec_key: &SecretKey,
@@ -433,6 +434,14 @@ impl Slate {
 		// Add our public key and nonce to the slate
 		let pub_key = PublicKey::from_secret_key(keychain.secp(), &sec_key)?;
 		let pub_nonce = PublicKey::from_secret_key(keychain.secp(), &sec_nonce)?;
+
+		// Remove if already here and replace
+		self.participant_data = self
+			.participant_data
+			.clone()
+			.into_iter()
+			.filter(|v| v.public_nonce != pub_nonce)
+			.collect();
 
 		self.participant_data.push(ParticipantData {
 			public_blind_excess: pub_key,

--- a/libwallet/src/types.rs
+++ b/libwallet/src/types.rs
@@ -559,6 +559,9 @@ pub struct Context {
 	pub offset: Option<BlindingFactor>,
 	/// whether this was an invoice transaction
 	pub is_invoice: bool,
+	/// for invoice I2 Only, store the tx excess so we can
+	/// remove it from the slate on return
+	pub calculated_excess: Option<pedersen::Commitment>,
 }
 
 impl Context {
@@ -588,6 +591,7 @@ impl Context {
 			payment_proof_derivation_index: None,
 			offset: offset.clone(),
 			is_invoice,
+			calculated_excess: None,
 		}
 	}
 }


### PR DESCRIPTION
When sending back the S2 or I2 invoice in the exchange, it's not necessary to re-include the initiators public excess and nonce values. This removes these values from the slate during the I2 and S2 phases, relying on each party to restore them when needed.