### PR TITLE
Slatepack Pt. 3 - The Packening (SlatepackAddress implementation)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1466,7 +1466,6 @@ dependencies = [
  "tokio",
  "url 1.7.2",
  "uuid",
- "x25519-dalek",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1444,6 +1444,7 @@ version = "4.0.0-alpha.1"
 dependencies = [
  "chrono",
  "easy-jsonrpc-mw",
+ "ed25519-dalek",
  "failure",
  "failure_derive",
  "futures 0.3.5",
@@ -1509,6 +1510,7 @@ version = "4.0.0-alpha.1"
 dependencies = [
  "age",
  "base64 0.9.3",
+ "bech32",
  "blake2-rfc",
  "bs58",
  "byteorder",

--- a/controller/Cargo.toml
+++ b/controller/Cargo.toml
@@ -38,5 +38,4 @@ grin_wallet_libwallet = { path = "../libwallet", version = "4.0.0-alpha.1" }
 grin_wallet_config = { path = "../config", version = "4.0.0-alpha.1" }
 
 [dev-dependencies]
-x25519-dalek = "0.6"
 ed25519-dalek = "1.0.0-pre.1"

--- a/controller/Cargo.toml
+++ b/controller/Cargo.toml
@@ -39,3 +39,4 @@ grin_wallet_config = { path = "../config", version = "4.0.0-alpha.1" }
 
 [dev-dependencies]
 x25519-dalek = "0.6"
+ed25519-dalek = "1.0.0-pre.1"

--- a/impls/src/adapters/mod.rs
+++ b/impls/src/adapters/mod.rs
@@ -20,7 +20,7 @@ mod slatepack;
 pub use self::file::PathToSlate;
 pub use self::http::{HttpSlateSender, SchemeNotHttp};
 pub use self::keybase::{KeybaseAllChannels, KeybaseChannel};
-pub use self::slatepack::{PathToSlatepack, PathToSlatepackArmored, SlatepackArgs};
+pub use self::slatepack::PathToSlatepack;
 
 use crate::config::{TorConfig, WalletConfig};
 use crate::libwallet::{Error, ErrorKind, Slate};

--- a/impls/src/adapters/slatepack.rs
+++ b/impls/src/adapters/slatepack.rs
@@ -18,12 +18,11 @@ use std::fs::File;
 use std::io::{Read, Write};
 use std::path::PathBuf;
 
-use x25519_dalek::PublicKey as xDalekPublicKey;
 use x25519_dalek::StaticSecret;
 
 use crate::libwallet::{
-	Error, ErrorKind, Slate, SlateVersion, Slatepack, SlatepackArmor, SlatepackBin,
-	VersionedBinSlate, VersionedSlate,
+	Error, ErrorKind, Slate, SlateVersion, Slatepack, SlatepackAddress, SlatepackArmor,
+	SlatepackBin, VersionedBinSlate, VersionedSlate,
 };
 use crate::{SlateGetter, SlatePutter};
 use grin_wallet_util::byte_ser;
@@ -31,8 +30,8 @@ use grin_wallet_util::byte_ser;
 #[derive(Clone)]
 pub struct SlatepackArgs<'a> {
 	pub pathbuf: PathBuf,
-	pub sender: Option<xDalekPublicKey>,
-	pub recipients: Vec<xDalekPublicKey>,
+	pub sender: Option<SlatepackAddress>,
+	pub recipients: Vec<SlatepackAddress>,
 	pub dec_key: Option<&'a StaticSecret>,
 }
 
@@ -81,7 +80,7 @@ impl<'a> PathToSlatepack<'a> {
 			VersionedBinSlate::try_from(out_slate).map_err(|_| ErrorKind::SlatepackSer)?;
 		let mut slatepack = Slatepack::default();
 		slatepack.payload = byte_ser::to_bytes(&bin_slate).map_err(|_| ErrorKind::SlatepackSer)?;
-		slatepack.sender = self.0.sender;
+		slatepack.sender = self.0.sender.clone();
 		slatepack.try_encrypt_payload(self.0.recipients.clone())?;
 		Ok(slatepack)
 	}

--- a/impls/src/adapters/slatepack.rs
+++ b/impls/src/adapters/slatepack.rs
@@ -18,7 +18,7 @@ use std::fs::File;
 use std::io::{Read, Write};
 use std::path::PathBuf;
 
-use x25519_dalek::StaticSecret;
+use ed25519_dalek::SecretKey as edSecretKey;
 
 use crate::libwallet::{
 	Error, ErrorKind, Slate, SlateVersion, Slatepack, SlatepackAddress, SlatepackArmor,
@@ -32,7 +32,7 @@ pub struct SlatepackArgs<'a> {
 	pub pathbuf: PathBuf,
 	pub sender: Option<SlatepackAddress>,
 	pub recipients: Vec<SlatepackAddress>,
-	pub dec_key: Option<&'a StaticSecret>,
+	pub dec_key: Option<&'a edSecretKey>,
 }
 
 pub struct PathToSlatepack<'a>(SlatepackArgs<'a>);

--- a/impls/src/adapters/slatepack.rs
+++ b/impls/src/adapters/slatepack.rs
@@ -12,89 +12,59 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-use std::convert::TryFrom;
 /// Slatepack Output 'plugin' implementation
 use std::fs::File;
 use std::io::{Read, Write};
 use std::path::PathBuf;
 
-use ed25519_dalek::SecretKey as edSecretKey;
-
-use crate::libwallet::{
-	Error, ErrorKind, Slate, SlateVersion, Slatepack, SlatepackAddress, SlatepackArmor,
-	SlatepackBin, VersionedBinSlate, VersionedSlate,
-};
+use crate::libwallet::{Error, ErrorKind, Slate, Slatepack, SlatepackBin, Slatepacker};
 use crate::{SlateGetter, SlatePutter};
 use grin_wallet_util::byte_ser;
 
-#[derive(Clone)]
-pub struct SlatepackArgs<'a> {
+// And Slate putter impls to output to files
+pub struct PathToSlatepack<'a> {
 	pub pathbuf: PathBuf,
-	pub sender: Option<SlatepackAddress>,
-	pub recipients: Vec<SlatepackAddress>,
-	pub dec_key: Option<&'a edSecretKey>,
+	pub packer: &'a Slatepacker<'a>,
+	pub armor_output: bool,
 }
-
-pub struct PathToSlatepack<'a>(SlatepackArgs<'a>);
 
 impl<'a> PathToSlatepack<'a> {
 	/// Create with pathbuf and recipients
-	pub fn new(args: SlatepackArgs<'a>) -> Self {
-		Self(args)
+	pub fn new(pathbuf: PathBuf, packer: &'a Slatepacker<'a>, armor_output: bool) -> Self {
+		Self {
+			pathbuf,
+			packer,
+			armor_output,
+		}
 	}
 
 	pub fn get_slatepack_file_contents(&self) -> Result<Vec<u8>, Error> {
-		let mut pub_tx_f = File::open(&self.0.pathbuf)?;
+		let mut pub_tx_f = File::open(&self.pathbuf)?;
 		let mut data = Vec::new();
 		pub_tx_f.read_to_end(&mut data)?;
 		Ok(data)
 	}
 
-	// return slatepack itself
-	pub fn deser_slatepack(&self, data: Vec<u8>) -> Result<Slatepack, Error> {
-		// try as bin first, then as json
-		let bin_res = byte_ser::from_bytes::<SlatepackBin>(&data);
-		match bin_res {
-			Err(e) => debug!("Not a valid binary slatepack: {} - Will try JSON", e),
-			Ok(s) => return Ok(s.0),
-		}
-		// Otherwise try json
-		let content = String::from_utf8(data).map_err(|_| ErrorKind::SlatepackDeser)?;
-		let slatepack: Slatepack = serde_json::from_str(&content).map_err(|e| {
-			error!("Error reading JSON Slatepack: {}", e);
-			ErrorKind::SlatepackDeser
-		})?;
-		slatepack.ver_check_warn();
-		Ok(slatepack)
-	}
-
 	pub fn get_slatepack(&self) -> Result<Slatepack, Error> {
 		let data = self.get_slatepack_file_contents()?;
-		self.deser_slatepack(data)
-	}
-
-	// Create slatepack from slate and args
-	pub fn create_slatepack(&self, slate: &Slate) -> Result<Slatepack, Error> {
-		let out_slate = VersionedSlate::into_version(slate.clone(), SlateVersion::V4)?;
-		let bin_slate =
-			VersionedBinSlate::try_from(out_slate).map_err(|_| ErrorKind::SlatepackSer)?;
-		let mut slatepack = Slatepack::default();
-		slatepack.payload = byte_ser::to_bytes(&bin_slate).map_err(|_| ErrorKind::SlatepackSer)?;
-		slatepack.sender = self.0.sender.clone();
-		slatepack.try_encrypt_payload(self.0.recipients.clone())?;
-		Ok(slatepack)
+		self.packer.deser_slatepack(data)
 	}
 }
 
 impl<'a> SlatePutter for PathToSlatepack<'a> {
 	fn put_tx(&self, slate: &Slate, as_bin: bool) -> Result<(), Error> {
-		let slatepack = self.create_slatepack(slate)?;
-		let mut pub_tx = File::create(&self.0.pathbuf)?;
+		let slatepack = self.packer.create_slatepack(slate)?;
+		let mut pub_tx = File::create(&self.pathbuf)?;
 		if as_bin {
-			pub_tx.write_all(
-				&byte_ser::to_bytes(&SlatepackBin(slatepack))
-					.map_err(|_| ErrorKind::SlatepackSer)?,
-			)?;
+			if self.armor_output {
+				let armored = self.packer.armor_slatepack(&slatepack)?;
+				pub_tx.write_all(armored.as_bytes())?;
+			} else {
+				pub_tx.write_all(
+					&byte_ser::to_bytes(&SlatepackBin(slatepack))
+						.map_err(|_| ErrorKind::SlatepackSer)?,
+				)?;
+			}
 		} else {
 			pub_tx.write_all(
 				serde_json::to_string_pretty(&slatepack)
@@ -110,59 +80,7 @@ impl<'a> SlatePutter for PathToSlatepack<'a> {
 impl<'a> SlateGetter for PathToSlatepack<'a> {
 	fn get_tx(&self) -> Result<(Slate, bool), Error> {
 		let data = self.get_slatepack_file_contents()?;
-		let mut slatepack = self.deser_slatepack(data)?;
-		slatepack.try_decrypt_payload(self.0.dec_key)?;
-		let slate = byte_ser::from_bytes::<VersionedBinSlate>(&slatepack.payload)
-			.map_err(|_| ErrorKind::SlatepackSer)?;
-		Ok((Slate::upgrade(slate.into())?, true))
-	}
-}
-
-pub struct PathToSlatepackArmored<'a>(SlatepackArgs<'a>);
-
-impl<'a> PathToSlatepackArmored<'a> {
-	/// Create with pathbuf and recipients
-	pub fn new(args: SlatepackArgs<'a>) -> Self {
-		Self(args)
-	}
-
-	/// decode armor
-	pub fn decode_armored_file(&self) -> Result<Vec<u8>, Error> {
-		let mut pub_sp_armored = File::open(&self.0.pathbuf)?;
-		let mut data = Vec::new();
-		pub_sp_armored.read_to_end(&mut data)?;
-		SlatepackArmor::decode(&String::from_utf8(data).unwrap())
-	}
-
-	// return slatepack
-	pub fn get_slatepack(&self) -> Result<Slatepack, Error> {
-		let data = self.decode_armored_file()?;
-		let pts = PathToSlatepack::new(self.0.clone());
-		pts.deser_slatepack(data)
-	}
-}
-
-impl<'a> SlatePutter for PathToSlatepackArmored<'a> {
-	fn put_tx(&self, slate: &Slate, _as_bin: bool) -> Result<(), Error> {
-		let pts = PathToSlatepack::new(self.0.clone());
-		let slatepack = pts.create_slatepack(slate)?;
-		let armored = SlatepackArmor::encode(&slatepack, 3)?;
-		let mut pub_tx = File::create(&self.0.pathbuf)?;
-		pub_tx.write_all(armored.as_bytes())?;
-		pub_tx.sync_all()?;
-		Ok(())
-	}
-}
-
-impl<'a> SlateGetter for PathToSlatepackArmored<'a> {
-	fn get_tx(&self) -> Result<(Slate, bool), Error> {
-		let mut slatepack = self.get_slatepack()?;
-		slatepack.try_decrypt_payload(self.0.dec_key)?;
-		let slate_bin =
-			byte_ser::from_bytes::<VersionedBinSlate>(&slatepack.payload).map_err(|e| {
-				error!("Error reading slate from armored slatepack: {}", e);
-				ErrorKind::SlatepackDeser
-			})?;
-		Ok((Slate::upgrade(slate_bin.into())?, true))
+		let slatepack = self.packer.deser_slatepack(data)?;
+		Ok((self.packer.get_slate(&slatepack)?, true))
 	}
 }

--- a/impls/src/lib.rs
+++ b/impls/src/lib.rs
@@ -45,8 +45,7 @@ pub mod tor;
 
 pub use crate::adapters::{
 	create_sender, HttpSlateSender, KeybaseAllChannels, KeybaseChannel, PathToSlate,
-	PathToSlatepack, PathToSlatepackArmored, SlateGetter, SlatePutter, SlateReceiver, SlateSender,
-	SlatepackArgs,
+	PathToSlatepack, SlateGetter, SlatePutter, SlateReceiver, SlateSender,
 };
 pub use crate::backends::{wallet_db_exists, LMDBBackend};
 pub use crate::error::{Error, ErrorKind};

--- a/libwallet/Cargo.toml
+++ b/libwallet/Cargo.toml
@@ -34,6 +34,7 @@ bs58 = "0.3"
 age = "0.4"
 curve25519-dalek = "2.0.0"
 secrecy = "0.6"
+bech32 = "0.7"
 
 grin_wallet_util = { path = "../util", version = "4.0.0-alpha.1" }
 grin_wallet_config = { path = "../config", version = "4.0.0-alpha.1" }

--- a/libwallet/src/error.rs
+++ b/libwallet/src/error.rs
@@ -290,6 +290,10 @@ pub enum ErrorKind {
 	#[fail(display = "Age error: {}", _0)]
 	Age(String),
 
+	/// Slatepack address parsing error
+	#[fail(display = "SlatepackAddress error: {}", _0)]
+	SlatepackAddress(String),
+
 	/// Other
 	#[fail(display = "Generic error: {}", _0)]
 	GenericError(String),
@@ -423,6 +427,14 @@ impl From<age::Error> for Error {
 	fn from(error: age::Error) -> Error {
 		Error {
 			inner: Context::new(ErrorKind::Age(format!("{}", error))),
+		}
+	}
+}
+
+impl From<bech32::Error> for Error {
+	fn from(error: bech32::Error) -> Error {
+		Error {
+			inner: Context::new(ErrorKind::SlatepackAddress(format!("{}", error))),
 		}
 	}
 }

--- a/libwallet/src/error.rs
+++ b/libwallet/src/error.rs
@@ -207,8 +207,8 @@ pub enum ErrorKind {
 	SlatepackSer,
 
 	/// Can't deserialize slate
-	#[fail(display = "Can't Deserialize slatepack")]
-	SlatepackDeser,
+	#[fail(display = "Can't Deserialize slatepack: {}", _0)]
+	SlatepackDeser(String),
 
 	/// Unknown slate version
 	#[fail(display = "Unknown Slate Version: {}", _0)]

--- a/libwallet/src/lib.rs
+++ b/libwallet/src/lib.rs
@@ -61,7 +61,9 @@ pub use crate::slate_versions::{
 	SlateVersion, VersionedBinSlate, VersionedCoinbase, VersionedSlate, CURRENT_SLATE_VERSION,
 	GRIN_BLOCK_HEADER_VERSION,
 };
-pub use crate::slatepack::{Slatepack, SlatepackAddress, SlatepackArmor, SlatepackBin};
+pub use crate::slatepack::{
+	Slatepack, SlatepackAddress, SlatepackArmor, SlatepackBin, Slatepacker, SlatepackerArgs,
+};
 pub use api_impl::owner_updater::StatusMessage;
 pub use api_impl::types::{
 	BlockFees, InitTxArgs, InitTxSendArgs, IssueInvoiceTxArgs, NodeHeightResult,

--- a/libwallet/src/lib.rs
+++ b/libwallet/src/lib.rs
@@ -61,7 +61,7 @@ pub use crate::slate_versions::{
 	SlateVersion, VersionedBinSlate, VersionedCoinbase, VersionedSlate, CURRENT_SLATE_VERSION,
 	GRIN_BLOCK_HEADER_VERSION,
 };
-pub use crate::slatepack::{Slatepack, SlatepackArmor, SlatepackBin};
+pub use crate::slatepack::{Slatepack, SlatepackAddress, SlatepackArmor, SlatepackBin};
 pub use api_impl::owner_updater::StatusMessage;
 pub use api_impl::types::{
 	BlockFees, InitTxArgs, InitTxSendArgs, IssueInvoiceTxArgs, NodeHeightResult,

--- a/libwallet/src/slatepack/address.rs
+++ b/libwallet/src/slatepack/address.rs
@@ -101,7 +101,6 @@ impl From<&SlatepackAddress> for OnionV3Address {
 impl TryFrom<&SlatepackAddress> for xDalekPublicKey {
 	type Error = Error;
 	fn try_from(addr: &SlatepackAddress) -> Result<Self, Self::Error> {
-		//println!("Slatepack ed25519 key: {:?}", addr.pub_key);
 		let cep =
 			curve25519_dalek::edwards::CompressedEdwardsY::from_slice(addr.pub_key.as_bytes());
 		let ep = match cep.decompress() {
@@ -113,7 +112,6 @@ impl TryFrom<&SlatepackAddress> for xDalekPublicKey {
 			}
 		};
 		let res = xDalekPublicKey::from(ep.to_montgomery().to_bytes());
-		//println!("CONVERTED TO: {:?}", res);
 		Ok(res)
 	}
 }

--- a/libwallet/src/slatepack/address.rs
+++ b/libwallet/src/slatepack/address.rs
@@ -1,0 +1,220 @@
+// Copyright 2020 The Grin Developers
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use bech32::{self, FromBase32, ToBase32};
+/// Slatepack Address definition
+use ed25519_dalek::PublicKey as edDalekPublicKey;
+use ed25519_dalek::SecretKey as edDalekSecretKey;
+use rand::{thread_rng, Rng};
+use serde::{Deserialize, Deserializer, Serialize, Serializer};
+use x25519_dalek::PublicKey as xDalekPublicKey;
+
+use crate::grin_core::ser::{self, Readable, Reader, Writeable, Writer};
+use crate::util::OnionV3Address;
+use crate::{Error, ErrorKind};
+
+use std::convert::TryFrom;
+use std::fmt::{self, Display};
+
+/// Definition of a Slatepack address
+#[derive(Debug, Clone, Eq, PartialEq)]
+pub struct SlatepackAddress {
+	/// Human-readable prefix
+	pub hrp: String,
+	/// ed25519 Public key, to be bech32 encoded,
+	/// interpreted as tor address or converted
+	/// to an X25519 public key for encrypting
+	/// slatepacks
+	pub pub_key: edDalekPublicKey,
+}
+
+impl SlatepackAddress {
+	/// new with default hrp
+	pub fn new(pub_key: &edDalekPublicKey) -> Self {
+		Self {
+			hrp: String::from("slatepack"),
+			pub_key: pub_key.clone(),
+		}
+	}
+
+	/// new with a random key
+	pub fn random() -> Self {
+		let bytes: [u8; 32] = thread_rng().gen();
+		let pub_key = edDalekPublicKey::from(&edDalekSecretKey::from_bytes(&bytes).unwrap());
+		SlatepackAddress::new(&pub_key)
+	}
+
+	/// calculate encoded length
+	pub fn encoded_len(&self) -> Result<usize, Error> {
+		let encoded = String::try_from(self)?;
+		// add length byte
+		Ok(encoded.as_bytes().len() + 1)
+	}
+}
+
+impl Display for SlatepackAddress {
+	fn fmt(&self, formatter: &mut fmt::Formatter) -> fmt::Result {
+		formatter.write_str(&String::try_from(self).unwrap())
+	}
+}
+
+impl TryFrom<&str> for SlatepackAddress {
+	type Error = Error;
+	fn try_from(encoded: &str) -> Result<Self, Self::Error> {
+		let (hrp, data) = bech32::decode(&encoded)?;
+		let bytes = Vec::<u8>::from_base32(&data)?;
+		let pub_key = match edDalekPublicKey::from_bytes(&bytes) {
+			Ok(k) => k,
+			Err(e) => {
+				return Err(ErrorKind::ED25519Key(format!("{}", e)).into());
+			}
+		};
+		Ok(SlatepackAddress { hrp, pub_key })
+	}
+}
+
+impl TryFrom<&SlatepackAddress> for String {
+	type Error = Error;
+	fn try_from(addr: &SlatepackAddress) -> Result<Self, Self::Error> {
+		let encoded = bech32::encode(&addr.hrp, addr.pub_key.to_bytes().to_base32())?;
+		Ok(encoded.to_string())
+	}
+}
+
+impl From<&SlatepackAddress> for OnionV3Address {
+	fn from(addr: &SlatepackAddress) -> Self {
+		OnionV3Address::from_bytes(addr.pub_key.to_bytes())
+	}
+}
+
+impl TryFrom<&SlatepackAddress> for xDalekPublicKey {
+	type Error = Error;
+	fn try_from(addr: &SlatepackAddress) -> Result<Self, Self::Error> {
+		println!("Slatepack ed25519 key: {:?}", addr.pub_key);
+		let cep =
+			curve25519_dalek::edwards::CompressedEdwardsY::from_slice(addr.pub_key.as_bytes());
+		let ep = match cep.decompress() {
+			Some(p) => p,
+			None => {
+				return Err(
+					ErrorKind::ED25519Key("Can't decompress ed25519 Edwards Point".into()).into(),
+				);
+			}
+		};
+		let res = xDalekPublicKey::from(ep.to_montgomery().to_bytes());
+		println!("CONVERTED TO: {:?}", res);
+		Ok(res)
+	}
+}
+
+/// Serializes a SlatepackAddress to a bech32 string
+impl Serialize for SlatepackAddress {
+	///
+	fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+	where
+		S: Serializer,
+	{
+		serializer.serialize_str(
+			&String::try_from(self).map_err(|err| serde::ser::Error::custom(err.to_string()))?,
+		)
+	}
+}
+
+/// Deserialize from a bech32 string
+impl<'de> Deserialize<'de> for SlatepackAddress {
+	fn deserialize<D>(deserializer: D) -> Result<SlatepackAddress, D::Error>
+	where
+		D: Deserializer<'de>,
+	{
+		struct SlatepackAddressVisitor;
+
+		impl<'de> serde::de::Visitor<'de> for SlatepackAddressVisitor {
+			type Value = SlatepackAddress;
+
+			fn expecting(&self, formatter: &mut std::fmt::Formatter) -> std::fmt::Result {
+				write!(formatter, "a SlatepackAddress")
+			}
+
+			fn visit_str<E>(self, value: &str) -> Result<SlatepackAddress, E>
+			where
+				E: serde::de::Error,
+			{
+				let s = SlatepackAddress::try_from(value)
+					.map_err(|err| serde::de::Error::custom(err.to_string()))?;
+				Ok(s)
+			}
+		}
+
+		deserializer.deserialize_str(SlatepackAddressVisitor)
+	}
+}
+
+/// write binary trait
+impl Writeable for SlatepackAddress {
+	fn write<W: Writer>(&self, writer: &mut W) -> Result<(), ser::Error> {
+		// We're actually going to encode the bech32 address as opposed to
+		// the binary serialization
+		let encoded = match String::try_from(self) {
+			Ok(e) => e,
+			Err(e) => {
+				error!("Cannot parse Slatepack address: {:?}, {}", self, e);
+				return Err(ser::Error::CorruptedData);
+			}
+		};
+		// write length, max 255
+		let bytes = encoded.as_bytes();
+		if bytes.len() > 255 {
+			error!(
+				"Cannot encode Slatepackaddress: {:?}, Too Long (Max 255)",
+				self
+			);
+			return Err(ser::Error::CorruptedData);
+		}
+		writer.write_u8(bytes.len() as u8)?;
+		writer.write_fixed_bytes(&bytes)
+	}
+}
+
+impl Readable for SlatepackAddress {
+	fn read<R: Reader>(reader: &mut R) -> Result<SlatepackAddress, ser::Error> {
+		// read length as u8
+		let len = reader.read_u8()?;
+		// and bech32 string
+		let encoded = match String::from_utf8(reader.read_fixed_bytes(len as usize)?) {
+			Ok(a) => a,
+			Err(e) => {
+				error!("Cannot parse Slatepack address from utf8: {}", e);
+				return Err(ser::Error::CorruptedData);
+			}
+		};
+		let parsed_addr = match SlatepackAddress::try_from(encoded.as_str()) {
+			Ok(a) => a,
+			Err(e) => {
+				error!("Cannot parse Slatepack address: {}, {}", encoded, e);
+				return Err(ser::Error::CorruptedData);
+			}
+		};
+		Ok(parsed_addr)
+	}
+}
+
+#[test]
+fn slatepack_address() -> Result<(), Error> {
+	let addr = SlatepackAddress::random();
+	let encoded = String::try_from(&addr).unwrap();
+	println!("Encoded bech32: {}", encoded);
+	let parsed_addr = SlatepackAddress::try_from(encoded.as_str()).unwrap();
+	assert_eq!(addr, parsed_addr);
+	Ok(())
+}

--- a/libwallet/src/slatepack/armor.rs
+++ b/libwallet/src/slatepack/armor.rs
@@ -29,7 +29,7 @@ use std::str;
 use super::types::{Slatepack, SlatepackBin};
 
 // Framing and formatting for slate armor
-static HEADER: &str = "BEGINSLATEPACK. ";
+pub static HEADER: &str = "BEGINSLATEPACK. ";
 static FOOTER: &str = ". ENDSLATEPACK.";
 const WORD_LENGTH: usize = 15;
 

--- a/libwallet/src/slatepack/mod.rs
+++ b/libwallet/src/slatepack/mod.rs
@@ -14,8 +14,10 @@
 
 mod address;
 mod armor;
+mod packer;
 mod types;
 
 pub use self::address::SlatepackAddress;
 pub use self::armor::SlatepackArmor;
+pub use self::packer::{Slatepacker, SlatepackerArgs};
 pub use self::types::{Slatepack, SlatepackBin};

--- a/libwallet/src/slatepack/mod.rs
+++ b/libwallet/src/slatepack/mod.rs
@@ -12,8 +12,10 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+mod address;
 mod armor;
 mod types;
 
+pub use self::address::SlatepackAddress;
 pub use self::armor::SlatepackArmor;
 pub use self::types::{Slatepack, SlatepackBin};

--- a/libwallet/src/slatepack/packer.rs
+++ b/libwallet/src/slatepack/packer.rs
@@ -1,0 +1,120 @@
+// Copyright 2020 The Grin Developers
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use std::convert::TryFrom;
+use std::iter::FromIterator;
+
+use crate::{Error, ErrorKind};
+use crate::{
+	Slate, SlateVersion, Slatepack, SlatepackAddress, SlatepackArmor, SlatepackBin,
+	VersionedBinSlate, VersionedSlate,
+};
+
+use grin_wallet_util::byte_ser;
+
+use ed25519_dalek::SecretKey as edSecretKey;
+
+#[derive(Clone)]
+/// Arguments, mostly for encrypting decrypting a slatepack
+pub struct SlatepackerArgs<'a> {
+	/// Optional sender to include in slatepack
+	pub sender: Option<SlatepackAddress>,
+	/// Optional list of recipients, for encryption
+	pub recipients: Vec<SlatepackAddress>,
+	/// Optional decryption key
+	pub dec_key: Option<&'a edSecretKey>,
+}
+
+/// Helper struct to pack and unpack slatepacks
+#[derive(Clone)]
+pub struct Slatepacker<'a>(SlatepackerArgs<'a>);
+
+impl<'a> Slatepacker<'a> {
+	/// Create with pathbuf and recipients
+	pub fn new(args: SlatepackerArgs<'a>) -> Self {
+		Self(args)
+	}
+
+	/// return slatepack
+	pub fn deser_slatepack(&self, data: Vec<u8>) -> Result<Slatepack, Error> {
+		// check if data is armored, if so, remove and continue
+		let test_header = Vec::from_iter(data[0..super::armor::HEADER.len()].iter().cloned());
+		let data = match String::from_utf8(test_header) {
+			Ok(s) => {
+				if s.as_str() == super::armor::HEADER {
+					SlatepackArmor::decode(
+						String::from_utf8(data)
+							.map_err(|e| {
+								let msg = format!("{}", e);
+								error!("Error decoding slatepack armor: {}", msg);
+								ErrorKind::SlatepackDeser(msg)
+							})?
+							.as_str(),
+					)?
+				} else {
+					data
+				}
+			}
+			Err(_) => data,
+		};
+
+		// try as bin first, then as json
+		let mut slatepack = match byte_ser::from_bytes::<SlatepackBin>(&data) {
+			Ok(s) => s.0,
+			Err(e) => {
+				debug!("Not a valid binary slatepack: {} - Will try JSON", e);
+				let content = String::from_utf8(data).map_err(|e| {
+					let msg = format!("{}", e);
+					ErrorKind::SlatepackDeser(msg)
+				})?;
+				serde_json::from_str(&content).map_err(|e| {
+					let msg = format!("Error reading JSON slatepack: {}", e);
+					ErrorKind::SlatepackDeser(msg)
+				})?
+			}
+		};
+
+		slatepack.ver_check_warn();
+		slatepack.try_decrypt_payload(self.0.dec_key)?;
+		Ok(slatepack)
+	}
+
+	/// Create slatepack from slate and args
+	pub fn create_slatepack(&self, slate: &Slate) -> Result<Slatepack, Error> {
+		let out_slate = VersionedSlate::into_version(slate.clone(), SlateVersion::V4)?;
+		let bin_slate =
+			VersionedBinSlate::try_from(out_slate).map_err(|_| ErrorKind::SlatepackSer)?;
+		let mut slatepack = Slatepack::default();
+		slatepack.payload = byte_ser::to_bytes(&bin_slate).map_err(|_| ErrorKind::SlatepackSer)?;
+		slatepack.sender = self.0.sender.clone();
+		slatepack.try_encrypt_payload(self.0.recipients.clone())?;
+		Ok(slatepack)
+	}
+
+	/// Armor a slatepack
+	pub fn armor_slatepack(&self, slatepack: &Slatepack) -> Result<String, Error> {
+		SlatepackArmor::encode(&slatepack, 3)
+	}
+
+	/// Return/upgrade slate from slatepack
+	pub fn get_slate(&self, slatepack: &Slatepack) -> Result<Slate, Error> {
+		let slate_bin =
+			byte_ser::from_bytes::<VersionedBinSlate>(&slatepack.payload).map_err(|e| {
+				error!("Error reading slate from armored slatepack: {}", e);
+				let msg = format!("{}", e);
+				ErrorKind::SlatepackDeser(msg)
+			})?;
+		Ok(Slate::upgrade(slate_bin.into())?)
+	}
+}


### PR DESCRIPTION
* Adds the `SlatepackAddress` struct as specified in the slatepack RFC with all required conversion and serialization functions.
* Replaces x25519 keys in the slatepack struct with `SlatepackAddress`
* Refactors Slatepack functions into libwallet in anticipation of adding slatepack functions to the API.
