### PR TITLE
Update get_stored_tx to accept UUID instead of full transaction log entry

### DIFF
--- a/api/src/owner.rs
+++ b/api/src/owner.rs
@@ -1092,22 +1092,21 @@ where
 	/// let result = api_owner.retrieve_txs(None, update_from_node, tx_id, tx_slate_id);
 	///
 	/// if let Ok((was_updated, tx_log_entries)) = result {
-	///     let stored_tx = api_owner.get_stored_tx(None, &tx_log_entries[0]).unwrap();
+	///     let stored_tx = api_owner.get_stored_tx(None, tx_log_entries[0].tx_slate_id.unwrap()).unwrap();
 	///     //...
 	/// }
 	/// ```
 
-	// TODO: Should be accepting an id, not an entire entry struct
 	pub fn get_stored_tx(
 		&self,
 		keychain_mask: Option<&SecretKey>,
-		tx_log_entry: &TxLogEntry,
+		tx_id: Uuid,
 	) -> Result<Option<Transaction>, Error> {
 		let mut w_lock = self.wallet_inst.lock();
 		let w = w_lock.lc_provider()?.wallet_inst()?;
 		// Test keychain mask, to keep API consistent
 		let _ = w.keychain(keychain_mask)?;
-		owner::get_stored_tx(&**w, tx_log_entry)
+		owner::get_stored_tx(&**w, &tx_id)
 	}
 
 	/// Scans the entire UTXO set from the node, identify which outputs belong to the given wallet

--- a/api/src/owner_rpc.rs
+++ b/api/src/owner_rpc.rs
@@ -798,39 +798,7 @@ pub trait OwnerRpc {
 		"id": 1,
 		"params": {
 			"token": "d202964900000000d302964900000000d402964900000000d502964900000000",
-			"tx": {
-				"amount_credited": "59993000000",
-				"amount_debited": "120000000000",
-				"confirmation_ts": "2019-01-15T16:01:26Z",
-				"confirmed": false,
-				"creation_ts": "2019-01-15T16:01:26Z",
-				"fee": "7000000",
-				"id": 5,
-				"messages": {
-					"messages": [
-						{
-							"id": "0",
-							"message": null,
-							"message_sig": null,
-							"public_key": "033ac2158fa0077f087de60c19d8e431753baa5b63b6e1477f05a2a6e7190d4592"
-						},
-						{
-							"id": "1",
-							"message": null,
-							"message_sig": null,
-							"public_key": "024f9bc78c984c78d6e916d3a00746aa30fa1172124c8dbc0cbddcb7b486719bc7"
-						}
-					]
-				},
-				"num_inputs": 2,
-				"num_outputs": 1,
-				"parent_key_id": "0200000000000000000000000000000000",
-				"stored_tx": "0436430c-2b02-624c-2032-570501212b00.grintx",
-				"tx_slate_id": "0436430c-2b02-624c-2032-570501212b00",
-				"tx_type": "TxSent",
-				"kernel_excess": null,
-				"kernel_lookup_min_height": null
-			}
+			"id": "0436430c-2b02-624c-2032-570501212b00"
 		}
 	}
 	# "#
@@ -847,9 +815,11 @@ pub trait OwnerRpc {
 						{
 							"excess": "000000000000000000000000000000000000000000000000000000000000000000",
 							"excess_sig": "00000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000",
-							"features": "Plain",
-							"fee": "7000000",
-							"lock_height": "0"
+							"features": {
+								"Plain": {
+									"fee": 7000000
+								}
+							}
 						}
 					],
 					"outputs": [
@@ -868,11 +838,7 @@ pub trait OwnerRpc {
 	# , 5, true, true, false, false);
 	```
 	 */
-	fn get_stored_tx(
-		&self,
-		token: Token,
-		tx: &TxLogEntry,
-	) -> Result<Option<TransactionV4>, ErrorKind>;
+	fn get_stored_tx(&self, token: Token, id: Uuid) -> Result<Option<Transaction>, ErrorKind>;
 
 	/**
 	Networked version of [Owner::scan](struct.Owner.html#method.scan).
@@ -1743,14 +1709,8 @@ where
 			.map_err(|e| e.kind())
 	}
 
-	fn get_stored_tx(
-		&self,
-		token: Token,
-		tx: &TxLogEntry,
-	) -> Result<Option<TransactionV4>, ErrorKind> {
-		Owner::get_stored_tx(self, (&token.keychain_mask).as_ref(), tx)
-			.map(|x| x.map(TransactionV4::from))
-			.map_err(|e| e.kind())
+	fn get_stored_tx(&self, token: Token, uuid: Uuid) -> Result<Option<Transaction>, ErrorKind> {
+		Owner::get_stored_tx(self, (&token.keychain_mask).as_ref(), uuid).map_err(|e| e.kind())
 	}
 
 	fn post_tx(&self, token: Token, tx: TransactionV4, fluff: bool) -> Result<(), ErrorKind> {

--- a/controller/src/command.rs
+++ b/controller/src/command.rs
@@ -803,7 +803,7 @@ where
 {
 	controller::owner_single_use(None, keychain_mask, Some(owner_api), |api, m| {
 		let (_, txs) = api.retrieve_txs(m, true, Some(args.id), None)?;
-		let stored_tx = api.get_stored_tx(m, &txs[0])?;
+		let stored_tx = api.get_stored_tx(m, txs[0].tx_slate_id.unwrap())?;
 		if stored_tx.is_none() {
 			error!(
 				"Transaction with id {} does not have transaction data. Not reposting.",

--- a/controller/tests/repost.rs
+++ b/controller/tests/repost.rs
@@ -155,7 +155,9 @@ fn file_repost_test_impl(test_dir: &'static str) -> Result<(), libwallet::Error>
 	// Now repost from cached
 	wallet::controller::owner_single_use(Some(wallet1.clone()), mask1, None, |api, m| {
 		let (_, txs) = api.retrieve_txs(m, true, None, Some(slate.id))?;
-		let stored_tx = api.get_stored_tx(m, &txs[0])?;
+		println!("TXS[0]: {:?}", txs[0]);
+		let stored_tx = api.get_stored_tx(m, txs[0].tx_slate_id.unwrap())?;
+		println!("Stored tx: {:?}", stored_tx);
 		api.post_tx(m, &stored_tx.unwrap(), false)?;
 		bh += 1;
 		Ok(())
@@ -223,7 +225,7 @@ fn file_repost_test_impl(test_dir: &'static str) -> Result<(), libwallet::Error>
 	// Now repost from cached
 	wallet::controller::owner_single_use(Some(wallet1.clone()), mask1, None, |api, m| {
 		let (_, txs) = api.retrieve_txs(m, true, None, Some(slate.id))?;
-		let stored_tx = api.get_stored_tx(m, &txs[0])?;
+		let stored_tx = api.get_stored_tx(m, txs[0].tx_slate_id.unwrap())?;
 		api.post_tx(m, &stored_tx.unwrap(), false)?;
 		bh += 1;
 		Ok(())

--- a/controller/tests/transaction.rs
+++ b/controller/tests/transaction.rs
@@ -317,7 +317,7 @@ fn basic_transaction_api(test_dir: &'static str) -> Result<(), libwallet::Error>
 			.iter()
 			.find(|t| t.tx_slate_id == Some(slate.id))
 			.unwrap();
-		let stored_tx = sender_api.get_stored_tx(m, &tx)?;
+		let stored_tx = sender_api.get_stored_tx(m, tx.tx_slate_id.unwrap())?;
 		sender_api.post_tx(m, &stored_tx.unwrap(), false)?;
 		let (_, wallet1_info) = sender_api.retrieve_summary_info(m, true, 1)?;
 		// should be mined now

--- a/impls/src/backends/lmdb.rs
+++ b/impls/src/backends/lmdb.rs
@@ -363,11 +363,8 @@ where
 		Ok(())
 	}
 
-	fn get_stored_tx(&self, entry: &TxLogEntry) -> Result<Option<Transaction>, Error> {
-		let filename = match entry.stored_tx.clone() {
-			Some(f) => f,
-			None => return Ok(None),
-		};
+	fn get_stored_tx(&self, uuid: &str) -> Result<Option<Transaction>, Error> {
+		let filename = format!("{}.grintx", uuid);
 		let path = path::Path::new(&self.data_file_dir)
 			.join(TX_SAVE_DIR)
 			.join(filename);

--- a/libwallet/src/api_impl/owner.rs
+++ b/libwallet/src/api_impl/owner.rs
@@ -648,16 +648,13 @@ where
 }
 
 /// get stored tx
-pub fn get_stored_tx<'a, T: ?Sized, C, K>(
-	w: &T,
-	entry: &TxLogEntry,
-) -> Result<Option<Transaction>, Error>
+pub fn get_stored_tx<'a, T: ?Sized, C, K>(w: &T, id: &Uuid) -> Result<Option<Transaction>, Error>
 where
 	T: WalletBackend<'a, C, K>,
 	C: NodeClient + 'a,
 	K: Keychain + 'a,
 {
-	w.get_stored_tx(entry)
+	w.get_stored_tx(&format!("{}", id))
 }
 
 /// Posts a transaction to the chain

--- a/libwallet/src/internal/tx.rs
+++ b/libwallet/src/internal/tx.rs
@@ -360,9 +360,7 @@ where
 		Some(t) => t,
 		None => return Err(ErrorKind::TransactionDoesntExist(slate.id.to_string()).into()),
 	};
-	wallet.store_tx(&format!("{}", tx.tx_slate_id.unwrap()), slate.tx_or_err()?)?;
 	let parent_key = tx.parent_key_id.clone();
-
 	{
 		let keychain = wallet.keychain(keychain_mask)?;
 		tx.kernel_excess = Some(slate.calc_excess(keychain.secp())?);
@@ -389,6 +387,8 @@ where
 			sender_signature: Some(sig),
 		})
 	}
+
+	wallet.store_tx(&format!("{}", tx.tx_slate_id.unwrap()), slate.tx_or_err()?)?;
 
 	let mut batch = wallet.batch(keychain_mask)?;
 	batch.save_tx_log_entry(tx, &parent_key)?;

--- a/libwallet/src/types.rs
+++ b/libwallet/src/types.rs
@@ -208,7 +208,7 @@ where
 	fn store_tx(&self, uuid: &str, tx: &Transaction) -> Result<(), Error>;
 
 	/// Retrieves a stored transaction from a TxLogEntry
-	fn get_stored_tx(&self, entry: &TxLogEntry) -> Result<Option<Transaction>, Error>;
+	fn get_stored_tx(&self, uuid: &str) -> Result<Option<Transaction>, Error>;
 
 	/// Create a new write batch to update or remove output data
 	fn batch<'a>(


### PR DESCRIPTION
* Modifies `get_stored_tx` to accept a UUID instead of a `TxLogEntry`
* Ensures the result is a core `Transaction` object instead of a TransactionV4

