### PR TITLE
[DNM] panic to demonstrate doctest failing prior to testing anything

### DIFF
--- a/api/src/owner.rs
+++ b/api/src/owner.rs
@@ -847,6 +847,8 @@ where
 	///     // ...
 	///     // Lock our outputs if we're happy the slate was (or is being) sent
 	///     api_owner.tx_lock_outputs(None, &slate);
+	/// } else {
+	/// 	panic!("if we get here we never actually test tx_lock_outputs");
 	/// }
 	/// ```
 
@@ -2079,6 +2081,8 @@ where
 	///     if let Ok(_) = valid {
 	///       //...
 	///     }
+	/// } else {
+	///		panic!("if we get here we never actually test verify_payment_proof");
 	/// }
 	/// ```
 
@@ -2150,7 +2154,11 @@ macro_rules! doctest_helper_setup_doc_env {
 				>;
 		let lc = wallet.lc_provider().unwrap();
 		let _ = lc.set_top_level_directory(&wallet_config.data_file_dir);
-		lc.open_wallet(None, pw, false, false);
+		let res = lc.open_wallet(None, pw, false, false);
+		println!(
+			"open_wallet fails in *every* test that uses this setup code: {:?}",
+			res
+			);
 		let mut $wallet = Arc::new(Mutex::new(wallet));
 	};
 }


### PR DESCRIPTION
In `doctest_helper_setup_doc_env` we call `open_wallet()` but this fails as we have not yet created a wallet.
So the setup code fails for every doctest that uses it.
This causes several tests to not actually test what they appear to be testing due to the way the tests are written.

Both `tx_lock_outputs` and `verify_payment_proof` appear to fail on CI regularly but they are not actually running correctly locally either.

I don't fully understand why they cause CI to fail while effectively failing silently locally, but the tests are not exercising the api.

----

```
failures:

---- src/owner.rs - owner::Owner<L, C, K>::tx_lock_outputs (line 827) stdout ----
Test executable failed (exit code 101).

stdout:
open_wallet fails in *every* test that uses this setup code: Err(Error { inner: Error { inner: 

Wallet seed doesn't exist error }

Lifecycle Error: Error opening wallet (is password correct?) })

stderr:
thread 'main' panicked at 'if we get here we never actually test tx_lock_outputs', src/owner.rs:27:5
note: run with `RUST_BACKTRACE=1` environment variable to display a backtrace


---- src/owner.rs - owner::Owner<L, C, K>::verify_payment_proof (line 2068) stdout ----
Test executable failed (exit code 101).

stdout:
open_wallet fails in *every* test that uses this setup code: Err(Error { inner: Error { inner: 

Wallet seed doesn't exist error }

Lifecycle Error: Error opening wallet (is password correct?) })

stderr:
thread 'main' panicked at 'if we get here we never actually test verify_payment_proof', src/owner.rs:22:5
note: run with `RUST_BACKTRACE=1` environment variable to display a backtrace



failures:
    src/owner.rs - owner::Owner<L, C, K>::tx_lock_outputs (line 827)
    src/owner.rs - owner::Owner<L, C, K>::verify_payment_proof (line 2068)
```