### PR TITLE
Remove lock_height, add kernel_features + arguments

### DIFF
--- a/controller/tests/payment_proofs.rs
+++ b/controller/tests/payment_proofs.rs
@@ -111,9 +111,9 @@ fn payment_proofs_test_impl(test_dir: &'static str) -> Result<(), libwallet::Err
 			slate_i.payment_proof.as_ref().unwrap().sender_address
 		);
 
-		// Check we are creating a tx with the expected lock_height of 0.
+		// Check we are creating a tx with kernel features 0
 		// We will check this produces a Plain kernel later.
-		assert_eq!(0, slate.lock_height);
+		assert_eq!(0, slate.kernel_features);
 
 		slate = client1.send_tx_slate_direct("wallet2", &slate_i)?;
 		sender_api.tx_lock_outputs(m, &slate)?;

--- a/controller/tests/transaction.rs
+++ b/controller/tests/transaction.rs
@@ -115,7 +115,7 @@ fn basic_transaction_api(test_dir: &'static str) -> Result<(), libwallet::Error>
 
 		// Check we are creating a tx with the expected lock_height of 0.
 		// We will check this produces a Plain kernel later.
-		assert_eq!(0, slate.lock_height);
+		assert_eq!(0, slate.kernel_features);
 
 		slate = client1.send_tx_slate_direct("wallet2", &slate_i)?;
 		assert_eq!(slate.state, SlateState::Standard2);

--- a/libwallet/src/error.rs
+++ b/libwallet/src/error.rs
@@ -262,6 +262,14 @@ pub enum ErrorKind {
 	#[fail(display = "Transaction Expired")]
 	TransactionExpired,
 
+	/// Kernel features args don't exist
+	#[fail(display = "Kernel Features Arg {} missing", _0)]
+	KernelFeaturesMissing(String),
+
+	/// Unknown Kernel Feature
+	#[fail(display = "Unknown Kernel Feature: {}", _0)]
+	UnknownKernelFeatures(u8),
+
 	/// Other
 	#[fail(display = "Generic error: {}", _0)]
 	GenericError(String),

--- a/libwallet/src/internal/tx.rs
+++ b/libwallet/src/internal/tx.rs
@@ -81,9 +81,9 @@ where
 		slate.version_info.block_header_version = 3;
 	}
 
-	// Set the lock_height explicitly to 0 here.
+	// Set the features explicitly to 0 here.
 	// This will generate a Plain kernel (rather than a HeightLocked kernel).
-	slate.lock_height = 0;
+	slate.kernel_features = 0;
 
 	Ok(slate)
 }


### PR DESCRIPTION
This removes `lock_height` and adds a kernel features flag + kernel arguments struct. See the Compact slates RFC for details.