### PR TITLE
local vs global chain_type (for better test isolation)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1176,7 +1176,7 @@ checksum = "9b919933a397b79c37e33b77bb2aa3dc8eb6e165ad809e58ff75bc7db2e34574"
 [[package]]
 name = "grin_api"
 version = "4.0.0-alpha.1"
-source = "git+https://github.com/mimblewimble/grin#93f5de3d2957f6f30dde8ae8f588efa0754c5ca3"
+source = "git+https://github.com/mimblewimble/grin#6faa0e8d75be42280f3954eebedb1676cd40bb6b"
 dependencies = [
  "bytes 0.5.4",
  "easy-jsonrpc-mw",
@@ -1209,7 +1209,7 @@ dependencies = [
 [[package]]
 name = "grin_chain"
 version = "4.0.0-alpha.1"
-source = "git+https://github.com/mimblewimble/grin#93f5de3d2957f6f30dde8ae8f588efa0754c5ca3"
+source = "git+https://github.com/mimblewimble/grin#6faa0e8d75be42280f3954eebedb1676cd40bb6b"
 dependencies = [
  "bit-vec",
  "bitflags 1.2.1",
@@ -1232,7 +1232,7 @@ dependencies = [
 [[package]]
 name = "grin_core"
 version = "4.0.0-alpha.1"
-source = "git+https://github.com/mimblewimble/grin#93f5de3d2957f6f30dde8ae8f588efa0754c5ca3"
+source = "git+https://github.com/mimblewimble/grin#6faa0e8d75be42280f3954eebedb1676cd40bb6b"
 dependencies = [
  "blake2-rfc",
  "byteorder",
@@ -1258,7 +1258,7 @@ dependencies = [
 [[package]]
 name = "grin_keychain"
 version = "4.0.0-alpha.1"
-source = "git+https://github.com/mimblewimble/grin#93f5de3d2957f6f30dde8ae8f588efa0754c5ca3"
+source = "git+https://github.com/mimblewimble/grin#6faa0e8d75be42280f3954eebedb1676cd40bb6b"
 dependencies = [
  "blake2-rfc",
  "byteorder",
@@ -1280,7 +1280,7 @@ dependencies = [
 [[package]]
 name = "grin_p2p"
 version = "4.0.0-alpha.1"
-source = "git+https://github.com/mimblewimble/grin#93f5de3d2957f6f30dde8ae8f588efa0754c5ca3"
+source = "git+https://github.com/mimblewimble/grin#6faa0e8d75be42280f3954eebedb1676cd40bb6b"
 dependencies = [
  "bitflags 1.2.1",
  "chrono",
@@ -1301,7 +1301,7 @@ dependencies = [
 [[package]]
 name = "grin_pool"
 version = "4.0.0-alpha.1"
-source = "git+https://github.com/mimblewimble/grin#93f5de3d2957f6f30dde8ae8f588efa0754c5ca3"
+source = "git+https://github.com/mimblewimble/grin#6faa0e8d75be42280f3954eebedb1676cd40bb6b"
 dependencies = [
  "blake2-rfc",
  "chrono",
@@ -1335,7 +1335,7 @@ dependencies = [
 [[package]]
 name = "grin_store"
 version = "4.0.0-alpha.1"
-source = "git+https://github.com/mimblewimble/grin#93f5de3d2957f6f30dde8ae8f588efa0754c5ca3"
+source = "git+https://github.com/mimblewimble/grin#6faa0e8d75be42280f3954eebedb1676cd40bb6b"
 dependencies = [
  "byteorder",
  "croaring-mw",
@@ -1355,7 +1355,7 @@ dependencies = [
 [[package]]
 name = "grin_util"
 version = "4.0.0-alpha.1"
-source = "git+https://github.com/mimblewimble/grin#93f5de3d2957f6f30dde8ae8f588efa0754c5ca3"
+source = "git+https://github.com/mimblewimble/grin#6faa0e8d75be42280f3954eebedb1676cd40bb6b"
 dependencies = [
  "backtrace",
  "base64 0.9.3",

--- a/api/src/foreign.rs
+++ b/api/src/foreign.rs
@@ -121,7 +121,7 @@ where
 	/// use impls::{DefaultWalletImpl, DefaultLCProvider, HTTPNodeClient};
 	/// use libwallet::WalletInst;
 	///
-	/// global::init_global_chain_type(global::ChainTypes::Mainnet);
+	/// global::set_local_chain_type(global::ChainTypes::AutomatedTesting);
 	///
 	/// let mut wallet_config = WalletConfig::default();
 	/// # let dir = tempdir().map_err(|e| format!("{:#?}", e)).unwrap();
@@ -427,7 +427,8 @@ macro_rules! doctest_helper_setup_doc_env_foreign {
 		use impls::{DefaultLCProvider, DefaultWalletImpl, HTTPNodeClient};
 		use libwallet::{BlockFees, IssueInvoiceTxArgs, Slate, WalletInst};
 
-		global::init_global_chain_type(global::ChainTypes::Mainnet);
+		// Set our local chain_type for testing.
+		global::set_local_chain_type(global::ChainTypes::AutomatedTesting);
 
 		let dir = tempdir().map_err(|e| format!("{:#?}", e)).unwrap();
 		let dir = dir

--- a/api/src/foreign.rs
+++ b/api/src/foreign.rs
@@ -102,6 +102,7 @@ where
 	/// ```
 	/// use grin_wallet_util::grin_keychain as keychain;
 	/// use grin_wallet_util::grin_util as util;
+	/// use grin_wallet_util::grin_core;
 	/// use grin_wallet_api as api;
 	/// use grin_wallet_config as config;
 	/// use grin_wallet_impls as impls;
@@ -113,10 +114,14 @@ where
 	/// use std::sync::Arc;
 	/// use util::{Mutex, ZeroingString};
 	///
+	/// use grin_core::global;
+	///
 	/// use api::Foreign;
 	/// use config::WalletConfig;
 	/// use impls::{DefaultWalletImpl, DefaultLCProvider, HTTPNodeClient};
 	/// use libwallet::WalletInst;
+	///
+	/// global::init_global_chain_type(global::ChainTypes::Mainnet);
 	///
 	/// let mut wallet_config = WalletConfig::default();
 	/// # let dir = tempdir().map_err(|e| format!("{:#?}", e)).unwrap();
@@ -406,9 +411,11 @@ macro_rules! doctest_helper_setup_doc_env_foreign {
 		use grin_wallet_config as config;
 		use grin_wallet_impls as impls;
 		use grin_wallet_libwallet as libwallet;
+		use grin_wallet_util::grin_core;
 		use grin_wallet_util::grin_keychain as keychain;
 		use grin_wallet_util::grin_util as util;
 
+		use grin_core::global;
 		use keychain::ExtKeychain;
 		use tempfile::tempdir;
 
@@ -419,6 +426,8 @@ macro_rules! doctest_helper_setup_doc_env_foreign {
 		use config::WalletConfig;
 		use impls::{DefaultLCProvider, DefaultWalletImpl, HTTPNodeClient};
 		use libwallet::{BlockFees, IssueInvoiceTxArgs, Slate, WalletInst};
+
+		global::init_global_chain_type(global::ChainTypes::Mainnet);
 
 		let dir = tempdir().map_err(|e| format!("{:#?}", e)).unwrap();
 		let dir = dir

--- a/api/src/foreign_rpc.rs
+++ b/api/src/foreign_rpc.rs
@@ -360,7 +360,7 @@ pub fn run_doctest_foreign(
 
 	util::init_test_logger();
 	let _ = fs::remove_dir_all(test_dir);
-	global::set_mining_mode(ChainTypes::AutomatedTesting);
+	global::set_local_chain_type(ChainTypes::AutomatedTesting);
 
 	let mut wallet_proxy: WalletProxy<
 		DefaultLCProvider<LocalWalletClient, ExtKeychain>,

--- a/api/src/owner.rs
+++ b/api/src/owner.rs
@@ -109,11 +109,13 @@ where
 	/// ```
 	/// use grin_wallet_util::grin_keychain as keychain;
 	/// use grin_wallet_util::grin_util as util;
+	/// use grin_wallet_util::grin_core;
 	/// use grin_wallet_api as api;
 	/// use grin_wallet_config as config;
 	/// use grin_wallet_impls as impls;
 	/// use grin_wallet_libwallet as libwallet;
 	///
+	/// use grin_core::global;
 	/// use keychain::ExtKeychain;
 	/// use tempfile::tempdir;
 	///
@@ -124,6 +126,8 @@ where
 	/// use config::WalletConfig;
 	/// use impls::{DefaultWalletImpl, DefaultLCProvider, HTTPNodeClient};
 	/// use libwallet::WalletInst;
+	///
+	/// global::init_global_chain_type(global::ChainTypes::Mainnet);
 	///
 	/// let mut wallet_config = WalletConfig::default();
 	/// # let dir = tempdir().map_err(|e| format!("{:#?}", e)).unwrap();
@@ -2113,6 +2117,8 @@ macro_rules! doctest_helper_setup_doc_env {
 		use grin_wallet_util::grin_keychain as keychain;
 		use grin_wallet_util::grin_util as util;
 
+		use grin_core::global;
+
 		use keychain::ExtKeychain;
 		use tempfile::tempdir;
 
@@ -2125,6 +2131,10 @@ macro_rules! doctest_helper_setup_doc_env {
 		use libwallet::{BlockFees, InitTxArgs, IssueInvoiceTxArgs, Slate, WalletInst};
 
 		use uuid::Uuid;
+
+		// Various levels of magic going on in these doctests and we need to ensure
+		// the global chain_type is set correctly.
+		global::init_global_chain_type(global::ChainTypes::Mainnet);
 
 		let dir = tempdir().map_err(|e| format!("{:#?}", e)).unwrap();
 		let dir = dir

--- a/api/src/owner.rs
+++ b/api/src/owner.rs
@@ -127,7 +127,7 @@ where
 	/// use impls::{DefaultWalletImpl, DefaultLCProvider, HTTPNodeClient};
 	/// use libwallet::WalletInst;
 	///
-	/// global::init_global_chain_type(global::ChainTypes::Mainnet);
+	/// global::set_local_chain_type(global::ChainTypes::AutomatedTesting);
 	///
 	/// let mut wallet_config = WalletConfig::default();
 	/// # let dir = tempdir().map_err(|e| format!("{:#?}", e)).unwrap();
@@ -2132,9 +2132,8 @@ macro_rules! doctest_helper_setup_doc_env {
 
 		use uuid::Uuid;
 
-		// Various levels of magic going on in these doctests and we need to ensure
-		// the global chain_type is set correctly.
-		global::init_global_chain_type(global::ChainTypes::Mainnet);
+		// Set our local chain_type for testing.
+		global::set_local_chain_type(global::ChainTypes::AutomatedTesting);
 
 		let dir = tempdir().map_err(|e| format!("{:#?}", e)).unwrap();
 		let dir = dir

--- a/api/src/owner_rpc.rs
+++ b/api/src/owner_rpc.rs
@@ -1937,7 +1937,7 @@ pub fn run_doctest_owner(
 
 	util::init_test_logger();
 	let _ = fs::remove_dir_all(test_dir);
-	global::set_mining_mode(ChainTypes::AutomatedTesting);
+	global::set_local_chain_type(ChainTypes::AutomatedTesting);
 
 	let mut wallet_proxy: WalletProxy<
 		DefaultLCProvider<LocalWalletClient, ExtKeychain>,

--- a/controller/src/command.rs
+++ b/controller/src/command.rs
@@ -54,7 +54,6 @@ pub struct GlobalArgs {
 	pub api_secret: Option<String>,
 	pub node_api_secret: Option<String>,
 	pub show_spent: bool,
-	pub chain_type: global::ChainTypes,
 	pub password: Option<ZeroingString>,
 	pub tls_conf: Option<TLSConfig>,
 }
@@ -71,7 +70,7 @@ pub struct InitArgs {
 
 pub fn init<L, C, K>(
 	owner_api: &mut Owner<L, C, K>,
-	g_args: &GlobalArgs,
+	_g_args: &GlobalArgs,
 	args: InitArgs,
 ) -> Result<(), Error>
 where
@@ -79,15 +78,12 @@ where
 	C: NodeClient + 'static,
 	K: keychain::Keychain + 'static,
 {
+	// Assume global chain type has already been initialized.
+	let chain_type = global::get_chain_type();
+
 	let mut w_lock = owner_api.wallet_inst.lock();
 	let p = w_lock.lc_provider()?;
-	p.create_config(
-		&g_args.chain_type,
-		WALLET_CONFIG_FILE_NAME,
-		None,
-		None,
-		None,
-	)?;
+	p.create_config(&chain_type, WALLET_CONFIG_FILE_NAME, None, None, None)?;
 	p.create_wallet(
 		None,
 		args.recovery_phrase,

--- a/controller/tests/common/mod.rs
+++ b/controller/tests/common/mod.rs
@@ -84,7 +84,15 @@ pub fn clean_output_dir(test_dir: &str) {
 pub fn setup(test_dir: &str) {
 	util::init_test_logger();
 	clean_output_dir(test_dir);
-	global::set_mining_mode(ChainTypes::AutomatedTesting);
+	global::set_local_chain_type(ChainTypes::AutomatedTesting);
+}
+
+/// Some tests require the global chain_type to be configured due to threads being spawned internally.
+/// It is recommended to avoid relying on this if at all possible as global chain_type
+/// leaks across multiple tests and will likely have unintended consequences.
+#[allow(dead_code)]
+pub fn setup_global_chain_type() {
+	global::init_global_chain_type(global::ChainTypes::AutomatedTesting);
 }
 
 pub fn create_wallet_proxy(

--- a/controller/tests/updater_thread.rs
+++ b/controller/tests/updater_thread.rs
@@ -29,7 +29,7 @@ use std::time::Duration;
 
 #[macro_use]
 mod common;
-use common::{clean_output_dir, create_wallet_proxy, setup};
+use common::{clean_output_dir, create_wallet_proxy, setup, setup_global_chain_type};
 
 /// updater thread test impl
 fn updater_thread_test_impl(test_dir: &'static str) -> Result<(), libwallet::Error> {
@@ -110,6 +110,10 @@ fn updater_thread_test_impl(test_dir: &'static str) -> Result<(), libwallet::Err
 
 #[test]
 fn updater_thread() {
+	// The "updater" kicks off a new thread so we need to ensure the global chain_type
+	// is set for this to work correctly.
+	setup_global_chain_type();
+
 	let test_dir = "test_output/updater_thread";
 	setup(test_dir);
 	if let Err(e) = updater_thread_test_impl(test_dir) {

--- a/impls/src/lifecycle/default.rs
+++ b/impls/src/lifecycle/default.rs
@@ -78,7 +78,7 @@ where
 		logging_config: Option<LoggingConfig>,
 		tor_config: Option<TorConfig>,
 	) -> Result<(), Error> {
-		let mut default_config = GlobalWalletConfig::for_chain(chain_type);
+		let mut default_config = GlobalWalletConfig::for_chain(&chain_type);
 		let logging = match logging_config {
 			Some(l) => Some(l),
 			None => match default_config.members.as_ref() {

--- a/impls/src/test_framework/testclient.rs
+++ b/impls/src/test_framework/testclient.rs
@@ -21,7 +21,7 @@ use crate::chain::types::NoopAdapter;
 use crate::chain::Chain;
 use crate::core::core::verifier_cache::LruVerifierCache;
 use crate::core::core::{Transaction, TxKernel};
-use crate::core::global::{set_mining_mode, ChainTypes};
+use crate::core::global::{set_local_chain_type, ChainTypes};
 use crate::core::pow;
 use crate::keychain::Keychain;
 use crate::libwallet;
@@ -93,7 +93,7 @@ where
 {
 	/// Create a new client that will communicate with the given grin node
 	pub fn new(chain_dir: &str) -> Self {
-		set_mining_mode(ChainTypes::AutomatedTesting);
+		set_local_chain_type(ChainTypes::AutomatedTesting);
 		let genesis_block = pow::mine_genesis_block().unwrap();
 		let verifier_cache = Arc::new(RwLock::new(LruVerifierCache::new()));
 		let dir_name = format!("{}/.grin", chain_dir);
@@ -136,6 +136,10 @@ where
 	/// Run the incoming message queue and respond more or less
 	/// synchronously
 	pub fn run(&mut self) -> Result<(), libwallet::Error> {
+		// We run the wallet_proxy within a spawned thread in tests.
+		// We set the local chain_type here within the thread.
+		set_local_chain_type(ChainTypes::AutomatedTesting);
+
 		self.running.store(true, Ordering::Relaxed);
 		loop {
 			thread::sleep(Duration::from_millis(10));

--- a/integration/tests/api.rs
+++ b/integration/tests/api.rs
@@ -33,7 +33,7 @@ fn simple_server_wallet() {
 	init_test_logger();
 	info!("starting simple_server_wallet");
 	let _test_name_dir = "test_servers";
-	core::global::set_mining_mode(core::global::ChainTypes::AutomatedTesting);
+	core::global::set_local_chain_type(core::global::ChainTypes::AutomatedTesting);
 
 	// Run a separate coinbase wallet for coinbase transactions
 	let coinbase_dir = "coinbase_wallet_api";
@@ -142,7 +142,7 @@ fn simple_server_wallet() {
 fn test_p2p() {
 	init_test_logger();
 	info!("starting test_p2p");
-	global::set_mining_mode(ChainTypes::AutomatedTesting);
+	global::set_local_chain_type(ChainTypes::AutomatedTesting);
 
 	let _test_name_dir = "test_servers";
 

--- a/integration/tests/dandelion.rs
+++ b/integration/tests/dandelion.rs
@@ -32,7 +32,7 @@ use std::{thread, time};
 #[ignore]
 fn test_dandelion_timeout() {
 	let test_name_dir = "test_dandelion_timeout";
-	core::global::set_mining_mode(core::global::ChainTypes::AutomatedTesting);
+	core::global::set_local_chain_type(core::global::ChainTypes::AutomatedTesting);
 	framework::clean_all_output(test_name_dir);
 	let mut log_config = util::LoggingConfig::default();
 	//log_config.stdout_log_level = util::LogLevel::Trace;

--- a/integration/tests/simulnet.rs
+++ b/integration/tests/simulnet.rs
@@ -52,7 +52,7 @@ use crate::framework::{
 #[test]
 fn basic_genesis_mine() {
 	util::init_test_logger();
-	global::set_mining_mode(ChainTypes::AutomatedTesting);
+	global::set_local_chain_type(ChainTypes::AutomatedTesting);
 
 	let test_name_dir = "genesis_mine";
 	framework::clean_all_output(test_name_dir);
@@ -84,7 +84,7 @@ fn basic_genesis_mine() {
 #[test]
 fn simulate_seeding() {
 	util::init_test_logger();
-	global::set_mining_mode(ChainTypes::AutomatedTesting);
+	global::set_local_chain_type(ChainTypes::AutomatedTesting);
 
 	let test_name_dir = "simulate_seeding";
 	framework::clean_all_output(test_name_dir);
@@ -151,7 +151,7 @@ fn simulate_seeding() {
 #[ignore]
 #[test]
 fn simulate_parallel_mining() {
-	global::set_mining_mode(ChainTypes::AutomatedTesting);
+	global::set_local_chain_type(ChainTypes::AutomatedTesting);
 
 	let test_name_dir = "simulate_parallel_mining";
 	// framework::clean_all_output(test_name_dir);
@@ -208,7 +208,7 @@ fn simulate_block_propagation() {
 
 	// we actually set the chain_type in the ServerConfig below
 	// TODO - avoid needing to set it in two places?
-	global::set_mining_mode(ChainTypes::AutomatedTesting);
+	global::set_local_chain_type(ChainTypes::AutomatedTesting);
 
 	let test_name_dir = "grin-prop";
 	framework::clean_all_output(test_name_dir);
@@ -268,7 +268,7 @@ fn simulate_full_sync() {
 	util::init_test_logger();
 
 	// we actually set the chain_type in the ServerConfig below
-	global::set_mining_mode(ChainTypes::AutomatedTesting);
+	global::set_local_chain_type(ChainTypes::AutomatedTesting);
 
 	let test_name_dir = "grin-sync";
 	framework::clean_all_output(test_name_dir);
@@ -324,7 +324,7 @@ fn simulate_fast_sync() {
 	util::init_test_logger();
 
 	// we actually set the chain_type in the ServerConfig below
-	global::set_mining_mode(ChainTypes::AutomatedTesting);
+	global::set_local_chain_type(ChainTypes::AutomatedTesting);
 
 	let test_name_dir = "grin-fast";
 	framework::clean_all_output(test_name_dir);
@@ -417,7 +417,7 @@ fn simulate_long_fork() {
 	println!("starting simulate_long_fork");
 
 	// we actually set the chain_type in the ServerConfig below
-	global::set_mining_mode(ChainTypes::AutomatedTesting);
+	global::set_local_chain_type(ChainTypes::AutomatedTesting);
 
 	let test_name_dir = "grin-long-fork";
 	framework::clean_all_output(test_name_dir);
@@ -903,7 +903,7 @@ pub fn create_wallet(
 #[test]
 fn replicate_tx_fluff_failure() {
 	util::init_test_logger();
-	global::set_mining_mode(ChainTypes::UserTesting);
+	global::set_local_chain_type(ChainTypes::UserTesting);
 	framework::clean_all_output("tx_fluff");
 
 	// Create Wallet 1 (Mining Input) and start it listening

--- a/integration/tests/stratum.rs
+++ b/integration/tests/stratum.rs
@@ -38,7 +38,7 @@ use std::{thread, time};
 #[test]
 fn basic_stratum_server() {
 	util::init_test_logger();
-	global::set_mining_mode(ChainTypes::AutomatedTesting);
+	global::set_local_chain_type(ChainTypes::AutomatedTesting);
 
 	let test_name_dir = "stratum_server";
 	framework::clean_all_output(test_name_dir);

--- a/src/bin/grin-wallet.rs
+++ b/src/bin/grin-wallet.rs
@@ -141,7 +141,7 @@ fn real_main() -> i32 {
 
 	log_build_info();
 
-	global::set_mining_mode(
+	global::init_global_chain_type(
 		config
 			.members
 			.as_ref()

--- a/src/cmd/wallet_args.rs
+++ b/src/cmd/wallet_args.rs
@@ -32,7 +32,6 @@ use grin_wallet_libwallet::Slate;
 use grin_wallet_libwallet::{IssueInvoiceTxArgs, NodeClient, WalletInst, WalletLCProvider};
 use grin_wallet_util::grin_core as core;
 use grin_wallet_util::grin_core::core::amount_to_hr_string;
-use grin_wallet_util::grin_core::global;
 use grin_wallet_util::grin_keychain as keychain;
 use grin_wallet_util::OnionV3Address;
 use linefeed::terminal::Signal;
@@ -275,18 +274,9 @@ pub fn parse_global_args(
 		}
 	};
 
-	let chain_type = match config.chain_type.clone() {
-		None => {
-			let param_ref = global::CHAIN_TYPE.read();
-			param_ref.clone()
-		}
-		Some(c) => c,
-	};
-
 	Ok(command::GlobalArgs {
 		account: account.to_owned(),
 		show_spent: show_spent,
-		chain_type: chain_type,
 		api_secret: api_secret,
 		node_api_secret: node_api_secret,
 		password: password,
@@ -843,10 +833,6 @@ where
 		>,
 	),
 {
-	if let Some(t) = wallet_config.chain_type.clone() {
-		core::global::set_mining_mode(t);
-	}
-
 	if wallet_args.is_present("external") {
 		wallet_config.api_listen_interface = "0.0.0.0".to_string();
 	}

--- a/tests/common/mod.rs
+++ b/tests/common/mod.rs
@@ -131,7 +131,17 @@ pub fn clean_output_dir(test_dir: &str) {
 pub fn setup(test_dir: &str) {
 	util::init_test_logger();
 	clean_output_dir(test_dir);
-	global::set_mining_mode(ChainTypes::AutomatedTesting);
+	global::set_local_chain_type(global::ChainTypes::AutomatedTesting);
+}
+
+/// Some tests require the global chain_type to be configured.
+/// If tokio is used in any tests we need to ensure any threads spawned
+/// have the chain_type configured correctly.
+/// It is recommended to avoid relying on this if at all possible as global chain_type
+/// leaks across multiple tests and will likely have unintended consequences.
+#[allow(dead_code)]
+pub fn setup_global_chain_type() {
+	global::init_global_chain_type(global::ChainTypes::AutomatedTesting);
 }
 
 /// Create a wallet config file in the given current directory

--- a/tests/owner_v3_init_secure.rs
+++ b/tests/owner_v3_init_secure.rs
@@ -36,11 +36,13 @@ use serde_json;
 mod common;
 use common::{
 	clean_output_dir, derive_ecdh_key, execute_command, initial_setup_wallet, instantiate_wallet,
-	send_request, send_request_enc, setup, RetrieveSummaryInfoResp,
+	send_request, send_request_enc, setup, setup_global_chain_type, RetrieveSummaryInfoResp,
 };
 
 #[test]
 fn owner_v3_init_secure() -> Result<(), grin_wallet_controller::Error> {
+	setup_global_chain_type();
+
 	let test_dir = "target/test_output/owner_v3_init_secure";
 	setup(test_dir);
 

--- a/tests/owner_v3_lifecycle.rs
+++ b/tests/owner_v3_lifecycle.rs
@@ -40,11 +40,13 @@ mod common;
 use common::{
 	clean_output_dir, derive_ecdh_key, execute_command, execute_command_no_setup,
 	initial_setup_wallet, instantiate_wallet, send_request, send_request_enc, setup,
-	RetrieveSummaryInfoResp,
+	setup_global_chain_type, RetrieveSummaryInfoResp,
 };
 
 #[test]
 fn owner_v3_lifecycle() -> Result<(), grin_wallet_controller::Error> {
+	setup_global_chain_type();
+
 	let test_dir = "target/test_output/owner_v3_lifecycle";
 	setup(test_dir);
 

--- a/tests/tor_dev_helper.rs
+++ b/tests/tor_dev_helper.rs
@@ -20,7 +20,6 @@ extern crate log;
 extern crate grin_wallet;
 
 use grin_wallet_impls::test_framework::{self, LocalWalletClient, WalletProxy};
-use grin_wallet_util::grin_core::global::{self, ChainTypes};
 
 use clap::App;
 use std::thread;
@@ -33,14 +32,14 @@ use grin_wallet_util::grin_util as util;
 
 #[macro_use]
 mod common;
-use common::{execute_command, initial_setup_wallet, instantiate_wallet};
+use common::{execute_command, initial_setup_wallet, instantiate_wallet, setup_global_chain_type};
 
 // Development testing helper for tor/socks investigation.
 // Not (yet) to be run as part of automated testing
 
 fn setup_no_clean() {
 	util::init_test_logger();
-	global::set_mining_mode(ChainTypes::AutomatedTesting);
+	setup_global_chain_type();
 }
 
 #[ignore]


### PR DESCRIPTION
Replaces #409 (closed due to merge/rebase problems).
Related https://github.com/mimblewimble/grin/pull/3327

Grin PR https://github.com/mimblewimble/grin/pull/3327 introduces (thread) local and global configuration of `chain_type`.
This PR makes the necessary changes in grin-wallet for compatibility.

----

Updated grin deps for latest master -

```
cargo update -p grin_core
    Updating git repository `https://github.com/mimblewimble/grin`
    Updating crates.io index
    Updating grin_api v4.0.0-alpha.1 (https://github.com/mimblewimble/grin#93f5de3d) -> #6faa0e8d
    Updating grin_chain v4.0.0-alpha.1 (https://github.com/mimblewimble/grin#93f5de3d) -> #6faa0e8d
    Updating grin_core v4.0.0-alpha.1 (https://github.com/mimblewimble/grin#93f5de3d) -> #6faa0e8d
    Updating grin_keychain v4.0.0-alpha.1 (https://github.com/mimblewimble/grin#93f5de3d) -> #6faa0e8d
    Updating grin_p2p v4.0.0-alpha.1 (https://github.com/mimblewimble/grin#93f5de3d) -> #6faa0e8d
    Updating grin_pool v4.0.0-alpha.1 (https://github.com/mimblewimble/grin#93f5de3d) -> #6faa0e8d
    Updating grin_store v4.0.0-alpha.1 (https://github.com/mimblewimble/grin#93f5de3d) -> #6faa0e8d
    Updating grin_util v4.0.0-alpha.1 (https://github.com/mimblewimble/grin#93f5de3d) -> #6faa0e8d
```
