### PR TITLE
Slatepack Implementation, Pt 1

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2,9 +2,9 @@
 # It is not intended for manual editing.
 [[package]]
 name = "addr2line"
-version = "0.12.0"
+version = "0.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "456d75cbb82da1ad150c8a9d97285ffcd21c9931dcb11e995903e7d75141b38b"
+checksum = "a49806b9dadc843c61e7c97e72490ad7f7220ae249012fbda9ad0609457c0543"
 dependencies = [
  "gimli",
 ]
@@ -99,9 +99,9 @@ version = "0.1.31"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "26c4f3195085c36ea8d24d32b2f828d23296a9370a28aa39d111f6f16bef9f3b"
 dependencies = [
- "proc-macro2 1.0.12",
- "quote 1.0.5",
- "syn 1.0.21",
+ "proc-macro2 1.0.13",
+ "quote 1.0.6",
+ "syn 1.0.22",
 ]
 
 [[package]]
@@ -181,8 +181,8 @@ dependencies = [
  "lazycell",
  "log",
  "peeking_take_while",
- "proc-macro2 1.0.12",
- "quote 1.0.5",
+ "proc-macro2 1.0.13",
+ "quote 1.0.6",
  "regex",
  "rustc-hash",
  "shlex",
@@ -266,6 +266,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "bs58"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "476e9cd489f9e121e02ffa6014a8ef220ecb15c05ed23fc34cca13925dc283fb"
+
+[[package]]
 name = "built"
 version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -319,9 +325,9 @@ checksum = "130aac562c0dd69c56b3b1cc8ffd2e17be31d0b6c25b61c96b76231aa23e39e1"
 
 [[package]]
 name = "cc"
-version = "1.0.52"
+version = "1.0.53"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c3d87b23d6a92cd03af510a5ade527033f6aa6fa92161e2d5863a907d4c5e31d"
+checksum = "404b1fe4f65288577753b17e3b36a04596ee784493ec249bf81c7f2d2acd751c"
 dependencies = [
  "jobserver",
 ]
@@ -744,9 +750,9 @@ version = "0.1.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "aa4da3c766cd7a0db8242e326e9e4e081edd567072893ed320008189715366a4"
 dependencies = [
- "proc-macro2 1.0.12",
- "quote 1.0.5",
- "syn 1.0.21",
+ "proc-macro2 1.0.13",
+ "quote 1.0.6",
+ "syn 1.0.22",
  "synstructure 0.12.3",
 ]
 
@@ -770,9 +776,9 @@ dependencies = [
 
 [[package]]
 name = "fnv"
-version = "1.0.6"
+version = "1.0.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2fad85553e09a6f881f739c29f0b00b0f01357c743266d478b68951ce23285f3"
+checksum = "3f9eec918d3f24069decb9af1554cad7c880e2da24a9afd88aca000531ab82c1"
 
 [[package]]
 name = "foreign-types"
@@ -872,9 +878,9 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d0b5a30a4328ab5473878237c447333c093297bded83a4983d10f4deea240d39"
 dependencies = [
  "proc-macro-hack",
- "proc-macro2 1.0.12",
- "quote 1.0.5",
- "syn 1.0.21",
+ "proc-macro2 1.0.13",
+ "quote 1.0.6",
+ "syn 1.0.22",
 ]
 
 [[package]]
@@ -975,7 +981,7 @@ checksum = "9b919933a397b79c37e33b77bb2aa3dc8eb6e165ad809e58ff75bc7db2e34574"
 [[package]]
 name = "grin_api"
 version = "4.0.0-alpha.1"
-source = "git+https://github.com/mimblewimble/grin#2c621115612013a68de7bd973a42ec88ae5f44fc"
+source = "git+https://github.com/mimblewimble/grin#93f5de3d2957f6f30dde8ae8f588efa0754c5ca3"
 dependencies = [
  "bytes 0.5.4",
  "easy-jsonrpc-mw",
@@ -1001,14 +1007,14 @@ dependencies = [
  "serde_derive",
  "serde_json",
  "tokio",
- "tokio-rustls 0.13.0",
+ "tokio-rustls 0.13.1",
  "url 1.7.2",
 ]
 
 [[package]]
 name = "grin_chain"
 version = "4.0.0-alpha.1"
-source = "git+https://github.com/mimblewimble/grin#2c621115612013a68de7bd973a42ec88ae5f44fc"
+source = "git+https://github.com/mimblewimble/grin#93f5de3d2957f6f30dde8ae8f588efa0754c5ca3"
 dependencies = [
  "bit-vec",
  "bitflags 1.2.1",
@@ -1031,7 +1037,7 @@ dependencies = [
 [[package]]
 name = "grin_core"
 version = "4.0.0-alpha.1"
-source = "git+https://github.com/mimblewimble/grin#2c621115612013a68de7bd973a42ec88ae5f44fc"
+source = "git+https://github.com/mimblewimble/grin#93f5de3d2957f6f30dde8ae8f588efa0754c5ca3"
 dependencies = [
  "blake2-rfc",
  "byteorder",
@@ -1057,7 +1063,7 @@ dependencies = [
 [[package]]
 name = "grin_keychain"
 version = "4.0.0-alpha.1"
-source = "git+https://github.com/mimblewimble/grin#2c621115612013a68de7bd973a42ec88ae5f44fc"
+source = "git+https://github.com/mimblewimble/grin#93f5de3d2957f6f30dde8ae8f588efa0754c5ca3"
 dependencies = [
  "blake2-rfc",
  "byteorder",
@@ -1079,7 +1085,7 @@ dependencies = [
 [[package]]
 name = "grin_p2p"
 version = "4.0.0-alpha.1"
-source = "git+https://github.com/mimblewimble/grin#2c621115612013a68de7bd973a42ec88ae5f44fc"
+source = "git+https://github.com/mimblewimble/grin#93f5de3d2957f6f30dde8ae8f588efa0754c5ca3"
 dependencies = [
  "bitflags 1.2.1",
  "chrono",
@@ -1100,7 +1106,7 @@ dependencies = [
 [[package]]
 name = "grin_pool"
 version = "4.0.0-alpha.1"
-source = "git+https://github.com/mimblewimble/grin#2c621115612013a68de7bd973a42ec88ae5f44fc"
+source = "git+https://github.com/mimblewimble/grin#93f5de3d2957f6f30dde8ae8f588efa0754c5ca3"
 dependencies = [
  "blake2-rfc",
  "chrono",
@@ -1134,7 +1140,7 @@ dependencies = [
 [[package]]
 name = "grin_store"
 version = "4.0.0-alpha.1"
-source = "git+https://github.com/mimblewimble/grin#2c621115612013a68de7bd973a42ec88ae5f44fc"
+source = "git+https://github.com/mimblewimble/grin#93f5de3d2957f6f30dde8ae8f588efa0754c5ca3"
 dependencies = [
  "byteorder",
  "croaring-mw",
@@ -1154,7 +1160,7 @@ dependencies = [
 [[package]]
 name = "grin_util"
 version = "4.0.0-alpha.1"
-source = "git+https://github.com/mimblewimble/grin#2c621115612013a68de7bd973a42ec88ae5f44fc"
+source = "git+https://github.com/mimblewimble/grin#93f5de3d2957f6f30dde8ae8f588efa0754c5ca3"
 dependencies = [
  "backtrace",
  "base64 0.9.3",
@@ -1306,6 +1312,7 @@ version = "4.0.0-alpha.1"
 dependencies = [
  "base64 0.9.3",
  "blake2-rfc",
+ "bs58",
  "byteorder",
  "chrono",
  "ed25519-dalek",
@@ -1316,9 +1323,11 @@ dependencies = [
  "lazy_static",
  "log",
  "rand 0.5.6",
+ "regex",
  "serde",
  "serde_derive",
  "serde_json",
+ "sha2 0.8.1",
  "strum",
  "strum_macros",
  "uuid",
@@ -1373,9 +1382,9 @@ dependencies = [
 
 [[package]]
 name = "hermit-abi"
-version = "0.1.12"
+version = "0.1.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "61565ff7aaace3525556587bd2dc31d4a07071957be715e63ce7b1eccf51a8f4"
+checksum = "91780f809e750b0a89f5544be56617ff6b1227ee485bcb06ebe10cdf89bd3b71"
 dependencies = [
  "libc",
 ]
@@ -1474,7 +1483,7 @@ dependencies = [
  "rustls 0.16.0",
  "rustls-native-certs 0.1.0",
  "tokio",
- "tokio-rustls 0.12.2",
+ "tokio-rustls 0.12.3",
  "webpki",
 ]
 
@@ -1492,7 +1501,7 @@ dependencies = [
  "rustls 0.17.0",
  "rustls-native-certs 0.3.0",
  "tokio",
- "tokio-rustls 0.13.0",
+ "tokio-rustls 0.13.1",
  "webpki",
 ]
 
@@ -2303,22 +2312,22 @@ dependencies = [
 
 [[package]]
 name = "pin-project"
-version = "0.4.16"
+version = "0.4.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "81d480cb4e89522ccda96d0eed9af94180b7a5f93fb28f66e1fd7d68431663d1"
+checksum = "edc93aeee735e60ecb40cf740eb319ff23eab1c5748abfdb5c180e4ce49f7791"
 dependencies = [
  "pin-project-internal",
 ]
 
 [[package]]
 name = "pin-project-internal"
-version = "0.4.16"
+version = "0.4.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a82996f11efccb19b685b14b5df818de31c1edcee3daa256ab5775dd98e72feb"
+checksum = "e58db2081ba5b4c93bd6be09c40fd36cb9193a8336c384f3b40012e531aa7e40"
 dependencies = [
- "proc-macro2 1.0.12",
- "quote 1.0.5",
- "syn 1.0.21",
+ "proc-macro2 1.0.13",
+ "quote 1.0.6",
+ "syn 1.0.22",
 ]
 
 [[package]]
@@ -2347,9 +2356,9 @@ checksum = "780fb4b6698bbf9cf2444ea5d22411cef2953f0824b98f33cf454ec5615645bd"
 
 [[package]]
 name = "ppv-lite86"
-version = "0.2.6"
+version = "0.2.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "74490b50b9fbe561ac330df47c08f3f33073d2d00c150f719147d7c54522fa1b"
+checksum = "237a5ed80e274dbc66f86bd59c1e25edc039660be53194b5fe0a482e0f2612ea"
 
 [[package]]
 name = "pretty_assertions"
@@ -2398,9 +2407,9 @@ dependencies = [
 
 [[package]]
 name = "proc-macro2"
-version = "1.0.12"
+version = "1.0.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8872cf6f48eee44265156c111456a700ab3483686b3f96df4cf5481c89157319"
+checksum = "53f5ffe53a6b28e37c9c1ce74893477864d64f74778a93a4beb43c8fa167f639"
 dependencies = [
  "unicode-xid 0.2.0",
 ]
@@ -2422,11 +2431,11 @@ dependencies = [
 
 [[package]]
 name = "quote"
-version = "1.0.5"
+version = "1.0.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "42934bc9c8ab0d3b273a16d8551c8f0fcff46be73276ca083ec2414c15c4ba5e"
+checksum = "54a21852a652ad6f610c9510194f398ff6f8692e334fd1145fed931f7fbe44ea"
 dependencies = [
- "proc-macro2 1.0.12",
+ "proc-macro2 1.0.13",
 ]
 
 [[package]]
@@ -2976,9 +2985,9 @@ version = "1.0.110"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "818fbf6bfa9a42d3bfcaca148547aa00c7b915bec71d1757aa2d44ca68771984"
 dependencies = [
- "proc-macro2 1.0.12",
- "quote 1.0.5",
- "syn 1.0.21",
+ "proc-macro2 1.0.13",
+ "quote 1.0.6",
+ "syn 1.0.22",
 ]
 
 [[package]]
@@ -3166,12 +3175,12 @@ dependencies = [
 
 [[package]]
 name = "syn"
-version = "1.0.21"
+version = "1.0.22"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4696caa4048ac7ce2bcd2e484b3cef88c1004e41b8e945a277e2c25dc0b72060"
+checksum = "1425de3c33b0941002740a420b1a906a350b88d08b82b2c8a01035a3f9447bac"
 dependencies = [
- "proc-macro2 1.0.12",
- "quote 1.0.5",
+ "proc-macro2 1.0.13",
+ "quote 1.0.6",
  "unicode-xid 0.2.0",
 ]
 
@@ -3193,9 +3202,9 @@ version = "0.12.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "67656ea1dc1b41b1451851562ea232ec2e5a80242139f7e679ceccfb5d61f545"
 dependencies = [
- "proc-macro2 1.0.12",
- "quote 1.0.5",
- "syn 1.0.21",
+ "proc-macro2 1.0.13",
+ "quote 1.0.6",
+ "syn 1.0.22",
  "unicode-xid 0.2.0",
 ]
 
@@ -3269,22 +3278,22 @@ dependencies = [
 
 [[package]]
 name = "thiserror"
-version = "1.0.17"
+version = "1.0.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "467e5ff447618a916519a4e0d62772ab14f434897f3d63f05d8700ef1e9b22c1"
+checksum = "5976891d6950b4f68477850b5b9e5aa64d955961466f9e174363f573e54e8ca7"
 dependencies = [
  "thiserror-impl",
 ]
 
 [[package]]
 name = "thiserror-impl"
-version = "1.0.17"
+version = "1.0.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e63c1091225b9834089b429bc4a2e01223470e3183e891582909e9d1c4cb55d9"
+checksum = "ab81dbd1cd69cd2ce22ecfbdd3bdb73334ba25350649408cc6c085f46d89573d"
 dependencies = [
- "proc-macro2 1.0.12",
- "quote 1.0.5",
- "syn 1.0.21",
+ "proc-macro2 1.0.13",
+ "quote 1.0.6",
+ "syn 1.0.22",
 ]
 
 [[package]]
@@ -3366,16 +3375,16 @@ version = "0.2.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f0c3acc6aa564495a0f2e1d59fab677cd7f81a19994cfc7f3ad0e64301560389"
 dependencies = [
- "proc-macro2 1.0.12",
- "quote 1.0.5",
- "syn 1.0.21",
+ "proc-macro2 1.0.13",
+ "quote 1.0.6",
+ "syn 1.0.22",
 ]
 
 [[package]]
 name = "tokio-rustls"
-version = "0.12.2"
+version = "0.12.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "141afec0978abae6573065a48882c6bae44c5cc61db9b511ac4abf6a09bfd9cc"
+checksum = "3068d891551949b37681724d6b73666787cc63fa8e255c812a41d2513aff9775"
 dependencies = [
  "futures-core",
  "rustls 0.16.0",
@@ -3385,9 +3394,9 @@ dependencies = [
 
 [[package]]
 name = "tokio-rustls"
-version = "0.13.0"
+version = "0.13.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4adb8b3e5f86b707f1b54e7c15b6de52617a823608ccda98a15d3a24222f265a"
+checksum = "15cb62a0d2770787abc96e99c1cd98fcf17f94959f3af63ca85bdfb203f051b4"
 dependencies = [
  "futures-core",
  "rustls 0.17.0",
@@ -3635,9 +3644,9 @@ dependencies = [
  "bumpalo",
  "lazy_static",
  "log",
- "proc-macro2 1.0.12",
- "quote 1.0.5",
- "syn 1.0.21",
+ "proc-macro2 1.0.13",
+ "quote 1.0.6",
+ "syn 1.0.22",
  "wasm-bindgen-shared",
 ]
 
@@ -3647,7 +3656,7 @@ version = "0.2.62"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2cd85aa2c579e8892442954685f0d801f9129de24fa2136b2c6a539c76b65776"
 dependencies = [
- "quote 1.0.5",
+ "quote 1.0.6",
  "wasm-bindgen-macro-support",
 ]
 
@@ -3657,9 +3666,9 @@ version = "0.2.62"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8eb197bd3a47553334907ffd2f16507b4f4f01bbec3ac921a7719e0decdfe72a"
 dependencies = [
- "proc-macro2 1.0.12",
- "quote 1.0.5",
- "syn 1.0.21",
+ "proc-macro2 1.0.13",
+ "quote 1.0.6",
+ "syn 1.0.22",
  "wasm-bindgen-backend",
  "wasm-bindgen-shared",
 ]

--- a/controller/tests/no_change.rs
+++ b/controller/tests/no_change.rs
@@ -93,7 +93,6 @@ fn no_change_test_impl(test_dir: &'static str) -> Result<(), libwallet::Error> {
 		api.tx_lock_outputs(m, &slate)?;
 		slate = api.finalize_tx(m, &slate)?;
 		println!("Posted Slate: {:?}", slate);
-		println!("Posted TX: {}", slate);
 		stored_excess = Some(slate.tx.as_ref().unwrap().body.kernels[0].excess);
 		api.post_tx(m, &slate, false)?;
 		Ok(())

--- a/controller/tests/slatepack.rs
+++ b/controller/tests/slatepack.rs
@@ -1,0 +1,360 @@
+// Copyright 2019 The Grin Developers
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+//! Test a wallet file send/recieve
+#[macro_use]
+extern crate log;
+extern crate grin_wallet_controller as wallet;
+extern crate grin_wallet_impls as impls;
+
+use grin_wallet_libwallet as libwallet;
+use grin_wallet_util::grin_core as core;
+use grin_wallet_util::OnionV3Address;
+
+use impls::test_framework::{self, LocalWalletClient};
+use impls::{PathToSlatepack, PathToSlatepackArmored, SlateGetter as _, SlatePutter as _};
+use std::sync::atomic::Ordering;
+use std::thread;
+use std::time::Duration;
+
+use grin_wallet_libwallet::{InitTxArgs, IssueInvoiceTxArgs, Slate};
+
+#[macro_use]
+mod common;
+use common::{clean_output_dir, create_wallet_proxy, setup};
+
+fn output_slatepack(
+	slate: &Slate,
+	file: &str,
+	armored: bool,
+	use_bin: bool,
+) -> Result<(), libwallet::Error> {
+	if armored {
+		let file = format!("{}.armored", file);
+		PathToSlatepackArmored((&file).into()).put_tx(&slate, use_bin)
+	} else {
+		PathToSlatepack((file).into()).put_tx(&slate, use_bin)
+	}
+}
+fn slate_from_packed(file: &str, armored: bool) -> Result<Slate, libwallet::Error> {
+	if armored {
+		let file = format!("{}.armored", file);
+		Ok(PathToSlatepackArmored((file).into()).get_tx()?.0)
+	} else {
+		Ok(PathToSlatepack((file).into()).get_tx()?.0)
+	}
+}
+
+/// self send impl
+fn slatepack_exchange_test_impl(
+	test_dir: &'static str,
+	use_bin: bool,
+	use_armored: bool,
+) -> Result<(), libwallet::Error> {
+	// Create a new proxy to simulate server and wallet responses
+	let mut wallet_proxy = create_wallet_proxy(test_dir);
+	let chain = wallet_proxy.chain.clone();
+	let stopper = wallet_proxy.running.clone();
+
+	// Create a new wallet test client, and set its queues to communicate with the
+	// proxy
+	create_wallet_and_add!(
+		client1,
+		wallet1,
+		mask1_i,
+		test_dir,
+		"wallet1",
+		None,
+		&mut wallet_proxy,
+		false
+	);
+	let mask1 = (&mask1_i).as_ref();
+	create_wallet_and_add!(
+		client2,
+		wallet2,
+		mask2_i,
+		test_dir,
+		"wallet2",
+		None,
+		&mut wallet_proxy,
+		false
+	);
+	let mask2 = (&mask2_i).as_ref();
+
+	// Set the wallet proxy listener running
+	thread::spawn(move || {
+		if let Err(e) = wallet_proxy.run() {
+			error!("Wallet Proxy error: {}", e);
+		}
+	});
+
+	// few values to keep things shorter
+	let reward = core::consensus::REWARD;
+
+	// add some accounts
+	wallet::controller::owner_single_use(Some(wallet1.clone()), mask1, None, |api, m| {
+		api.create_account_path(m, "mining")?;
+		api.create_account_path(m, "listener")?;
+		Ok(())
+	})?;
+
+	// add some accounts
+	wallet::controller::owner_single_use(Some(wallet2.clone()), mask2, None, |api, m| {
+		api.create_account_path(m, "account1")?;
+		api.create_account_path(m, "account2")?;
+		Ok(())
+	})?;
+
+	// Get some mining done
+	{
+		wallet_inst!(wallet1, w);
+		w.set_parent_key_id_by_name("mining")?;
+	}
+	let mut bh = 10u64;
+	let _ =
+		test_framework::award_blocks_to_wallet(&chain, wallet1.clone(), mask1, bh as usize, false);
+
+	let (send_file, receive_file, final_file) = match use_bin {
+		false => (
+			format!("{}/standard_S1.slatepack", test_dir),
+			format!("{}/standard_S2.slatepack", test_dir),
+			format!("{}/standard_S3.slatepack", test_dir),
+		),
+		true => (
+			format!("{}/standard_S1.slatepackbin", test_dir),
+			format!("{}/standard_S2.slatepackbin", test_dir),
+			format!("{}/standard_S3.slatepackbin", test_dir),
+		),
+	};
+
+	wallet::controller::owner_single_use(Some(wallet1.clone()), mask1, None, |api, m| {
+		let (wallet1_refreshed, wallet1_info) = api.retrieve_summary_info(m, true, 1)?;
+		assert!(wallet1_refreshed);
+		assert_eq!(wallet1_info.last_confirmed_height, bh);
+		assert_eq!(wallet1_info.total, bh * reward);
+		// send to send
+		let args = InitTxArgs {
+			src_acct_name: Some("mining".to_owned()),
+			amount: reward * 2,
+			minimum_confirmations: 2,
+			max_outputs: 500,
+			num_change_outputs: 1,
+			selection_strategy_is_use_all: true,
+			..Default::default()
+		};
+		let slate = api.init_send_tx(m, args)?;
+		// output tx file
+		output_slatepack(&slate, &send_file, use_armored, use_bin)?;
+		api.tx_lock_outputs(m, &slate)?;
+		Ok(())
+	})?;
+
+	// Get some mining done
+	{
+		wallet_inst!(wallet2, w);
+		w.set_parent_key_id_by_name("account1")?;
+	}
+
+	let mut slate = slate_from_packed(&send_file, use_armored)?;
+
+	// wallet 2 receives file, completes, sends file back
+	wallet::controller::foreign_single_use(wallet2.clone(), mask2_i.clone(), |api| {
+		slate = api.receive_tx(&slate, None)?;
+		output_slatepack(&slate, &receive_file, use_armored, use_bin)?;
+		Ok(())
+	})?;
+
+	// wallet 1 finalises and posts
+	wallet::controller::owner_single_use(Some(wallet1.clone()), mask1, None, |api, m| {
+		let mut slate = slate_from_packed(&receive_file, use_armored)?;
+		slate = api.finalize_tx(m, &slate)?;
+		// Output final file for reference
+		output_slatepack(&slate, &final_file, use_armored, use_bin)?;
+		api.post_tx(m, &slate, false)?;
+		bh += 1;
+		Ok(())
+	})?;
+
+	let _ = test_framework::award_blocks_to_wallet(&chain, wallet1.clone(), mask1, 3, false);
+	bh += 3;
+
+	// Check total in mining account
+	wallet::controller::owner_single_use(Some(wallet1.clone()), mask1, None, |api, m| {
+		let (wallet1_refreshed, wallet1_info) = api.retrieve_summary_info(m, true, 1)?;
+		assert!(wallet1_refreshed);
+		assert_eq!(wallet1_info.last_confirmed_height, bh);
+		assert_eq!(wallet1_info.total, bh * reward - reward * 2);
+		Ok(())
+	})?;
+
+	// Check total in 'wallet 2' account
+	wallet::controller::owner_single_use(Some(wallet2.clone()), mask2, None, |api, m| {
+		let (wallet2_refreshed, wallet2_info) = api.retrieve_summary_info(m, true, 1)?;
+		assert!(wallet2_refreshed);
+		assert_eq!(wallet2_info.last_confirmed_height, bh);
+		assert_eq!(wallet2_info.total, 2 * reward);
+		Ok(())
+	})?;
+
+	// Now other types of exchange, for reference
+	// Invoice transaction
+	let (send_file, receive_file, final_file) = match use_bin {
+		false => (
+			format!("{}/invoice_I1.slatepack", test_dir),
+			format!("{}/invoice_I2.slatepack", test_dir),
+			format!("{}/invoice_I3.slatepack", test_dir),
+		),
+		true => (
+			format!("{}/invoice_I1.slatepackbin", test_dir),
+			format!("{}/invoice_I2.slatepackbin", test_dir),
+			format!("{}/invoice_I3.slatepackbin", test_dir),
+		),
+	};
+
+	let mut slate = Slate::blank(2, true);
+
+	wallet::controller::owner_single_use(Some(wallet2.clone()), mask2, None, |api, m| {
+		let args = IssueInvoiceTxArgs {
+			amount: 1000000000,
+			..Default::default()
+		};
+		slate = api.issue_invoice_tx(m, args)?;
+		output_slatepack(&slate, &send_file, use_armored, use_bin)?;
+		Ok(())
+	})?;
+
+	wallet::controller::owner_single_use(Some(wallet1.clone()), mask1, None, |api, m| {
+		let args = InitTxArgs {
+			src_acct_name: None,
+			amount: slate.amount,
+			minimum_confirmations: 2,
+			max_outputs: 500,
+			num_change_outputs: 1,
+			selection_strategy_is_use_all: true,
+			..Default::default()
+		};
+		slate = slate_from_packed(&send_file, use_armored)?;
+		slate = api.process_invoice_tx(m, &slate, args)?;
+		api.tx_lock_outputs(m, &slate)?;
+		output_slatepack(&slate, &receive_file, use_armored, use_bin)?;
+		Ok(())
+	})?;
+	wallet::controller::foreign_single_use(wallet2.clone(), mask2_i.clone(), |api| {
+		// Wallet 2 receives the invoice transaction
+		slate = slate_from_packed(&receive_file, use_armored)?;
+		slate = api.finalize_invoice_tx(&slate)?;
+		output_slatepack(&slate, &final_file, use_armored, use_bin)?;
+		Ok(())
+	})?;
+	wallet::controller::owner_single_use(Some(wallet1.clone()), mask1, None, |api, m| {
+		api.post_tx(m, &slate, false)?;
+		Ok(())
+	})?;
+
+	// Standard, with payment proof
+	let _ = test_framework::award_blocks_to_wallet(&chain, wallet1.clone(), mask1, 3, false);
+	let (send_file, receive_file, final_file) = match use_bin {
+		false => (
+			format!("{}/standard_pp_S1.slatepack", test_dir),
+			format!("{}/standard_pp_S2.slatepack", test_dir),
+			format!("{}/standard_pp_S3.slatepack", test_dir),
+		),
+		true => (
+			format!("{}/standard_pp_S1.slatepackbin", test_dir),
+			format!("{}/standard_pp_S2.slatepackbin", test_dir),
+			format!("{}/standard_pp_S3.slatepackbin", test_dir),
+		),
+	};
+	let mut slate = Slate::blank(2, true);
+	let mut address = None;
+	wallet::controller::owner_single_use(Some(wallet2.clone()), mask2, None, |api, m| {
+		address = Some(api.get_public_proof_address(m, 0)?);
+		Ok(())
+	})?;
+
+	let address = OnionV3Address::from_bytes(address.as_ref().unwrap().to_bytes());
+
+	wallet::controller::owner_single_use(Some(wallet1.clone()), mask1, None, |api, m| {
+		// send to send
+		let args = InitTxArgs {
+			src_acct_name: Some("mining".to_owned()),
+			amount: reward,
+			minimum_confirmations: 2,
+			max_outputs: 500,
+			num_change_outputs: 1,
+			selection_strategy_is_use_all: true,
+			payment_proof_recipient_address: Some(address.clone()),
+			..Default::default()
+		};
+		let slate = api.init_send_tx(m, args)?;
+		output_slatepack(&slate, &send_file, use_armored, use_bin)?;
+		api.tx_lock_outputs(m, &slate)?;
+		Ok(())
+	})?;
+
+	wallet::controller::foreign_single_use(wallet2.clone(), mask2_i.clone(), |api| {
+		slate = slate_from_packed(&send_file, use_armored)?;
+		slate = api.receive_tx(&slate, None)?;
+		output_slatepack(&slate, &receive_file, use_armored, use_bin)?;
+		Ok(())
+	})?;
+
+	// wallet 1 finalises and posts
+	wallet::controller::owner_single_use(Some(wallet1.clone()), mask1, None, |api, m| {
+		slate = slate_from_packed(&receive_file, use_armored)?;
+		slate = api.finalize_tx(m, &slate)?;
+		// Output final file for reference
+		output_slatepack(&slate, &final_file, use_armored, use_bin)?;
+		api.post_tx(m, &slate, false)?;
+		bh += 1;
+		Ok(())
+	})?;
+
+	// let logging finish
+	stopper.store(false, Ordering::Relaxed);
+	thread::sleep(Duration::from_millis(200));
+	Ok(())
+}
+
+#[test]
+fn slatepack_exchange_json() {
+	let test_dir = "test_output/slatepack_exchange_json";
+	setup(test_dir);
+	// Json output
+	if let Err(e) = slatepack_exchange_test_impl(test_dir, false, false) {
+		panic!("Libwallet Error: {} - {}", e, e.backtrace().unwrap());
+	}
+	//clean_output_dir(test_dir);
+}
+
+#[test]
+fn slatepack_exchange_bin() {
+	let test_dir = "test_output/slatepack_exchange_bin";
+	setup(test_dir);
+	// Bin output
+	if let Err(e) = slatepack_exchange_test_impl(test_dir, true, false) {
+		panic!("Libwallet Error: {} - {}", e, e.backtrace().unwrap());
+	}
+	//clean_output_dir(test_dir);
+}
+
+#[test]
+fn slatepack_exchange_armored() {
+	let test_dir = "test_output/slatepack_exchange_armored";
+	setup(test_dir);
+	// Bin output
+	if let Err(e) = slatepack_exchange_test_impl(test_dir, true, true) {
+		panic!("Libwallet Error: {} - {}", e, e.backtrace().unwrap());
+	}
+	//clean_output_dir(test_dir);
+}

--- a/impls/src/adapters/file.rs
+++ b/impls/src/adapters/file.rs
@@ -16,13 +16,13 @@
 use std::fs::File;
 use std::io::{Read, Write};
 
-use crate::client_utils::byte_ser;
 use crate::libwallet::slate_versions::v3::SlateV3;
 use crate::libwallet::slate_versions::v4::SlateV4;
 use crate::libwallet::{
 	Error, ErrorKind, Slate, SlateState, SlateVersion, VersionedBinSlate, VersionedSlate,
 };
 use crate::{SlateGetter, SlatePutter};
+use grin_wallet_util::byte_ser;
 use std::convert::TryFrom;
 use std::path::PathBuf;
 

--- a/impls/src/adapters/mod.rs
+++ b/impls/src/adapters/mod.rs
@@ -15,10 +15,12 @@
 mod file;
 pub mod http;
 mod keybase;
+mod slatepack;
 
 pub use self::file::PathToSlate;
 pub use self::http::{HttpSlateSender, SchemeNotHttp};
 pub use self::keybase::{KeybaseAllChannels, KeybaseChannel};
+pub use self::slatepack::{PathToSlatepack, PathToSlatepackArmored};
 
 use crate::config::{TorConfig, WalletConfig};
 use crate::libwallet::{Error, ErrorKind, Slate};

--- a/impls/src/adapters/slatepack.rs
+++ b/impls/src/adapters/slatepack.rs
@@ -1,0 +1,122 @@
+// Copyright 2020 The Grin Developers
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use std::convert::TryFrom;
+/// Slatepack Output 'plugin' implementation
+use std::fs::File;
+use std::io::{Read, Write};
+use std::path::PathBuf;
+
+use crate::libwallet::{
+	Error, ErrorKind, Slate, SlateVersion, Slatepack, SlatepackArmor, SlatepackBin,
+	VersionedBinSlate, VersionedSlate,
+};
+use crate::{SlateGetter, SlatePutter};
+use grin_wallet_util::byte_ser;
+
+#[derive(Clone)]
+pub struct PathToSlatepack(pub PathBuf);
+
+impl SlatePutter for PathToSlatepack {
+	fn put_tx(&self, slate: &Slate, as_bin: bool) -> Result<(), Error> {
+		let mut pub_tx = File::create(&self.0)?;
+		let out_slate = VersionedSlate::into_version(slate.clone(), SlateVersion::V4)?;
+		let bin_slate =
+			VersionedBinSlate::try_from(out_slate).map_err(|_| ErrorKind::SlatepackSer)?;
+		let mut slatepack = Slatepack::default();
+		slatepack.payload = byte_ser::to_bytes(&bin_slate).map_err(|_| ErrorKind::SlatepackSer)?;
+		if as_bin {
+			pub_tx.write_all(
+				&byte_ser::to_bytes(&SlatepackBin(slatepack))
+					.map_err(|_| ErrorKind::SlatepackSer)?,
+			)?;
+		} else {
+			pub_tx.write_all(
+				serde_json::to_string_pretty(&slatepack)
+					.map_err(|_| ErrorKind::SlateSer)?
+					.as_bytes(),
+			)?;
+		}
+		pub_tx.sync_all()?;
+		Ok(())
+	}
+}
+
+impl SlateGetter for PathToSlatepack {
+	fn get_tx(&self) -> Result<(Slate, bool), Error> {
+		// try as bin first, then as json
+		let mut pub_tx_f = File::open(&self.0)?;
+		let mut data = Vec::new();
+		pub_tx_f.read_to_end(&mut data)?;
+		let bin_res = byte_ser::from_bytes::<SlatepackBin>(&data);
+		if let Err(e) = bin_res {
+			debug!("Not a valid binary slatepack: {} - Will try JSON", e);
+		} else {
+			if let Ok(s) = bin_res {
+				let slate = byte_ser::from_bytes::<VersionedBinSlate>(&s.0.payload);
+				if let Ok(s) = slate {
+					return Ok((Slate::upgrade(s.into())?, true));
+				}
+			}
+		}
+
+		// Otherwise try json
+		let content = String::from_utf8(data).map_err(|_| ErrorKind::SlatepackDeser)?;
+		println!("{:?}", content);
+		let slatepack: Slatepack = serde_json::from_str(&content).map_err(|e| {
+			error!("Error reading JSON Slatepack: {}", e);
+			ErrorKind::SlatepackDeser
+		})?;
+		let slate = byte_ser::from_bytes::<VersionedBinSlate>(&slatepack.payload);
+		if let Ok(s) = slate {
+			return Ok((Slate::upgrade(s.into())?, true));
+		}
+
+		Ok((Slate::deserialize_upgrade(&content)?, false))
+	}
+}
+
+#[derive(Clone)]
+pub struct PathToSlatepackArmored(pub PathBuf);
+
+impl SlatePutter for PathToSlatepackArmored {
+	fn put_tx(&self, slate: &Slate, _as_bin: bool) -> Result<(), Error> {
+		let mut pub_tx = File::create(&self.0)?;
+		let out_slate = VersionedSlate::into_version(slate.clone(), SlateVersion::V4)?;
+		let bin_slate =
+			VersionedBinSlate::try_from(out_slate).map_err(|_| ErrorKind::SlatepackSer)?;
+		let mut slatepack = Slatepack::default();
+		slatepack.payload = byte_ser::to_bytes(&bin_slate).map_err(|_| ErrorKind::SlatepackSer)?;
+		let armored = SlatepackArmor::encode(&slatepack, 3)?;
+		pub_tx.write_all(armored.as_bytes())?;
+		pub_tx.sync_all()?;
+		Ok(())
+	}
+}
+
+impl SlateGetter for PathToSlatepackArmored {
+	fn get_tx(&self) -> Result<(Slate, bool), Error> {
+		// try as bin first, then as json
+		let mut pub_tx_f = File::open(&self.0)?;
+		let mut data = Vec::new();
+		pub_tx_f.read_to_end(&mut data)?;
+		let slatepack = SlatepackArmor::decode(&String::from_utf8(data).unwrap())?;
+		let slate_bin =
+			byte_ser::from_bytes::<VersionedBinSlate>(&slatepack.payload).map_err(|e| {
+				error!("Error reading slate from armored slatepack: {}", e);
+				ErrorKind::SlatepackDeser
+			})?;
+		Ok((Slate::upgrade(slate_bin.into())?, true))
+	}
+}

--- a/impls/src/client_utils/mod.rs
+++ b/impls/src/client_utils/mod.rs
@@ -12,7 +12,6 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-pub mod byte_ser;
 mod client;
 pub mod json_rpc;
 

--- a/impls/src/lib.rs
+++ b/impls/src/lib.rs
@@ -44,8 +44,8 @@ pub mod test_framework;
 pub mod tor;
 
 pub use crate::adapters::{
-	create_sender, HttpSlateSender, KeybaseAllChannels, KeybaseChannel, PathToSlate, SlateGetter,
-	SlatePutter, SlateReceiver, SlateSender,
+	create_sender, HttpSlateSender, KeybaseAllChannels, KeybaseChannel, PathToSlate,
+	PathToSlatepack, PathToSlatepackArmored, SlateGetter, SlatePutter, SlateReceiver, SlateSender,
 };
 pub use crate::backends::{wallet_db_exists, LMDBBackend};
 pub use crate::error::{Error, ErrorKind};

--- a/libwallet/Cargo.toml
+++ b/libwallet/Cargo.toml
@@ -27,6 +27,9 @@ strum_macros = "0.15"
 ed25519-dalek = "1.0.0-pre.1"
 byteorder = "1"
 base64 = "0.9"
+regex = "1.3"
+sha2 = "0.8"
+bs58 = "0.3"
 
 grin_wallet_util = { path = "../util", version = "4.0.0-alpha.1" }
 grin_wallet_config = { path = "../config", version = "4.0.0-alpha.1" }

--- a/libwallet/src/error.rs
+++ b/libwallet/src/error.rs
@@ -202,6 +202,14 @@ pub enum ErrorKind {
 	#[fail(display = "Can't Deserialize slate")]
 	SlateDeser,
 
+	/// Can't serialize slate pack
+	#[fail(display = "Can't Serialize slatepack")]
+	SlatepackSer,
+
+	/// Can't deserialize slate
+	#[fail(display = "Can't Deserialize slatepack")]
+	SlatepackDeser,
+
 	/// Unknown slate version
 	#[fail(display = "Unknown Slate Version: {}", _0)]
 	SlateVersion(u16),
@@ -269,6 +277,10 @@ pub enum ErrorKind {
 	/// Unknown Kernel Feature
 	#[fail(display = "Unknown Kernel Feature: {}", _0)]
 	UnknownKernelFeatures(u8),
+
+	/// Invalid Slatepack Data
+	#[fail(display = "Invalid Slatepack Data: {}", _0)]
+	InvalidSlatepackData(String),
 
 	/// Other
 	#[fail(display = "Generic error: {}", _0)]

--- a/libwallet/src/lib.rs
+++ b/libwallet/src/lib.rs
@@ -52,6 +52,7 @@ mod error;
 mod internal;
 mod slate;
 pub mod slate_versions;
+mod slatepack;
 mod types;
 
 pub use crate::error::{Error, ErrorKind};
@@ -60,6 +61,7 @@ pub use crate::slate_versions::{
 	SlateVersion, VersionedBinSlate, VersionedCoinbase, VersionedSlate, CURRENT_SLATE_VERSION,
 	GRIN_BLOCK_HEADER_VERSION,
 };
+pub use crate::slatepack::{Slatepack, SlatepackArmor, SlatepackBin};
 pub use api_impl::owner_updater::StatusMessage;
 pub use api_impl::types::{
 	BlockFees, InitTxArgs, InitTxSendArgs, IssueInvoiceTxArgs, NodeHeightResult,

--- a/libwallet/src/slatepack/armor.rs
+++ b/libwallet/src/slatepack/armor.rs
@@ -1,0 +1,187 @@
+// Copyright 2020 The Grin Developers
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// A note on encoding efficiency: 0.75 for Base64, 0.744 for Base62, 0.732 for Base58
+// slatepack uses a modified Base58Check encoding to create armored slate payloads:
+// 1. Take first four bytes of SHA256(SHA256(slate.as_bytes()))
+// 2. Concatenate result of step 1 and slate.as_bytes()
+// 3. Base58 encode bytes from step 2
+// Finally add armor framing and space/newline formatting as desired
+
+use crate::{Error, ErrorKind};
+use grin_wallet_util::byte_ser;
+use regex::Regex;
+use sha2::{Digest, Sha256};
+use std::str;
+
+use super::types::{Slatepack, SlatepackBin};
+
+// Framing and formatting for slate armor
+static HEADER: &str = "BEGINSLATEPACK. ";
+static FOOTER: &str = ". ENDSLATEPACK.";
+const WORD_LENGTH: usize = 15;
+
+lazy_static! {
+	static ref HEADER_REGEX: Regex =
+		Regex::new(concat!(r"^[>\n\r\t ]*BEGINSLATEPACK[>\n\r\t ]*$")).unwrap();
+	static ref FOOTER_REGEX: Regex =
+		Regex::new(concat!(r"^[>\n\r\t ]*ENDSLATEPACK[>\n\r\t ]*$")).unwrap();
+	static ref WHITESPACE_LIST: [u8; 5] = [b'>', b'\n', b'\r', b'\t', b' '];
+}
+
+/// Wrapper for associated functions
+pub struct SlatepackArmor;
+
+impl SlatepackArmor {
+	/// Decode an armored Slatepack
+	pub fn decode(data: &str) -> Result<Slatepack, Error> {
+		// Convert the armored slate to bytes for parsing
+		let armor_bytes: Vec<u8> = data.as_bytes().to_vec();
+		// Collect the bytes up to the first period, this is the header
+		let header_bytes = &armor_bytes
+			.iter()
+			.take_while(|byte| **byte != b'.')
+			.cloned()
+			.collect::<Vec<u8>>();
+		// Verify the header...
+		check_header(&header_bytes)?;
+		// Get the length of the header
+		let header_len = *&header_bytes.len() + 1;
+		// Skip the length of the header to read for the payload until the next period
+		let payload_bytes = &armor_bytes[header_len as usize..]
+			.iter()
+			.take_while(|byte| **byte != b'.')
+			.cloned()
+			.collect::<Vec<u8>>();
+		// Get length of the payload to check the footer framing
+		let payload_len = *&payload_bytes.len();
+		// Get footer bytes and verify them
+		let consumed_bytes = header_len + payload_len + 1;
+		let footer_bytes = &armor_bytes[consumed_bytes as usize..]
+			.iter()
+			.take_while(|byte| **byte != b'.')
+			.cloned()
+			.collect::<Vec<u8>>();
+		check_footer(&footer_bytes)?;
+		// Clean up the payload bytes to be deserialized
+		let clean_payload = &payload_bytes
+			.iter()
+			.filter(|byte| !WHITESPACE_LIST.contains(byte))
+			.cloned()
+			.collect::<Vec<u8>>();
+		// Decode payload from base58
+		let base_decode = bs58::decode(&clean_payload).into_vec().unwrap();
+		let error_code = &base_decode[0..4];
+		let slate_bytes = &base_decode[4..];
+		// Make sure the error check code is valid for the slate data
+		error_check(&error_code.to_vec(), &slate_bytes.to_vec())?;
+		// Return slate as binary or string
+		let slatepack_bin = byte_ser::from_bytes::<SlatepackBin>(&slate_bytes).map_err(|e| {
+			error!("Error reading JSON Slatepack: {}", e);
+			ErrorKind::SlatepackDeser
+		})?;
+		Ok(slatepack_bin.0)
+	}
+
+	/// Encode an armored slatepack
+	pub fn encode(slatepack: &Slatepack, num_cols: usize) -> Result<String, Error> {
+		let slatepack_bytes = byte_ser::to_bytes(&SlatepackBin(slatepack.clone()))
+			.map_err(|_| ErrorKind::SlatepackSer)?;
+		let encoded_slatepack = base58check(&slatepack_bytes)?;
+		let formatted_slatepack = format_slatepack(&encoded_slatepack, num_cols)?;
+		Ok(format!("{}{}{}\n", HEADER, formatted_slatepack, FOOTER))
+	}
+}
+
+// Takes an error check code and a slate binary and verifies that the code was generated from slate
+fn error_check(error_code: &Vec<u8>, slate_bytes: &Vec<u8>) -> Result<(), Error> {
+	let new_check = generate_check(&slate_bytes)?;
+	if error_code.iter().eq(new_check.iter()) {
+		Ok(())
+	} else {
+		Err(ErrorKind::InvalidSlatepackData(
+			"Bad slate error code- some data was corrupted".to_string(),
+		)
+		.into())
+	}
+}
+
+// Checks header framing bytes and returns an error if they are invalid
+fn check_header(header: &Vec<u8>) -> Result<(), Error> {
+	let framing = str::from_utf8(&header).unwrap();
+	if HEADER_REGEX.is_match(framing) {
+		Ok(())
+	} else {
+		Err(ErrorKind::InvalidSlatepackData("Bad armor header".to_string()).into())
+	}
+}
+
+// Checks footer framing bytes and returns an error if they are invalid
+fn check_footer(footer: &Vec<u8>) -> Result<(), Error> {
+	let framing = str::from_utf8(&footer).unwrap();
+	if FOOTER_REGEX.is_match(framing) {
+		Ok(())
+	} else {
+		Err(ErrorKind::InvalidSlatepackData("Bad armor footer".to_string()).into())
+	}
+}
+
+// MODIFIED Base58Check encoding for slate bytes
+fn base58check(slate: &[u8]) -> Result<String, Error> {
+	// Serialize the slate json string to a vector of bytes
+	let mut slate_bytes: Vec<u8> = slate.to_vec();
+	// Get the four byte checksum for the slate binary
+	let mut check_bytes: Vec<u8> = generate_check(&slate_bytes)?;
+	// Make a new buffer and concatenate checksum bytes and slate bytes
+	let mut slate_buf = Vec::new();
+	slate_buf.append(&mut check_bytes);
+	slate_buf.append(&mut slate_bytes);
+	// Encode the slate buffer containing the slate binary and checksum bytes as Base58
+	let b58_slate = bs58::encode(slate_buf).into_string();
+	Ok(b58_slate)
+}
+
+// Adds human readable formatting to the slate payload for armoring
+fn format_slatepack(slatepack: &str, num_cols: usize) -> Result<String, Error> {
+	let formatter = slatepack
+		.chars()
+		.enumerate()
+		.flat_map(|(i, c)| {
+			if i != 0 && i % WORD_LENGTH == 0 {
+				if num_cols != 0 && i % (WORD_LENGTH * num_cols) == WORD_LENGTH * 2 {
+					Some('\n')
+				} else {
+					Some(' ')
+				}
+			} else {
+				None
+			}
+			.into_iter()
+			.chain(std::iter::once(c))
+		})
+		.collect::<String>();
+	Ok(formatter)
+}
+
+// Returns the first four bytes of a double sha256 hash of some bytes
+fn generate_check(payload: &Vec<u8>) -> Result<Vec<u8>, Error> {
+	let mut first_hash = Sha256::new();
+	first_hash.input(payload);
+	let mut second_hash = Sha256::new();
+	second_hash.input(first_hash.result());
+	let checksum = second_hash.result();
+	let check_bytes: Vec<u8> = checksum[0..4].to_vec();
+	Ok(check_bytes)
+}

--- a/libwallet/src/slatepack/mod.rs
+++ b/libwallet/src/slatepack/mod.rs
@@ -1,4 +1,4 @@
-// Copyright 2019 The Grin Developers
+// Copyright 2020 The Grin Developers
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -12,27 +12,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-//! Utilities and re-exports
+mod armor;
+mod types;
 
-#![deny(non_upper_case_globals)]
-#![deny(non_camel_case_types)]
-#![deny(non_snake_case)]
-#![deny(unused_mut)]
-#![warn(missing_docs)]
-
-#[macro_use]
-extern crate serde_derive;
-
-mod ov3;
-pub use ov3::OnionV3Address;
-pub use ov3::OnionV3Error as OnionV3AddressError;
-
-#[allow(missing_docs)]
-pub mod byte_ser;
-
-pub use grin_api;
-pub use grin_chain;
-pub use grin_core;
-pub use grin_keychain;
-pub use grin_store;
-pub use grin_util;
+pub use self::armor::SlatepackArmor;
+pub use self::types::{Slatepack, SlatepackBin};

--- a/libwallet/src/slatepack/types.rs
+++ b/libwallet/src/slatepack/types.rs
@@ -1,0 +1,354 @@
+// Copyright 2020 The Grin Developers
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+/// Slatepack Types + Serialization implementation
+use ed25519_dalek::PublicKey as DalekPublicKey;
+
+use crate::dalek_ser;
+use crate::grin_core::ser::{self, Readable, Reader, Writeable, Writer};
+use crate::util::byte_ser;
+
+/// Basic Slatepack definition
+#[derive(Serialize, Deserialize, Debug, Clone)]
+pub struct Slatepack {
+	// Required Fields
+	/// Versioning info
+	#[serde(with = "slatepack_version")]
+	pub slatepack: SlatepackVersion,
+	/// Delivery Mode, 0 = plain_text, 1 = encrypted
+	pub mode: u8,
+	/// Sender address
+	#[serde(default = "default_sender_none")]
+	#[serde(with = "dalek_ser::option_dalek_pubkey_base64")]
+	#[serde(skip_serializing_if = "Option::is_none")]
+	pub sender: Option<DalekPublicKey>,
+	/// Header, used if encryption enabled, mode == 1
+	#[serde(default = "default_header_none")]
+	#[serde(skip_serializing_if = "Option::is_none")]
+	pub header: Option<SlatepackHeader>,
+	/// Binary payload, can be encrypted or plaintext
+	#[serde(
+		serialize_with = "dalek_ser::as_base64",
+		deserialize_with = "dalek_ser::bytes_from_base64"
+	)]
+	pub payload: Vec<u8>,
+}
+
+fn default_header_none() -> Option<SlatepackHeader> {
+	None
+}
+
+fn default_sender_none() -> Option<DalekPublicKey> {
+	None
+}
+
+impl Default for Slatepack {
+	fn default() -> Self {
+		Self {
+			slatepack: SlatepackVersion { major: 0, minor: 1 },
+			mode: 0,
+			sender: None,
+			header: None,
+			payload: vec![],
+		}
+	}
+}
+
+impl Slatepack {
+	/// return length of optional fields
+	pub fn opt_fields_len(&self) -> Result<usize, ser::Error> {
+		let mut retval = 0;
+		if self.sender.is_some() {
+			retval += 4;
+		}
+		Ok(retval)
+	}
+	/// return the length of the header
+	pub fn header_len(&self) -> Result<usize, ser::Error> {
+		match self.header.as_ref() {
+			None => Ok(0),
+			Some(h) => h.len(),
+		}
+	}
+}
+
+/// Wrapper for outputting slate as binary
+#[derive(Debug, Clone)]
+pub struct SlatepackBin(pub Slatepack);
+
+impl serde::Serialize for SlatepackBin {
+	fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+	where
+		S: serde::Serializer,
+	{
+		let mut vec = vec![];
+		ser::serialize(&mut vec, ser::ProtocolVersion(4), self)
+			.map_err(|err| serde::ser::Error::custom(err.to_string()))?;
+		serializer.serialize_bytes(&vec)
+	}
+}
+
+impl<'de> serde::Deserialize<'de> for SlatepackBin {
+	fn deserialize<D>(deserializer: D) -> Result<SlatepackBin, D::Error>
+	where
+		D: serde::Deserializer<'de>,
+	{
+		struct SlatepackBinVisitor;
+
+		impl<'de> serde::de::Visitor<'de> for SlatepackBinVisitor {
+			type Value = SlatepackBin;
+
+			fn expecting(&self, formatter: &mut std::fmt::Formatter) -> std::fmt::Result {
+				write!(formatter, "a serialised binary Slatepack")
+			}
+
+			fn visit_bytes<E>(self, value: &[u8]) -> Result<SlatepackBin, E>
+			where
+				E: serde::de::Error,
+			{
+				let mut reader = std::io::Cursor::new(value.to_vec());
+				let s = ser::deserialize(&mut reader, ser::ProtocolVersion(4))
+					.map_err(|err| serde::de::Error::custom(err.to_string()))?;
+				Ok(s)
+			}
+		}
+
+		deserializer.deserialize_bytes(SlatepackBinVisitor)
+	}
+}
+
+impl Writeable for SlatepackBin {
+	fn write<W: Writer>(&self, writer: &mut W) -> Result<(), ser::Error> {
+		let sp = self.0.clone();
+		// Version (2)
+		sp.slatepack.write(writer)?;
+		// Mode (1)
+		writer.write_u8(sp.mode)?;
+		// 16 bits of optional content flags (2), most reserved for future use
+		let mut opt_flags: u16 = 0;
+		if sp.sender.is_some() {
+			opt_flags |= 0x01;
+		}
+		writer.write_u16(opt_flags)?;
+
+		// Bytes to skip from here (Start of optional fields other than header) to get to header (4)
+		writer.write_u32(sp.opt_fields_len()? as u32)?;
+
+		// write optional fields
+		if let Some(s) = sp.sender {
+			writer.write_fixed_bytes(s.to_bytes())?;
+		};
+
+		// Write Length of header
+		writer.write_u32(sp.header_len()? as u32)?;
+
+		// write header
+		if let Some(h) = &sp.header {
+			h.write(writer)?;
+		}
+
+		// Now write payload (length prefixed)
+		writer.write_bytes(sp.payload.clone())
+	}
+}
+
+impl Readable for SlatepackBin {
+	fn read<R: Reader>(reader: &mut R) -> Result<SlatepackBin, ser::Error> {
+		// Version (2)
+		let slatepack = SlatepackVersion::read(reader)?;
+		// Mode (1)
+		let mode = reader.read_u8()?;
+		if mode > 1 {
+			return Err(ser::Error::UnexpectedData {
+				expected: vec![0, 1],
+				received: vec![mode],
+			});
+		}
+		// optional content flags (2)
+		let opt_flags = reader.read_u16()?;
+		// start of header
+		let mut bytes_to_header = reader.read_u32()?;
+
+		let sender = if opt_flags & 0x01 > 0 {
+			bytes_to_header -= 32;
+			Some(DalekPublicKey::from_bytes(&reader.read_fixed_bytes(32)?).unwrap())
+		} else {
+			None
+		};
+
+		// skip over any unknown future fields until header
+		while bytes_to_header > 0 {
+			let _ = reader.read_u8()?;
+			bytes_to_header -= 1;
+		}
+
+		// read length of header
+		let header_len = reader.read_u32()?;
+
+		let header = if header_len > 0 {
+			Some(SlatepackHeader::read(reader)?)
+		} else {
+			None
+		};
+
+		let payload = reader.read_bytes_len_prefix()?;
+
+		Ok(SlatepackBin(Slatepack {
+			slatepack,
+			mode,
+			sender,
+			header,
+			payload,
+		}))
+	}
+}
+
+#[derive(Serialize, Deserialize, Debug, Clone, PartialEq, Eq)]
+pub struct SlatepackVersion {
+	/// Major
+	pub major: u8,
+	/// Minor
+	pub minor: u8,
+}
+
+impl Writeable for SlatepackVersion {
+	fn write<W: Writer>(&self, writer: &mut W) -> Result<(), ser::Error> {
+		writer.write_u8(self.major)?;
+		writer.write_u8(self.minor)
+	}
+}
+
+impl Readable for SlatepackVersion {
+	fn read<R: Reader>(reader: &mut R) -> Result<SlatepackVersion, ser::Error> {
+		let major = reader.read_u8()?;
+		let minor = reader.read_u8()?;
+		Ok(SlatepackVersion { major, minor })
+	}
+}
+
+/// Serializes version field JSON
+pub mod slatepack_version {
+	use serde::de::Error;
+	use serde::{Deserialize, Deserializer, Serializer};
+
+	use super::SlatepackVersion;
+
+	///
+	pub fn serialize<S>(v: &SlatepackVersion, serializer: S) -> Result<S::Ok, S::Error>
+	where
+		S: Serializer,
+	{
+		serializer.serialize_str(&format!("{}.{}", v.major, v.minor))
+	}
+
+	///
+	pub fn deserialize<'de, D>(deserializer: D) -> Result<SlatepackVersion, D::Error>
+	where
+		D: Deserializer<'de>,
+	{
+		String::deserialize(deserializer).and_then(|s| {
+			let mut retval = SlatepackVersion { major: 0, minor: 0 };
+			let v: Vec<&str> = s.split('.').collect();
+			if v.len() != 2 {
+				return Err(Error::custom("Cannot parse version"));
+			}
+			match u8::from_str_radix(v[0], 10) {
+				Ok(u) => retval.major = u,
+				Err(e) => return Err(Error::custom(format!("Cannot parse version: {}", e))),
+			}
+			match u8::from_str_radix(v[1], 10) {
+				Ok(u) => retval.minor = u,
+				Err(e) => return Err(Error::custom(format!("Cannot parse version: {}", e))),
+			}
+			Ok(retval)
+		})
+	}
+}
+
+/// Header struct definition
+#[derive(Serialize, Deserialize, Debug, Clone)]
+pub struct SlatepackHeader {
+	/// List of recipients, entry for each
+	recipients_list: Vec<RecipientListEntry>,
+	/// MAC on all "header" data up to the MAC
+	//TODO: check length
+	mac: [u8; 32],
+}
+
+impl SlatepackHeader {
+	/// return length
+	pub fn len(&self) -> Result<usize, ser::Error> {
+		Ok(byte_ser::to_bytes(self)
+			.map_err(|_| ser::Error::CorruptedData)?
+			.len())
+	}
+}
+
+impl Writeable for &SlatepackHeader {
+	fn write<W: Writer>(&self, writer: &mut W) -> Result<(), ser::Error> {
+		// write number of entries
+		writer.write_u8(self.recipients_list.len() as u8)?;
+		for r in self.recipients_list.iter() {
+			r.write(writer)?;
+		}
+		// Mac
+		writer.write_fixed_bytes(&self.mac)
+	}
+}
+
+impl Readable for SlatepackHeader {
+	fn read<R: Reader>(reader: &mut R) -> Result<SlatepackHeader, ser::Error> {
+		let num_entries = reader.read_u8()?;
+		let mut ret_val = SlatepackHeader {
+			recipients_list: vec![],
+			mac: [0; 32],
+		};
+		for _ in 0..num_entries {
+			ret_val
+				.recipients_list
+				.push(RecipientListEntry::read(reader)?);
+		}
+		let mac_bytes = reader.read_fixed_bytes(32)?;
+		ret_val.mac.copy_from_slice(&mac_bytes[0..32]);
+		Ok(ret_val)
+	}
+}
+
+/// Header struct definition
+#[derive(Serialize, Deserialize, Debug, Clone)]
+pub struct RecipientListEntry {
+	#[serde(with = "dalek_ser::dalek_pubkey_serde")]
+	/// Ephemeral public key
+	epk: DalekPublicKey,
+	/// Ephemeral message key, equivalent to file_key in age
+	/// TODO: Check length
+	emk: [u8; 32],
+}
+
+impl Writeable for RecipientListEntry {
+	fn write<W: Writer>(&self, writer: &mut W) -> Result<(), ser::Error> {
+		writer.write_fixed_bytes(self.epk.to_bytes())?;
+		writer.write_fixed_bytes(&self.emk)
+	}
+}
+
+impl Readable for RecipientListEntry {
+	fn read<R: Reader>(reader: &mut R) -> Result<RecipientListEntry, ser::Error> {
+		let epk = DalekPublicKey::from_bytes(&reader.read_fixed_bytes(32)?).unwrap();
+		let emk_bytes = reader.read_fixed_bytes(32)?;
+		let mut emk = [0u8; 32];
+		emk.copy_from_slice(&emk_bytes[0..32]);
+		Ok(RecipientListEntry { epk, emk })
+	}
+}

--- a/util/src/byte_ser.rs
+++ b/util/src/byte_ser.rs
@@ -12,9 +12,10 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-// Simple serde byte array serializer, assumes target already
-// knows how to serialize itself into binary (because that all
-// this serializer can do)
+//! Simple serde byte array serializer, assumes target already
+//! knows how to serialize itself into binary (because that all
+//! this serializer can do)
+
 use serde::de::Visitor;
 use serde::{de, ser, Deserialize, Serialize};
 use std;


### PR DESCRIPTION
Adds a first pass at the implementation of Slatepack via a new Slatepack file adapter. Currently only implements the adapter, a slatepack model, its binary serialization and tests that operate on and output slatepack.

All changes so far are isolated and not being called from anywhere in the code other than tests. Ongoing results can be viewed by commenting out the `clean_output_dir` statements at the bottom of `controller/tests/slatepack.rs` and running `cargo test slatepack` from the `controller` directory.

Note this isn't going to be a perfect implementation of slatepack just yet, the idea is to do this in a few stages while keeping the results in tests only, then integrate the workflow into the command-line once we're all happy with the implementation.

Recreated from #400