### PR TITLE
v3.x.x - v4.0.0 wallet compatibility fixes

### DIFF
--- a/api/src/foreign_rpc.rs
+++ b/api/src/foreign_rpc.rs
@@ -180,6 +180,8 @@ pub trait ForeignRpc {
 		&self,
 		slate: VersionedSlate,
 		dest_acct_name: Option<String>,
+		//TODO: Remove post-HF3
+		message: Option<String>,
 	) -> Result<VersionedSlate, ErrorKind>;
 
 	/**
@@ -295,6 +297,8 @@ where
 		&self,
 		in_slate: VersionedSlate,
 		dest_acct_name: Option<String>,
+		//TODO: Remove post HF3
+		_message: Option<String>,
 	) -> Result<VersionedSlate, ErrorKind> {
 		let version = in_slate.version();
 		let slate_from = Slate::from(in_slate);

--- a/api/src/foreign_rpc.rs
+++ b/api/src/foreign_rpc.rs
@@ -142,6 +142,7 @@ pub trait ForeignRpc {
 					}
 				]
 			},
+			null,
 			null
 		]
 	}

--- a/controller/src/command.rs
+++ b/controller/src/command.rs
@@ -584,7 +584,7 @@ where
 			w.w2n_client().get_chain_tip()?.0
 		};
 		// TODO: Floonet HF4
-		if cur_height < 786240 && !a.output_v4_slate {
+		if cur_height < 786240 && !a.output_v4_slate && !a.bin {
 			a.issue_args.target_slate_version = Some(3);
 		}
 		a

--- a/impls/src/adapters/file.rs
+++ b/impls/src/adapters/file.rs
@@ -43,11 +43,22 @@ impl SlatePutter for PathToSlate {
 				// which can be read by v3.x wallets
 				let v4_slate = SlateV4::from(slate.clone());
 				let mut v3_slate = SlateV3::try_from(&v4_slate)?;
-				// if responding to an invoice, manually fill in participant id to 0
+				// Fill in V3 participant IDs according to state
 				if slate.state == SlateState::Invoice2 {
 					for mut e in v3_slate.participant_data.iter_mut() {
 						if Some(e.public_blind_excess.clone()) == slate.participant_id {
+							e.id = 0;
+						} else {
 							e.id = 1;
+						}
+					}
+				}
+				if slate.state == SlateState::Standard2 {
+					for mut e in v3_slate.participant_data.iter_mut() {
+						if Some(e.public_blind_excess.clone()) == slate.participant_id {
+							e.id = 1;
+						} else {
+							e.id = 0;
 						}
 					}
 				}

--- a/impls/src/adapters/file.rs
+++ b/impls/src/adapters/file.rs
@@ -17,7 +17,11 @@ use std::fs::File;
 use std::io::{Read, Write};
 
 use crate::client_utils::byte_ser;
-use crate::libwallet::{Error, ErrorKind, Slate, SlateVersion, VersionedBinSlate, VersionedSlate};
+use crate::libwallet::slate_versions::v3::SlateV3;
+use crate::libwallet::slate_versions::v4::SlateV4;
+use crate::libwallet::{
+	Error, ErrorKind, Slate, SlateState, SlateVersion, VersionedBinSlate, VersionedSlate,
+};
 use crate::{SlateGetter, SlatePutter};
 use std::convert::TryFrom;
 use std::path::PathBuf;
@@ -29,20 +33,28 @@ impl SlatePutter for PathToSlate {
 	fn put_tx(&self, slate: &Slate, as_bin: bool) -> Result<(), Error> {
 		let mut pub_tx = File::create(&self.0)?;
 		// TODO:
-		// * Will need to set particpant id to 1 manually if this is invoice
-		// * Set slate height manually
+		// * Will need to set participant id to 1 manually if this is invoice
 		// * Reconcile unknown slate states from V3
 		let _r: crate::adapters::Reminder;
 		let out_slate = {
-			// TODO: This will need to be filled with any incompatibilities in the V4 Slate
-			if false {
-				warn!("Transaction contains features that require grin-wallet 4.0.0 or later");
-				warn!("Please ensure the other party is running grin-wallet v4.0.0 or later before sending");
-				VersionedSlate::into_version(slate.clone(), SlateVersion::V4)?
+			// TODO: Remove post HF3
+			if slate.version_info.version == 2 || slate.version_info.version == 3 {
+				// if the slate we read in in V3 or 2 (holdover from 3.0.0), output a slate V3,
+				// which can be read by v3.x wallets
+				let v4_slate = SlateV4::from(slate.clone());
+				let mut v3_slate = SlateV3::try_from(&v4_slate)?;
+				// if responding to an invoice, manually fill in participant id to 0
+				if slate.state == SlateState::Invoice2 {
+					for mut e in v3_slate.participant_data.iter_mut() {
+						if Some(e.public_blind_excess.clone()) == slate.participant_id {
+							e.id = 1;
+						}
+					}
+				}
+				v3_slate.version_info.version = 3;
+				VersionedSlate::V3(v3_slate)
 			} else {
-				let mut s = slate.clone();
-				s.version_info.version = 4;
-				VersionedSlate::into_version(s, SlateVersion::V4)?
+				VersionedSlate::into_version(slate.clone(), SlateVersion::V4)?
 			}
 		};
 		if as_bin {

--- a/impls/src/adapters/file.rs
+++ b/impls/src/adapters/file.rs
@@ -33,9 +33,6 @@ impl SlatePutter for PathToSlate {
 	fn put_tx(&self, slate: &Slate, as_bin: bool) -> Result<(), Error> {
 		let mut pub_tx = File::create(&self.0)?;
 		// TODO:
-		// * Will need to set participant id to 1 manually if this is invoice
-		// * Reconcile unknown slate states from V3
-		let _r: crate::adapters::Reminder;
 		let out_slate = {
 			// TODO: Remove post HF3
 			if slate.version_info.version == 2 || slate.version_info.version == 3 {

--- a/impls/src/adapters/file.rs
+++ b/impls/src/adapters/file.rs
@@ -44,7 +44,25 @@ impl SlatePutter for PathToSlate {
 				let v4_slate = SlateV4::from(slate.clone());
 				let mut v3_slate = SlateV3::try_from(&v4_slate)?;
 				// Fill in V3 participant IDs according to state
+				if slate.state == SlateState::Invoice1 {
+					for mut e in v3_slate.participant_data.iter_mut() {
+						if Some(e.public_blind_excess.clone()) == slate.participant_id {
+							e.id = 1;
+						} else {
+							e.id = 0;
+						}
+					}
+				}
 				if slate.state == SlateState::Invoice2 {
+					for mut e in v3_slate.participant_data.iter_mut() {
+						if Some(e.public_blind_excess.clone()) == slate.participant_id {
+							e.id = 0;
+						} else {
+							e.id = 1;
+						}
+					}
+				}
+				if slate.state == SlateState::Standard1 {
 					for mut e in v3_slate.participant_data.iter_mut() {
 						if Some(e.public_blind_excess.clone()) == slate.participant_id {
 							e.id = 0;

--- a/impls/src/adapters/http.rs
+++ b/impls/src/adapters/http.rs
@@ -180,7 +180,6 @@ impl SlateSender for HttpSlateSender {
 			SlateVersion::V4 => VersionedSlate::into_version(slate.clone(), SlateVersion::V4)?,
 			SlateVersion::V3 => {
 				let mut slate = slate.clone();
-				let _r: crate::adapters::Reminder;
 				//TODO: Fill out with Slate V4 incompatibilities
 				// * Will need to set particpant id to 1 manually if this is invoice
 				// * Set slate height manually

--- a/impls/src/adapters/mod.rs
+++ b/impls/src/adapters/mod.rs
@@ -25,13 +25,6 @@ use crate::libwallet::{Error, ErrorKind, Slate};
 use crate::tor::config::complete_tor_address;
 use crate::util::ZeroingString;
 
-/// Little SlateV4 reminder warning helper
-#[deprecated(
-	since = "3.0.0",
-	note = "Remember to handle SlateV4 incompatibilities here"
-)]
-pub struct Reminder;
-
 /// Sends transactions to a corresponding SlateReceiver
 pub trait SlateSender {
 	/// Send a transaction slate to another listening wallet and return result

--- a/libwallet/src/api_impl/owner.rs
+++ b/libwallet/src/api_impl/owner.rs
@@ -325,6 +325,10 @@ where
 		args.ttl_blocks,
 	)?;
 
+	if let Some(v) = args.target_slate_version {
+		slate.version_info.version = v;
+	};
+
 	// if we just want to estimate, don't save a context, just send the results
 	// back
 	if let Some(true) = args.estimate_only {
@@ -388,7 +392,9 @@ where
 		batch.commit()?;
 	}
 
-	slate.compact()?;
+	if slate.is_compact() {
+		slate.compact()?;
+	}
 
 	Ok(slate)
 }
@@ -428,6 +434,10 @@ where
 		use_test_rng,
 	)?;
 
+	if let Some(v) = args.target_slate_version {
+		slate.version_info.version = v;
+	};
+
 	context.offset = Some(slate.tx_or_err()?.offset.clone());
 
 	// Save the aggsig context in our DB for when we
@@ -438,7 +448,9 @@ where
 		batch.commit()?;
 	}
 
-	slate.compact()?;
+	if slate.is_compact() {
+		slate.compact()?;
+	}
 
 	Ok(slate)
 }

--- a/libwallet/src/api_impl/owner.rs
+++ b/libwallet/src/api_impl/owner.rs
@@ -384,6 +384,9 @@ where
 
 	context.offset = Some(slate.tx_or_err()?.offset.clone());
 
+	//TODO: Remove after HF3
+	slate.offset = slate.tx_or_err()?.offset.clone();
+
 	// Save the aggsig context in our DB for when we
 	// recieve the transaction back
 	{

--- a/libwallet/src/api_impl/owner.rs
+++ b/libwallet/src/api_impl/owner.rs
@@ -443,6 +443,9 @@ where
 
 	context.offset = Some(slate.tx_or_err()?.offset.clone());
 
+	//TODO: Remove after HF3
+	slate.offset = slate.tx_or_err()?.offset.clone();
+
 	// Save the aggsig context in our DB for when we
 	// recieve the transaction back
 	{

--- a/libwallet/src/internal/tx.rs
+++ b/libwallet/src/internal/tx.rs
@@ -281,6 +281,7 @@ where
 	slate.fill_round_2(&wallet.keychain(keychain_mask)?, &sec_key, &sec_nonce)?;
 
 	// Final transaction can be built by anyone at this stage
+	trace!("Slate to finalize is: {}", slate);
 	slate.finalize(&wallet.keychain(keychain_mask)?)?;
 	Ok(())
 }

--- a/libwallet/src/slate.rs
+++ b/libwallet/src/slate.rs
@@ -123,6 +123,10 @@ pub struct Slate {
 	pub participant_data: Vec<ParticipantData>,
 	/// Payment Proof
 	pub payment_proof: Option<PaymentInfo>,
+	//TODO: Remove post HF3
+	/// participant ID, only stored for compatibility with V3 slates
+	/// not serialized anywhere
+	pub participant_id: Option<PublicKey>,
 }
 
 impl fmt::Display for Slate {
@@ -242,6 +246,7 @@ impl Slate {
 				block_header_version: GRIN_BLOCK_HEADER_VERSION,
 			},
 			payment_proof: None,
+			participant_id: None,
 		}
 	}
 	/// Removes any signature data that isn't mine, for compacting
@@ -467,6 +472,7 @@ impl Slate {
 			public_nonce: pub_nonce,
 			part_sig: part_sig,
 		});
+		self.participant_id = Some(pub_key);
 		Ok(())
 	}
 
@@ -683,6 +689,7 @@ impl From<Slate> for SlateV4 {
 			participant_data,
 			version_info,
 			payment_proof,
+			participant_id: _participant_id,
 		} = slate.clone();
 		let participant_data = map_vec!(participant_data, |data| ParticipantDataV4::from(data));
 		let ver = VersionCompatInfoV4::from(&version_info);
@@ -723,6 +730,7 @@ impl From<&Slate> for SlateV4 {
 			participant_data,
 			version_info,
 			payment_proof,
+			participant_id: _participant_id,
 		} = slate;
 		let num_parts = *num_participants;
 		let id = *id;
@@ -974,6 +982,7 @@ impl From<SlateV4> for Slate {
 			participant_data,
 			version_info,
 			payment_proof,
+			participant_id: None,
 		}
 	}
 }

--- a/libwallet/src/slate.rs
+++ b/libwallet/src/slate.rs
@@ -210,7 +210,7 @@ impl Slate {
 	pub fn upgrade(v_slate: VersionedSlate) -> Result<Slate, Error> {
 		let v4: SlateV4 = match v_slate {
 			VersionedSlate::V4(s) => s,
-			VersionedSlate::V3(_) => return Err(ErrorKind::SlateVersion(3).into()),
+			VersionedSlate::V3(s) => SlateV4::from(s),
 		};
 		Ok(v4.into())
 	}
@@ -421,6 +421,7 @@ impl Slate {
 	fn part_sigs(&self) -> Vec<&Signature> {
 		self.participant_data
 			.iter()
+			.filter(|p| p.part_sig.is_some())
 			.map(|p| p.part_sig.as_ref().unwrap())
 			.collect()
 	}
@@ -624,14 +625,21 @@ impl Slate {
 
 		// confirm the kernel verifies successfully before proceeding
 		debug!("Validating final transaction");
+		trace!(
+			"Final tx: {}",
+			serde_json::to_string_pretty(final_tx).unwrap()
+		);
 		final_tx.kernels()[0].verify()?;
 
 		// confirm the overall transaction is valid (including the updated kernel)
 		// accounting for tx weight limits
 		let verifier_cache = Arc::new(RwLock::new(LruVerifierCache::new()));
-		final_tx.validate(Weighting::AsTransaction, verifier_cache)?;
-
-		Ok(())
+		if let Err(e) = final_tx.validate(Weighting::AsTransaction, verifier_cache) {
+			error!("Error with final tx validation: {}", e);
+			Err(e.into())
+		} else {
+			Ok(())
+		}
 	}
 }
 

--- a/libwallet/src/slate.rs
+++ b/libwallet/src/slate.rs
@@ -195,6 +195,7 @@ impl Slate {
 	/// This info must be stored in the context for repopulation later
 	pub fn compact(&mut self) -> Result<(), Error> {
 		self.tx = None;
+		self.offset = BlindingFactor::zero();
 		Ok(())
 	}
 

--- a/libwallet/src/slate_versions/v3.rs
+++ b/libwallet/src/slate_versions/v3.rs
@@ -58,6 +58,7 @@ pub struct SlateV3 {
 	/// TTL, the block height at which wallets
 	/// should refuse to process the transaction and unlock all
 	/// associated outputs
+	#[serde(default = "default_ttl_none")]
 	#[serde(with = "secp_ser::opt_string_or_u64")]
 	pub ttl_cutoff_height: Option<u64>,
 	/// Participant data, each participant in the transaction will
@@ -70,6 +71,10 @@ pub struct SlateV3 {
 }
 
 fn default_payment_none() -> Option<PaymentInfoV3> {
+	None
+}
+
+fn default_ttl_none() -> Option<u64> {
 	None
 }
 

--- a/libwallet/src/slate_versions/v4.rs
+++ b/libwallet/src/slate_versions/v4.rs
@@ -709,12 +709,8 @@ impl From<&SlateV4> for Option<TransactionV3> {
 		};
 		let mut out_fee = 0;
 		let mut out_lock_height = 0;
-		let txv4 = TransactionV3 {
-			offset: if slate.offset != BlindingFactor::zero() {
-				tx.offset
-			} else {
-				slate.offset.clone()
-			},
+		let txv3 = TransactionV3 {
+			offset: tx.offset,
 			body: TransactionBodyV3 {
 				inputs: tx
 					.body
@@ -760,7 +756,7 @@ impl From<&SlateV4> for Option<TransactionV3> {
 					.collect(),
 			},
 		};
-		Some(txv4)
+		Some(txv3)
 	}
 }
 

--- a/src/bin/grin-wallet.yml
+++ b/src/bin/grin-wallet.yml
@@ -158,6 +158,11 @@ subcommands:
             short: b
             long: ttl_blocks
             takes_value: true
+        #TODO: Remove HF3
+        - v4:
+            help: Output a V4 slate prior to HF3 block
+            long: v4
+            takes_value: false
   - receive:
       about: Processes a transaction file to accept a transfer from a sender
       args:

--- a/src/bin/grin-wallet.yml
+++ b/src/bin/grin-wallet.yml
@@ -207,6 +207,11 @@ subcommands:
             help: Whether to output file as binary
             short: b
             long: bin
+        #TODO: Remove HF3
+        - v4:
+            help: Output a V4 slate prior to HF3 block
+            long: v4
+            takes_value: false
   - pay:
       about: Spend coins to pay the provided invoice transaction
       args:

--- a/src/cmd/wallet_args.rs
+++ b/src/cmd/wallet_args.rs
@@ -459,6 +459,9 @@ pub fn parse_send_args(args: &ArgMatches) -> Result<command::SendArgs, ParseErro
 	// max_outputs
 	let max_outputs = 500;
 
+	// TODO: Remove HF3
+	let output_v4_slate = args.is_present("v4");
+
 	// target slate version to create/send
 	let target_slate_version = {
 		match args.is_present("slate_version") {
@@ -506,6 +509,7 @@ pub fn parse_send_args(args: &ArgMatches) -> Result<command::SendArgs, ParseErro
 		payment_proof_address,
 		ttl_blocks,
 		target_slate_version: target_slate_version,
+		output_v4_slate,
 	})
 }
 

--- a/src/cmd/wallet_args.rs
+++ b/src/cmd/wallet_args.rs
@@ -567,6 +567,10 @@ pub fn parse_issue_invoice_args(
 		}
 	};
 	let bin = args.is_present("bin");
+
+	// TODO: Remove HF3
+	let output_v4_slate = args.is_present("v4");
+
 	// target slate version to create
 	let target_slate_version = {
 		match args.is_present("slate_version") {
@@ -582,6 +586,7 @@ pub fn parse_issue_invoice_args(
 	Ok(command::IssueInvoiceArgs {
 		dest: dest.into(),
 		bin,
+		output_v4_slate,
 		issue_args: IssueInvoiceTxArgs {
 			dest_acct_name: None,
 			amount,


### PR DESCRIPTION
This PR should cover whatever changes are necessary to ensure communication with V3 wallets continues to work for the period between the release of v4.0.0 and the date of HF3. Note that quite a bit of this will be temporary code, to be removed shortly after HF3.