### PR TITLE
Slatepack OwnerAPI Changes

### DIFF
--- a/api/src/lib.rs
+++ b/api/src/lib.rs
@@ -55,5 +55,6 @@ pub use crate::foreign_rpc::run_doctest_foreign;
 pub use crate::owner_rpc::run_doctest_owner;
 
 pub use types::{
-	ECDHPubkey, EncryptedRequest, EncryptedResponse, EncryptionErrorResponse, JsonId, Token,
+	ECDHPubkey, Ed25519SecretKey, EncryptedRequest, EncryptedResponse, EncryptionErrorResponse,
+	JsonId, Token,
 };

--- a/api/src/lib.rs
+++ b/api/src/lib.rs
@@ -55,6 +55,5 @@ pub use crate::foreign_rpc::run_doctest_foreign;
 pub use crate::owner_rpc::run_doctest_owner;
 
 pub use types::{
-	ECDHPubkey, EncryptedRequest, EncryptedResponse, EncryptionErrorResponse, JsonId, PubAddress,
-	Token,
+	ECDHPubkey, EncryptedRequest, EncryptedResponse, EncryptionErrorResponse, JsonId, Token,
 };

--- a/api/src/owner.rs
+++ b/api/src/owner.rs
@@ -1851,6 +1851,8 @@ where
 		Ok(q.split_off(index))
 	}
 
+	// SLATEPACK
+
 	/// Retrieve the public slatepack address associated with the active account at the
 	/// given derivation path.
 	///
@@ -1899,7 +1901,7 @@ where
 	/// // Set up as above
 	/// # let api_owner = Owner::new(wallet.clone(), None);
 	///
-	/// let res = api_owner.get_public_proof_address(None, 0);
+	/// let res = api_owner.get_slatepack_address(None, 0);
 	///
 	/// if let Ok(_) = res {
 	///   // ...
@@ -1912,12 +1914,41 @@ where
 		keychain_mask: Option<&SecretKey>,
 		derivation_index: u32,
 	) -> Result<SlatepackAddress, Error> {
-		owner::get_public_proof_address(self.wallet_inst.clone(), keychain_mask, derivation_index)
+		owner::get_slatepack_address(self.wallet_inst.clone(), keychain_mask, derivation_index)
 	}
 
-	// TODO: Doc
-	/// get public proof a
-	pub fn get_secret_key(
+	/// Retrieve the private slatepack key at the given derivation index. Currently
+	/// used to decrypt encrypted slatepack messages.
+	///
+	/// # Arguments
+	///
+	/// * `keychain_mask` - Wallet secret mask to XOR against the stored wallet seed before using, if
+	/// * `derivation_index` - The index along the derivation path to for which to retrieve the secret key
+	///
+	/// # Returns
+	/// * Ok with a SecretKey if successful
+	/// * or [`libwallet::Error`](../grin_wallet_libwallet/struct.Error.html) if an error is encountered.
+	///
+	/// # Example
+	/// Set up as in [`new`](struct.Owner.html#method.new) method above.
+	/// ```
+	/// # grin_wallet_api::doctest_helper_setup_doc_env!(wallet, wallet_config);
+	///
+	/// use grin_core::global::ChainTypes;
+	///
+	/// use std::time::Duration;
+	///
+	/// // Set up as above
+	/// # let api_owner = Owner::new(wallet.clone(), None);
+	///
+	/// let res = api_owner.get_slatepack_secret_key(None, 0);
+	///
+	/// if let Ok(_) = res {
+	///   // ...
+	/// }
+	///
+	/// ```
+	pub fn get_slatepack_secret_key(
 		&self,
 		keychain_mask: Option<&SecretKey>,
 		derivation_index: u32,

--- a/api/src/owner.rs
+++ b/api/src/owner.rs
@@ -2000,7 +2000,7 @@ where
 	///
 	/// if let Ok(slate) = result {
 	///     // Create a slatepack from our slate
-	///     let slatepack = api_owner.create_slatepack(
+	///     let slatepack = api_owner.create_slatepack_message(
 	///        None,
 	///        &slate,
 	///        Some(0),
@@ -2011,7 +2011,7 @@ where
 	///
 	/// ```
 
-	pub fn create_slatepack(
+	pub fn create_slatepack_message(
 		&self,
 		keychain_mask: Option<&SecretKey>,
 		slate: &Slate,
@@ -2019,7 +2019,7 @@ where
 		num_cols: usize,
 		recipients: Vec<SlatepackAddress>,
 	) -> Result<String, Error> {
-		owner::create_slatepack(
+		owner::create_slatepack_message(
 			self.wallet_inst.clone(),
 			keychain_mask,
 			slate,
@@ -2057,20 +2057,20 @@ where
 	/// # let api_owner = Owner::new(wallet.clone(), None);
 	/// // ... receive a slatepack from somewhere
 	/// # let slatepack_string = String::from("");
-	///   let res = api_owner.slate_from_slatepack(
+	///   let res = api_owner.slate_from_slatepack_message(
 	///    None,
 	///    slatepack_string,
 	///    vec![0, 1, 2],
 	///   );
 	/// ```
 
-	pub fn slate_from_slatepack(
+	pub fn slate_from_slatepack_message(
 		&self,
 		keychain_mask: Option<&SecretKey>,
 		slatepack: String,
 		secret_indices: Vec<u32>,
 	) -> Result<Slate, Error> {
-		owner::slate_from_slatepack(
+		owner::slate_from_slatepack_message(
 			self.wallet_inst.clone(),
 			keychain_mask,
 			slatepack,
@@ -2103,14 +2103,14 @@ where
 	/// # let api_owner = Owner::new(wallet.clone(), None);
 	/// # let slatepack_string = String::from("");
 	/// // .. receive a slatepack from somewhere
-	/// let res = api_owner.decode_slatepack(
+	/// let res = api_owner.decode_slatepack_message(
 	///    slatepack_string
 	/// );
 	///
 	/// ```
 
-	pub fn decode_slatepack(&self, slatepack: String) -> Result<Slatepack, Error> {
-		owner::decode_slatepack(slatepack)
+	pub fn decode_slatepack_message(&self, slatepack: String) -> Result<Slatepack, Error> {
+		owner::decode_slatepack_message(slatepack)
 	}
 
 	// PAYMENT PROOFS

--- a/api/src/owner.rs
+++ b/api/src/owner.rs
@@ -1917,7 +1917,7 @@ where
 		owner::get_slatepack_address(self.wallet_inst.clone(), keychain_mask, derivation_index)
 	}
 
-	/// Retrieve the private slatepack key at the given derivation index. Currently
+	/// Retrieve the private ed25519 slatepack key at the given derivation index. Currently
 	/// used to decrypt encrypted slatepack messages.
 	///
 	/// # Arguments
@@ -1926,7 +1926,7 @@ where
 	/// * `derivation_index` - The index along the derivation path to for which to retrieve the secret key
 	///
 	/// # Returns
-	/// * Ok with a SecretKey if successful
+	/// * Ok with an ed25519_dalek::SecretKey if successful
 	/// * or [`libwallet::Error`](../grin_wallet_libwallet/struct.Error.html) if an error is encountered.
 	///
 	/// # Example
@@ -1953,7 +1953,7 @@ where
 		keychain_mask: Option<&SecretKey>,
 		derivation_index: u32,
 	) -> Result<DalekSecretKey, Error> {
-		owner::get_secret_key(self.wallet_inst.clone(), keychain_mask, derivation_index)
+		owner::get_slatepack_secret_key(self.wallet_inst.clone(), keychain_mask, derivation_index)
 	}
 
 	/// Returns a single, exportable [PaymentProof](../grin_wallet_libwallet/api_impl/types/struct.PaymentProof.html)

--- a/api/src/owner_rpc.rs
+++ b/api/src/owner_rpc.rs
@@ -21,8 +21,8 @@ use crate::core::global;
 use crate::keychain::{Identifier, Keychain};
 use crate::libwallet::{
 	AcctPathMapping, ErrorKind, InitTxArgs, IssueInvoiceTxArgs, NodeClient, NodeHeightResult,
-	OutputCommitMapping, PaymentProof, Slate, SlateVersion, SlatepackAddress, StatusMessage,
-	TxLogEntry, VersionedSlate, WalletInfo, WalletLCProvider,
+	OutputCommitMapping, PaymentProof, Slate, SlateVersion, Slatepack, SlatepackAddress,
+	StatusMessage, TxLogEntry, VersionedSlate, WalletInfo, WalletLCProvider,
 };
 use crate::util::logger::LoggingConfig;
 use crate::util::secp::key::{PublicKey, SecretKey};
@@ -1459,6 +1459,153 @@ pub trait OwnerRpc {
 	) -> Result<Ed25519SecretKey, ErrorKind>;
 
 	/**
+	Networked version of [Owner::create_slatepack](struct.Owner.html#method.create_slatepack).
+	```
+	# grin_wallet_api::doctest_helper_json_rpc_owner_assert_response!(
+	# r#"
+	{
+		"jsonrpc": "2.0",
+		"method": "create_slatepack",
+		"params": {
+			"token": "d202964900000000d302964900000000d402964900000000d502964900000000",
+			"sender_index": 0,
+			"num_cols": 3,
+			"recipients": [],
+			"slate": {
+				"amt": "6000000000",
+				"fee": "8000000",
+				"id": "0436430c-2b02-624c-2032-570501212b00",
+				"off": "0gKWSQAAAADTApZJAAAAANQClkkAAAAA1QKWSQAAAAA=",
+				"proof": {
+					"raddr": "eD9lKGaXQqmQ4Prwpfyl1bMzDje7uc1cYoaW0Dzk6BA=",
+					"saddr": "Ms3WOSiFT4smKLHc5GJt3N811Wy3z999ZMylgit41NM="
+				},
+				"sigs": [
+					{
+						"nonce": "AxuExVZ7EmRAmV0+1aq6BWXXHhg0YEgZ/5wX9enV3QeP",
+						"xs": "Ajh4zoRXJ/Ok7HbKPz20s4otBdY2uMNjIQi4V/7WPJbe"
+					}
+				],
+				"sta": "S1",
+				"ver": "4:2"
+			}
+		},
+		"id": 1
+	}
+	# "#
+	# ,
+	# r#"
+	{
+		"id": 1,
+		"jsonrpc": "2.0",
+		"result": {
+			"Ok": "BEGINSLATEPACK. 8GQrdcwdLKJD28F 3a9siP7ZhZgAh7w\nBR2EiZHza5WMWmZ Cc8zBUemrrYRjhq j3VBwA8vYnvXXKU\nBDmQBN2yKgmR8mX UzvXHezfznA61d7 qFZYChhz94vd8Ew\nNEPLz7jmcVN2C3w wrfHbeiLubYozP2 uhLouFiYRrbe3fQ\n4uhWGfT3sQYXScT dAeo29EaZJpfauh j8VL5jsxST2SPHq\nnzXFC2w9yYVjt7D ju7GSgHEp5aHz9R xstGbHjbsb4JQod\nkYLuELta1ohUwDD pvjhyJmsbLcsPei k5AQhZsJ8RJGBtY\nbou6cU7tZeFJvor 4LB9CBfFB3pmVWD vSLd5RPS75dcnHP\nnbXD8mSDZ8hJS2Q A9wgvppWzuWztJ2 dLUU8f9tLJgsRBw\nYZAs71HiVeg7. ENDSLATEPACK.\n"
+		}
+	}
+	# "#
+	# , 0, false, false, false, false);
+	```
+	*/
+
+	fn create_slatepack(
+		&self,
+		token: Token,
+		slate: VersionedSlate,
+		sender_index: Option<u32>,
+		num_cols: u32,
+		recipients: Vec<SlatepackAddress>,
+	) -> Result<String, ErrorKind>;
+
+	/**
+	Networked version of [Owner::slate_from_slatepack](struct.Owner.html#method.slate_from_slatepack).
+	```
+	# grin_wallet_api::doctest_helper_json_rpc_owner_assert_response!(
+	# r#"
+	{
+		"jsonrpc": "2.0",
+		"method": "slate_from_slatepack",
+		"params": {
+			"token": "d202964900000000d302964900000000d402964900000000d502964900000000",
+			"secret_indices": [0],
+			"slatepack": "BEGINSLATEPACK. 8GQrdcwdLKJD28F 3a9siP7ZhZgAh7w\nBR2EiZHza5WMWmZ Cc8zBUemrrYRjhq j3VBwA8vYnvXXKU\nBDmQBN2yKgmR8mX UzvXHezfznA61d7 qFZYChhz94vd8Ew\nNEPLz7jmcVN2C3w wrfHbeiLubYozP2 uhLouFiYRrbe3fQ\n4uhWGfT3sQYXScT dAeo29EaZJpfauh j8VL5jsxST2SPHq\nnzXFC2w9yYVjt7D ju7GSgHEp5aHz9R xstGbHjbsb4JQod\nkYLuELta1ohUwDD pvjhyJmsbLcsPei k5AQhZsJ8RJGBtY\nbou6cU7tZeFJvor 4LB9CBfFB3pmVWD vSLd5RPS75dcnHP\nnbXD8mSDZ8hJS2Q A9wgvppWzuWztJ2 dLUU8f9tLJgsRBw\nYZAs71HiVeg7. ENDSLATEPACK.\n"
+		},
+		"id": 1
+	}
+	# "#
+	# ,
+	# r#"
+	{
+		"id": 1,
+		"jsonrpc": "2.0",
+		"result": {
+			"Ok": {
+				"amt": "6000000000",
+				"fee": "8000000",
+				"id": "0436430c-2b02-624c-2032-570501212b00",
+				"off": "0gKWSQAAAADTApZJAAAAANQClkkAAAAA1QKWSQAAAAA=",
+				"proof": {
+					"raddr": "eD9lKGaXQqmQ4Prwpfyl1bMzDje7uc1cYoaW0Dzk6BA=",
+					"saddr": "Ms3WOSiFT4smKLHc5GJt3N811Wy3z999ZMylgit41NM="
+				},
+				"sigs": [
+					{
+						"nonce": "AxuExVZ7EmRAmV0+1aq6BWXXHhg0YEgZ/5wX9enV3QeP",
+						"xs": "Ajh4zoRXJ/Ok7HbKPz20s4otBdY2uMNjIQi4V/7WPJbe"
+					}
+				],
+				"sta": "S1",
+				"ver": "4:2"
+			}
+		}
+	}
+	# "#
+	# , 0, false, false, false, false);
+	```
+	*/
+
+	fn slate_from_slatepack(
+		&self,
+		token: Token,
+		slatepack: String,
+		secret_indices: Vec<u32>,
+	) -> Result<VersionedSlate, ErrorKind>;
+
+	/**
+	Networked version of [Owner::decode_slatepack](struct.Owner.html#method.decode_slatepack).
+	```
+	# grin_wallet_api::doctest_helper_json_rpc_owner_assert_response!(
+	# r#"
+	{
+		"jsonrpc": "2.0",
+		"method": "decode_slatepack",
+		"params": {
+			"slatepack": "BEGINSLATEPACK. 8GQrdcwdLKJD28F 3a9siP7ZhZgAh7w\nBR2EiZHza5WMWmZ Cc8zBUemrrYRjhq j3VBwA8vYnvXXKU\nBDmQBN2yKgmR8mX UzvXHezfznA61d7 qFZYChhz94vd8Ew\nNEPLz7jmcVN2C3w wrfHbeiLubYozP2 uhLouFiYRrbe3fQ\n4uhWGfT3sQYXScT dAeo29EaZJpfauh j8VL5jsxST2SPHq\nnzXFC2w9yYVjt7D ju7GSgHEp5aHz9R xstGbHjbsb4JQod\nkYLuELta1ohUwDD pvjhyJmsbLcsPei k5AQhZsJ8RJGBtY\nbou6cU7tZeFJvor 4LB9CBfFB3pmVWD vSLd5RPS75dcnHP\nnbXD8mSDZ8hJS2Q A9wgvppWzuWztJ2 dLUU8f9tLJgsRBw\nYZAs71HiVeg7. ENDSLATEPACK.\n"
+		},
+		"id": 1
+	}
+	# "#
+	# ,
+	# r#"
+	{
+		"id": 1,
+		"jsonrpc": "2.0",
+		"result": {
+			"Ok": {
+				"mode": 0,
+				"payload": "AAQAAgQ2QwwrAmJMIDJXBQEhKwAB0gKWSQAAAADTApZJAAAAANQClkkAAAAA1QKWSQAAAAAGAAAAAWWgvAAAAAAAAHoSAAEAAjh4zoRXJ/Ok7HbKPz20s4otBdY2uMNjIQi4V/7WPJbeAxuExVZ7EmRAmV0+1aq6BWXXHhg0YEgZ/5wX9enV3QePAjLN1jkohU+LJiix3ORibdzfNdVst8/ffWTMpYIreNTTeD9lKGaXQqmQ4Prwpfyl1bMzDje7uc1cYoaW0Dzk6BAA",
+				"sender": "slatepack1xtxavwfgs48ckf3gk8wwgcndmn0nt4tvkl8a7ltyejjcy2mc6nfskdvkdu",
+				"slatepack": "1.0"
+			}
+		}
+	}
+	# "#
+	# , 0, false, false, false, false);
+	```
+	*/
+
+	fn decode_slatepack(&self, slatepack: String) -> Result<Slatepack, ErrorKind>;
+
+	/**
 	Networked version of [Owner::retrieve_payment_proof](struct.Owner.html#method.retrieve_payment_proof).
 	```
 	# grin_wallet_api::doctest_helper_json_rpc_owner_assert_response!(
@@ -1888,6 +2035,46 @@ where
 		)
 		.map_err(|e| e.kind())?;
 		Ok(Ed25519SecretKey { key })
+	}
+
+	fn create_slatepack(
+		&self,
+		token: Token,
+		slate: VersionedSlate,
+		sender_index: Option<u32>,
+		num_cols: u32,
+		recipients: Vec<SlatepackAddress>,
+	) -> Result<String, ErrorKind> {
+		Owner::create_slatepack(
+			self,
+			(&token.keychain_mask).as_ref(),
+			&Slate::from(slate),
+			sender_index,
+			num_cols as usize,
+			recipients,
+		)
+		.map_err(|e| e.kind())
+	}
+
+	fn slate_from_slatepack(
+		&self,
+		token: Token,
+		slatepack: String,
+		secret_indices: Vec<u32>,
+	) -> Result<VersionedSlate, ErrorKind> {
+		let slate = Owner::slate_from_slatepack(
+			self,
+			(&token.keychain_mask).as_ref(),
+			slatepack,
+			secret_indices,
+		)
+		.map_err(|e| e.kind())?;
+		let version = SlateVersion::V4;
+		Ok(VersionedSlate::into_version(slate, version).map_err(|e| e.kind())?)
+	}
+
+	fn decode_slatepack(&self, slatepack: String) -> Result<Slatepack, ErrorKind> {
+		Owner::decode_slatepack(self, slatepack).map_err(|e| e.kind())
 	}
 
 	fn retrieve_payment_proof(

--- a/api/src/owner_rpc.rs
+++ b/api/src/owner_rpc.rs
@@ -1459,13 +1459,13 @@ pub trait OwnerRpc {
 	) -> Result<Ed25519SecretKey, ErrorKind>;
 
 	/**
-	Networked version of [Owner::create_slatepack](struct.Owner.html#method.create_slatepack).
+	Networked version of [Owner::create_slatepack_message](struct.Owner.html#method.create_slatepack_message).
 	```
 	# grin_wallet_api::doctest_helper_json_rpc_owner_assert_response!(
 	# r#"
 	{
 		"jsonrpc": "2.0",
-		"method": "create_slatepack",
+		"method": "create_slatepack_message",
 		"params": {
 			"token": "d202964900000000d302964900000000d402964900000000d502964900000000",
 			"sender_index": 0,
@@ -1507,7 +1507,7 @@ pub trait OwnerRpc {
 	```
 	*/
 
-	fn create_slatepack(
+	fn create_slatepack_message(
 		&self,
 		token: Token,
 		slate: VersionedSlate,
@@ -1517,17 +1517,17 @@ pub trait OwnerRpc {
 	) -> Result<String, ErrorKind>;
 
 	/**
-	Networked version of [Owner::slate_from_slatepack](struct.Owner.html#method.slate_from_slatepack).
+	Networked version of [Owner::slate_from_slatepack_message](struct.Owner.html#method.slate_from_slatepack_message).
 	```
 	# grin_wallet_api::doctest_helper_json_rpc_owner_assert_response!(
 	# r#"
 	{
 		"jsonrpc": "2.0",
-		"method": "slate_from_slatepack",
+		"method": "slate_from_slatepack_message",
 		"params": {
 			"token": "d202964900000000d302964900000000d402964900000000d502964900000000",
 			"secret_indices": [0],
-			"slatepack": "BEGINSLATEPACK. 8GQrdcwdLKJD28F 3a9siP7ZhZgAh7w\nBR2EiZHza5WMWmZ Cc8zBUemrrYRjhq j3VBwA8vYnvXXKU\nBDmQBN2yKgmR8mX UzvXHezfznA61d7 qFZYChhz94vd8Ew\nNEPLz7jmcVN2C3w wrfHbeiLubYozP2 uhLouFiYRrbe3fQ\n4uhWGfT3sQYXScT dAeo29EaZJpfauh j8VL5jsxST2SPHq\nnzXFC2w9yYVjt7D ju7GSgHEp5aHz9R xstGbHjbsb4JQod\nkYLuELta1ohUwDD pvjhyJmsbLcsPei k5AQhZsJ8RJGBtY\nbou6cU7tZeFJvor 4LB9CBfFB3pmVWD vSLd5RPS75dcnHP\nnbXD8mSDZ8hJS2Q A9wgvppWzuWztJ2 dLUU8f9tLJgsRBw\nYZAs71HiVeg7. ENDSLATEPACK.\n"
+			"message": "BEGINSLATEPACK. 8GQrdcwdLKJD28F 3a9siP7ZhZgAh7w\nBR2EiZHza5WMWmZ Cc8zBUemrrYRjhq j3VBwA8vYnvXXKU\nBDmQBN2yKgmR8mX UzvXHezfznA61d7 qFZYChhz94vd8Ew\nNEPLz7jmcVN2C3w wrfHbeiLubYozP2 uhLouFiYRrbe3fQ\n4uhWGfT3sQYXScT dAeo29EaZJpfauh j8VL5jsxST2SPHq\nnzXFC2w9yYVjt7D ju7GSgHEp5aHz9R xstGbHjbsb4JQod\nkYLuELta1ohUwDD pvjhyJmsbLcsPei k5AQhZsJ8RJGBtY\nbou6cU7tZeFJvor 4LB9CBfFB3pmVWD vSLd5RPS75dcnHP\nnbXD8mSDZ8hJS2Q A9wgvppWzuWztJ2 dLUU8f9tLJgsRBw\nYZAs71HiVeg7. ENDSLATEPACK.\n"
 		},
 		"id": 1
 	}
@@ -1563,23 +1563,23 @@ pub trait OwnerRpc {
 	```
 	*/
 
-	fn slate_from_slatepack(
+	fn slate_from_slatepack_message(
 		&self,
 		token: Token,
-		slatepack: String,
+		message: String,
 		secret_indices: Vec<u32>,
 	) -> Result<VersionedSlate, ErrorKind>;
 
 	/**
-	Networked version of [Owner::decode_slatepack](struct.Owner.html#method.decode_slatepack).
+	Networked version of [Owner::decode_slatepack_message](struct.Owner.html#method.decode_slatepack_message).
 	```
 	# grin_wallet_api::doctest_helper_json_rpc_owner_assert_response!(
 	# r#"
 	{
 		"jsonrpc": "2.0",
-		"method": "decode_slatepack",
+		"method": "decode_slatepack_message",
 		"params": {
-			"slatepack": "BEGINSLATEPACK. 8GQrdcwdLKJD28F 3a9siP7ZhZgAh7w\nBR2EiZHza5WMWmZ Cc8zBUemrrYRjhq j3VBwA8vYnvXXKU\nBDmQBN2yKgmR8mX UzvXHezfznA61d7 qFZYChhz94vd8Ew\nNEPLz7jmcVN2C3w wrfHbeiLubYozP2 uhLouFiYRrbe3fQ\n4uhWGfT3sQYXScT dAeo29EaZJpfauh j8VL5jsxST2SPHq\nnzXFC2w9yYVjt7D ju7GSgHEp5aHz9R xstGbHjbsb4JQod\nkYLuELta1ohUwDD pvjhyJmsbLcsPei k5AQhZsJ8RJGBtY\nbou6cU7tZeFJvor 4LB9CBfFB3pmVWD vSLd5RPS75dcnHP\nnbXD8mSDZ8hJS2Q A9wgvppWzuWztJ2 dLUU8f9tLJgsRBw\nYZAs71HiVeg7. ENDSLATEPACK.\n"
+			"message": "BEGINSLATEPACK. 8GQrdcwdLKJD28F 3a9siP7ZhZgAh7w\nBR2EiZHza5WMWmZ Cc8zBUemrrYRjhq j3VBwA8vYnvXXKU\nBDmQBN2yKgmR8mX UzvXHezfznA61d7 qFZYChhz94vd8Ew\nNEPLz7jmcVN2C3w wrfHbeiLubYozP2 uhLouFiYRrbe3fQ\n4uhWGfT3sQYXScT dAeo29EaZJpfauh j8VL5jsxST2SPHq\nnzXFC2w9yYVjt7D ju7GSgHEp5aHz9R xstGbHjbsb4JQod\nkYLuELta1ohUwDD pvjhyJmsbLcsPei k5AQhZsJ8RJGBtY\nbou6cU7tZeFJvor 4LB9CBfFB3pmVWD vSLd5RPS75dcnHP\nnbXD8mSDZ8hJS2Q A9wgvppWzuWztJ2 dLUU8f9tLJgsRBw\nYZAs71HiVeg7. ENDSLATEPACK.\n"
 		},
 		"id": 1
 	}
@@ -1603,7 +1603,7 @@ pub trait OwnerRpc {
 	```
 	*/
 
-	fn decode_slatepack(&self, slatepack: String) -> Result<Slatepack, ErrorKind>;
+	fn decode_slatepack_message(&self, message: String) -> Result<Slatepack, ErrorKind>;
 
 	/**
 	Networked version of [Owner::retrieve_payment_proof](struct.Owner.html#method.retrieve_payment_proof).
@@ -2037,7 +2037,7 @@ where
 		Ok(Ed25519SecretKey { key })
 	}
 
-	fn create_slatepack(
+	fn create_slatepack_message(
 		&self,
 		token: Token,
 		slate: VersionedSlate,
@@ -2045,7 +2045,7 @@ where
 		num_cols: u32,
 		recipients: Vec<SlatepackAddress>,
 	) -> Result<String, ErrorKind> {
-		Owner::create_slatepack(
+		Owner::create_slatepack_message(
 			self,
 			(&token.keychain_mask).as_ref(),
 			&Slate::from(slate),
@@ -2056,16 +2056,16 @@ where
 		.map_err(|e| e.kind())
 	}
 
-	fn slate_from_slatepack(
+	fn slate_from_slatepack_message(
 		&self,
 		token: Token,
-		slatepack: String,
+		message: String,
 		secret_indices: Vec<u32>,
 	) -> Result<VersionedSlate, ErrorKind> {
-		let slate = Owner::slate_from_slatepack(
+		let slate = Owner::slate_from_slatepack_message(
 			self,
 			(&token.keychain_mask).as_ref(),
-			slatepack,
+			message,
 			secret_indices,
 		)
 		.map_err(|e| e.kind())?;
@@ -2073,8 +2073,8 @@ where
 		Ok(VersionedSlate::into_version(slate, version).map_err(|e| e.kind())?)
 	}
 
-	fn decode_slatepack(&self, slatepack: String) -> Result<Slatepack, ErrorKind> {
-		Owner::decode_slatepack(self, slatepack).map_err(|e| e.kind())
+	fn decode_slatepack_message(&self, message: String) -> Result<Slatepack, ErrorKind> {
+		Owner::decode_slatepack_message(self, message).map_err(|e| e.kind())
 	}
 
 	fn retrieve_payment_proof(

--- a/api/src/owner_rpc.rs
+++ b/api/src/owner_rpc.rs
@@ -21,13 +21,13 @@ use crate::core::global;
 use crate::keychain::{Identifier, Keychain};
 use crate::libwallet::{
 	AcctPathMapping, ErrorKind, InitTxArgs, IssueInvoiceTxArgs, NodeClient, NodeHeightResult,
-	OutputCommitMapping, PaymentProof, Slate, SlateVersion, StatusMessage, TxLogEntry,
-	VersionedSlate, WalletInfo, WalletLCProvider,
+	OutputCommitMapping, PaymentProof, Slate, SlateVersion, SlatepackAddress, StatusMessage,
+	TxLogEntry, VersionedSlate, WalletInfo, WalletLCProvider,
 };
 use crate::util::logger::LoggingConfig;
 use crate::util::secp::key::{PublicKey, SecretKey};
 use crate::util::{static_secp_instance, Mutex, ZeroingString};
-use crate::{ECDHPubkey, Owner, PubAddress, Token};
+use crate::{ECDHPubkey, Owner, Token};
 use easy_jsonrpc_mw;
 use grin_wallet_util::OnionV3Address;
 use rand::thread_rng;
@@ -378,7 +378,7 @@ pub trait OwnerRpc {
 					"num_change_outputs": 1,
 					"selection_strategy_is_use_all": true,
 					"target_slate_version": null,
-					"payment_proof_recipient_address": "pa7wkkdgs5bkteha7lykl7ff2wztgdrxxo442xdcq2lnaphe5aidd4id",
+					"payment_proof_recipient_address": "slatepack10qlk22rxjap2ny8qltc2tl996kenxr3hhwuu6hrzs6tdq08yaqgqnlumr7",
 					"ttl_blocks": null,
 					"send_args": null
 				}
@@ -1389,13 +1389,13 @@ pub trait OwnerRpc {
 	fn get_updater_messages(&self, count: u32) -> Result<Vec<StatusMessage>, ErrorKind>;
 
 	/**
-	Networked version of [Owner::get_public_proof_address](struct.Owner.html#method.get_public_proof_address).
+	Networked version of [Owner::get_slatepack_address](struct.Owner.html#method.get_slatepack_address).
 	```
 	# grin_wallet_api::doctest_helper_json_rpc_owner_assert_response!(
 	# r#"
 	{
 		"jsonrpc": "2.0",
-		"method": "get_public_proof_address",
+		"method": "get_slatepack_address",
 		"params": {
 			"token": "d202964900000000d302964900000000d402964900000000d502964900000000",
 			"derivation_index": 0
@@ -1409,7 +1409,7 @@ pub trait OwnerRpc {
 		"id": 1,
 		"jsonrpc": "2.0",
 		"result": {
-			"Ok": "32cdd63928854f8b2628b1dce4626ddcdf35d56cb7cfdf7d64cca5822b78d4d3"
+			"Ok": "slatepack1xtxavwfgs48ckf3gk8wwgcndmn0nt4tvkl8a7ltyejjcy2mc6nfskdvkdu"
 		}
 	}
 	# "#
@@ -1417,41 +1417,11 @@ pub trait OwnerRpc {
 	```
 	*/
 
-	fn get_public_proof_address(
+	fn get_slatepack_address(
 		&self,
 		token: Token,
 		derivation_index: u32,
-	) -> Result<PubAddress, ErrorKind>;
-
-	/**
-	Networked version of [Owner::proof_address_from_onion_v3](struct.Owner.html#method.proof_address_from_onion_v3).
-	```
-	# grin_wallet_api::doctest_helper_json_rpc_owner_assert_response!(
-	# r#"
-	{
-		"jsonrpc": "2.0",
-		"method": "proof_address_from_onion_v3",
-		"params": {
-			"address_v3": "2a6at2obto3uvkpkitqp4wxcg6u36qf534eucbskqciturczzc5suyid"
-		},
-		"id": 1
-	}
-	# "#
-	# ,
-	# r#"
-	{
-		"id": 1,
-		"jsonrpc": "2.0",
-		"result": {
-			"Ok": "d03c09e9c19bb74aa9ea44e0fe5ae237a9bf40bddf0941064a80913a4459c8bb"
-		}
-	}
-	# "#
-	# , 0, false, false, false, false);
-	```
-	*/
-
-	fn proof_address_from_onion_v3(&self, address_v3: String) -> Result<PubAddress, ErrorKind>;
+	) -> Result<SlatepackAddress, ErrorKind>;
 
 	/**
 	Networked version of [Owner::retrieve_payment_proof](struct.Owner.html#method.retrieve_payment_proof).
@@ -1479,9 +1449,9 @@ pub trait OwnerRpc {
 			"Ok": {
 				"amount": "60000000000",
 				"excess": "091f151170bfac881479bfb56c7012c52cd4ce4198ad661586374dd499925922fb",
-				"recipient_address": "pa7wkkdgs5bkteha7lykl7ff2wztgdrxxo442xdcq2lnaphe5aidd4id",
+				"recipient_address": "slatepack10qlk22rxjap2ny8qltc2tl996kenxr3hhwuu6hrzs6tdq08yaqgqnlumr7",
 				"recipient_sig": "b9b1885a3f33297df32e1aa4db23220bd305da8ed92ff6873faf3ab2c116fea25e9d0e34bd4f567f022b88a37400821ffbcaec71c9a8c3a327c4626611886d0d",
-				"sender_address": "glg5mojiqvhywjriwhooiytn3tptlvlmw7h567lezssyek3y2tjzznad",
+				"sender_address": "slatepack1xtxavwfgs48ckf3gk8wwgcndmn0nt4tvkl8a7ltyejjcy2mc6nfskdvkdu",
 				"sender_sig": "611b92331e395c3d29871ac35b1fce78ec595e28ccbe8cc55452da40775e8e46d35a2e84eaffd986935da3275e34d46a8d777d02dabcf4339704c2a621da9700"
 			}
 		}
@@ -1512,9 +1482,9 @@ pub trait OwnerRpc {
 			"proof": {
 				"amount": "60000000000",
 				"excess": "091f151170bfac881479bfb56c7012c52cd4ce4198ad661586374dd499925922fb",
-				"recipient_address": "pa7wkkdgs5bkteha7lykl7ff2wztgdrxxo442xdcq2lnaphe5aidd4id",
+				"recipient_address": "slatepack10qlk22rxjap2ny8qltc2tl996kenxr3hhwuu6hrzs6tdq08yaqgqnlumr7",
 				"recipient_sig": "b9b1885a3f33297df32e1aa4db23220bd305da8ed92ff6873faf3ab2c116fea25e9d0e34bd4f567f022b88a37400821ffbcaec71c9a8c3a327c4626611886d0d",
-				"sender_address": "glg5mojiqvhywjriwhooiytn3tptlvlmw7h567lezssyek3y2tjzznad",
+				"sender_address": "slatepack1xtxavwfgs48ckf3gk8wwgcndmn0nt4tvkl8a7ltyejjcy2mc6nfskdvkdu",
 				"sender_sig": "611b92331e395c3d29871ac35b1fce78ec595e28ccbe8cc55452da40775e8e46d35a2e84eaffd986935da3275e34d46a8d777d02dabcf4339704c2a621da9700"
 			}
 		},
@@ -1862,18 +1832,13 @@ where
 		Owner::get_updater_messages(self, count as usize).map_err(|e| e.kind())
 	}
 
-	fn get_public_proof_address(
+	fn get_slatepack_address(
 		&self,
 		token: Token,
 		derivation_index: u32,
-	) -> Result<PubAddress, ErrorKind> {
-		let address = Owner::get_public_proof_address(
-			self,
-			(&token.keychain_mask).as_ref(),
-			derivation_index,
-		)
-		.map_err(|e| e.kind())?;
-		Ok(PubAddress { address })
+	) -> Result<SlatepackAddress, ErrorKind> {
+		Owner::get_slatepack_address(self, (&token.keychain_mask).as_ref(), derivation_index)
+			.map_err(|e| e.kind())
 	}
 
 	fn retrieve_payment_proof(
@@ -1900,12 +1865,6 @@ where
 	) -> Result<(bool, bool), ErrorKind> {
 		Owner::verify_payment_proof(self, (&token.keychain_mask).as_ref(), &proof)
 			.map_err(|e| e.kind())
-	}
-
-	fn proof_address_from_onion_v3(&self, address_v3: String) -> Result<PubAddress, ErrorKind> {
-		let address =
-			Owner::proof_address_from_onion_v3(self, &address_v3).map_err(|e| e.kind())?;
-		Ok(PubAddress { address })
 	}
 
 	fn set_tor_config(&self, tor_config: Option<TorConfig>) -> Result<(), ErrorKind> {
@@ -2055,7 +2014,8 @@ pub fn run_doctest_owner(
 		let proof_address = match payment_proof {
 			true => {
 				let address = "783f6528669742a990e0faf0a5fca5d5b3330e37bbb9cd5c628696d03ce4e810";
-				Some(OnionV3Address::try_from(address).unwrap())
+				let address = OnionV3Address::try_from(address).unwrap();
+				Some(SlatepackAddress::try_from(address).unwrap())
 			}
 			false => None,
 		};

--- a/api/src/owner_rpc.rs
+++ b/api/src/owner_rpc.rs
@@ -2005,8 +2005,6 @@ pub fn run_doctest_owner(
 		assert!(wallet_refreshed);
 	}
 
-	//let proof_address = api_impl::owner::get_public_proof_address(wallet2.clone(), (&mask2).as_ref(), 0).unwrap();
-
 	if perform_tx {
 		let amount = 60_000_000_000;
 		let mut w_lock = wallet1.lock();

--- a/api/src/types.rs
+++ b/api/src/types.rs
@@ -12,9 +12,11 @@
 // limitations under the License.
 
 use crate::core::libtx::secp_ser;
+use crate::libwallet::slate_versions::ser as dalek_ser;
 use crate::libwallet::{Error, ErrorKind};
 use crate::util::secp::key::{PublicKey, SecretKey};
 use crate::util::{from_hex, ToHex};
+use ed25519_dalek::SecretKey as DalekSecretKey;
 use failure::ResultExt;
 
 use base64;
@@ -50,6 +52,15 @@ pub struct ECDHPubkey {
 	/// public key, flattened
 	#[serde(with = "secp_ser::pubkey_serde")]
 	pub ecdh_pubkey: PublicKey,
+}
+
+/// Wrapper for Secret Keys
+#[derive(Serialize, Deserialize, Debug)]
+#[serde(transparent)]
+pub struct Ed25519SecretKey {
+	#[serde(with = "dalek_ser::dalek_seckey_serde")]
+	/// Token to XOR mask against the stored wallet seed
+	pub key: DalekSecretKey,
 }
 
 #[derive(Serialize, Deserialize, Debug, Clone)]

--- a/api/src/types.rs
+++ b/api/src/types.rs
@@ -12,14 +12,12 @@
 // limitations under the License.
 
 use crate::core::libtx::secp_ser;
-use crate::libwallet::dalek_ser;
 use crate::libwallet::{Error, ErrorKind};
 use crate::util::secp::key::{PublicKey, SecretKey};
 use crate::util::{from_hex, ToHex};
 use failure::ResultExt;
 
 use base64;
-use ed25519_dalek::PublicKey as DalekPublicKey;
 use rand::{thread_rng, Rng};
 use ring::aead;
 use serde_json::{self, Value};
@@ -43,15 +41,6 @@ pub struct Token {
 	#[serde(with = "secp_ser::option_seckey_serde")]
 	/// Token to XOR mask against the stored wallet seed
 	pub keychain_mask: Option<SecretKey>,
-}
-
-/// Wrapper for dalek public keys, used as addresses
-#[derive(Serialize, Deserialize, Debug, Clone)]
-#[serde(transparent)]
-pub struct PubAddress {
-	#[serde(with = "dalek_ser::dalek_pubkey_serde")]
-	/// Public address
-	pub address: DalekPublicKey,
 }
 
 /// Wrapper for ECDH Public keys

--- a/controller/src/command.rs
+++ b/controller/src/command.rs
@@ -24,12 +24,11 @@ use crate::impls::{HttpSlateSender, PathToSlate, SlatePutter};
 use crate::keychain;
 use crate::libwallet::{
 	self, InitTxArgs, IssueInvoiceTxArgs, NodeClient, PaymentProof, Slate, SlateVersion,
-	WalletLCProvider,
+	SlatepackAddress, WalletLCProvider,
 };
 use crate::util::secp::key::SecretKey;
 use crate::util::{Mutex, ZeroingString};
 use crate::{controller, display};
-use grin_wallet_util::OnionV3Address;
 use serde_json as json;
 use std::fs::File;
 use std::io::{Read, Write};
@@ -272,7 +271,7 @@ pub struct SendArgs {
 	pub fluff: bool,
 	pub max_outputs: usize,
 	pub target_slate_version: Option<u16>,
-	pub payment_proof_address: Option<OnionV3Address>,
+	pub payment_proof_address: Option<SlatepackAddress>,
 	pub ttl_blocks: Option<u64>,
 	//TODO: Remove HF3
 	pub output_v4_slate: bool,
@@ -997,12 +996,11 @@ where
 {
 	controller::owner_single_use(None, keychain_mask, Some(owner_api), |api, m| {
 		// Just address at derivation index 0 for now
-		let pub_key = api.get_public_proof_address(m, 0)?;
-		let addr = OnionV3Address::from_bytes(pub_key.to_bytes());
+		let address = api.get_slatepack_address(m, 0)?;
 		println!();
 		println!("Address for account - {}", g_args.account);
 		println!("-------------------------------------");
-		println!("{}", addr);
+		println!("{}", address);
 		println!();
 		Ok(())
 	})?;

--- a/controller/tests/file.rs
+++ b/controller/tests/file.rs
@@ -19,7 +19,6 @@ extern crate grin_wallet_impls as impls;
 
 use grin_wallet_libwallet as libwallet;
 use grin_wallet_util::grin_core as core;
-use grin_wallet_util::OnionV3Address;
 
 use impls::test_framework::{self, LocalWalletClient};
 use impls::{PathToSlate, SlateGetter as _, SlatePutter as _};
@@ -253,11 +252,9 @@ fn file_exchange_test_impl(test_dir: &'static str, use_bin: bool) -> Result<(), 
 	let mut slate = Slate::blank(2, true);
 	let mut address = None;
 	wallet::controller::owner_single_use(Some(wallet2.clone()), mask2, None, |api, m| {
-		address = Some(api.get_public_proof_address(m, 0)?);
+		address = Some(api.get_slatepack_address(m, 0)?);
 		Ok(())
 	})?;
-
-	let address = OnionV3Address::from_bytes(address.as_ref().unwrap().to_bytes());
 
 	wallet::controller::owner_single_use(Some(wallet1.clone()), mask1, None, |api, m| {
 		// send to send
@@ -268,7 +265,7 @@ fn file_exchange_test_impl(test_dir: &'static str, use_bin: bool) -> Result<(), 
 			max_outputs: 500,
 			num_change_outputs: 1,
 			selection_strategy_is_use_all: true,
-			payment_proof_recipient_address: Some(address.clone()),
+			payment_proof_recipient_address: address.clone(),
 			..Default::default()
 		};
 		let slate = api.init_send_tx(m, args)?;

--- a/controller/tests/slatepack.rs
+++ b/controller/tests/slatepack.rs
@@ -151,7 +151,7 @@ fn slatepack_exchange_test_impl(
 			let mut rec_address = SlatepackAddress::random();
 			let mut sec_key = edDalekSecretKey::from_bytes(&[0u8; 32]).unwrap();
 			wallet::controller::owner_single_use(Some(wallet1.clone()), mask1, None, |api, m| {
-				sec_key = api.get_secret_key(m, 0)?;
+				sec_key = api.get_slatepack_secret_key(m, 0)?;
 				let pub_key = edDalekPublicKey::from(&sec_key);
 				rec_address = SlatepackAddress::new(&pub_key);
 				Ok(())
@@ -170,7 +170,7 @@ fn slatepack_exchange_test_impl(
 			let mut rec_address = SlatepackAddress::random();
 			let mut sec_key = edDalekSecretKey::from_bytes(&[0u8; 32]).unwrap();
 			wallet::controller::owner_single_use(Some(wallet2.clone()), mask2, None, |api, m| {
-				sec_key = api.get_secret_key(m, 0)?;
+				sec_key = api.get_slatepack_secret_key(m, 0)?;
 				let pub_key = edDalekPublicKey::from(&sec_key);
 				rec_address = SlatepackAddress::new(&pub_key);
 				Ok(())

--- a/controller/tests/slatepack.rs
+++ b/controller/tests/slatepack.rs
@@ -19,7 +19,6 @@ extern crate grin_wallet_impls as impls;
 
 use grin_wallet_libwallet as libwallet;
 use grin_wallet_util::grin_core as core;
-use grin_wallet_util::OnionV3Address;
 
 use impls::test_framework::{self, LocalWalletClient};
 use impls::{PathToSlatepack, SlatePutter as _};
@@ -379,11 +378,9 @@ fn slatepack_exchange_test_impl(
 	let mut slate = Slate::blank(2, true);
 	let mut address = None;
 	wallet::controller::owner_single_use(Some(wallet2.clone()), mask2, None, |api, m| {
-		address = Some(api.get_public_proof_address(m, 0)?);
+		address = Some(api.get_slatepack_address(m, 0)?);
 		Ok(())
 	})?;
-
-	let address = OnionV3Address::from_bytes(address.as_ref().unwrap().to_bytes());
 
 	wallet::controller::owner_single_use(Some(wallet1.clone()), mask1, None, |api, m| {
 		// send to send
@@ -394,7 +391,7 @@ fn slatepack_exchange_test_impl(
 			max_outputs: 500,
 			num_change_outputs: 1,
 			selection_strategy_is_use_all: true,
-			payment_proof_recipient_address: Some(address.clone()),
+			payment_proof_recipient_address: address.clone(),
 			..Default::default()
 		};
 		let slate = api.init_send_tx(m, args)?;

--- a/controller/tests/slatepack.rs
+++ b/controller/tests/slatepack.rs
@@ -494,11 +494,11 @@ fn slatepack_api_impl(test_dir: &'static str) -> Result<(), libwallet::Error> {
 		let slate = api.init_send_tx(m, args)?;
 		// create an encrypted slatepack (just encrypted for self)
 		let enc_addr = api.get_slatepack_address(m, 0)?;
-		let slatepack = api.create_slatepack(m, &slate, Some(0), 3, vec![enc_addr])?;
+		let slatepack = api.create_slatepack_message(m, &slate, Some(0), 3, vec![enc_addr])?;
 		println!("{}", slatepack);
-		let slatepack_raw = api.decode_slatepack(slatepack.clone())?;
+		let slatepack_raw = api.decode_slatepack_message(slatepack.clone())?;
 		println!("{}", slatepack_raw);
-		let decoded_slate = api.slate_from_slatepack(m, slatepack, vec![0])?;
+		let decoded_slate = api.slate_from_slatepack_message(m, slatepack, vec![0])?;
 		println!("{}", decoded_slate);
 		Ok(())
 	})?;

--- a/impls/src/adapters/slatepack.rs
+++ b/impls/src/adapters/slatepack.rs
@@ -57,7 +57,7 @@ impl<'a> SlatePutter for PathToSlatepack<'a> {
 		let mut pub_tx = File::create(&self.pathbuf)?;
 		if as_bin {
 			if self.armor_output {
-				let armored = self.packer.armor_slatepack(&slatepack)?;
+				let armored = self.packer.armor_slatepack(&slatepack, 3)?;
 				pub_tx.write_all(armored.as_bytes())?;
 			} else {
 				pub_tx.write_all(

--- a/libwallet/src/api_impl/owner.rs
+++ b/libwallet/src/api_impl/owner.rs
@@ -124,8 +124,8 @@ where
 	Ok(d_skey)
 }
 
-/// Create a slatepack from the given slate
-pub fn create_slatepack<'a, L, C, K>(
+/// Create a slatepack message from the given slate
+pub fn create_slatepack_message<'a, L, C, K>(
 	wallet_inst: Arc<Mutex<Box<dyn WalletInst<'a, L, C, K>>>>,
 	keychain_mask: Option<&SecretKey>,
 	slate: &Slate,
@@ -151,9 +151,9 @@ where
 	packer.armor_slatepack(&slatepack, num_cols)
 }
 
-/// Unpack a slate from the given slatepack,
+/// Unpack a slate from the given slatepack message,
 /// optionally decrypting
-pub fn slate_from_slatepack<'a, L, C, K>(
+pub fn slate_from_slatepack_message<'a, L, C, K>(
 	wallet_inst: Arc<Mutex<Box<dyn WalletInst<'a, L, C, K>>>>,
 	keychain_mask: Option<&SecretKey>,
 	slatepack: String,
@@ -201,8 +201,8 @@ where
 	}
 }
 
-/// Decode a slatepack, to allow viewing
-pub fn decode_slatepack(slatepack: String) -> Result<Slatepack, Error> {
+/// Decode a slatepack message, to allow viewing
+pub fn decode_slatepack_message(slatepack: String) -> Result<Slatepack, Error> {
 	let packer = Slatepacker::new(SlatepackerArgs {
 		sender: None,
 		recipients: vec![],

--- a/libwallet/src/api_impl/owner.rs
+++ b/libwallet/src/api_impl/owner.rs
@@ -74,10 +74,10 @@ where
 	w.set_parent_key_id_by_name(label)
 }
 
-/// Retrieve the payment proof address for the current parent key at
+/// Retrieve the slatepack address for the current parent key at
 /// the given index
 /// set active account
-pub fn get_public_proof_address<'a, L, C, K>(
+pub fn get_slatepack_address<'a, L, C, K>(
 	wallet_inst: Arc<Mutex<Box<dyn WalletInst<'a, L, C, K>>>>,
 	keychain_mask: Option<&SecretKey>,
 	index: u32,

--- a/libwallet/src/api_impl/owner.rs
+++ b/libwallet/src/api_impl/owner.rs
@@ -97,7 +97,7 @@ where
 /// Retrieve the decryption key for the current parent key
 /// the given index
 /// set active account
-pub fn get_secret_key<'a, L, C, K>(
+pub fn get_slatepack_secret_key<'a, L, C, K>(
 	wallet_inst: Arc<Mutex<Box<dyn WalletInst<'a, L, C, K>>>>,
 	keychain_mask: Option<&SecretKey>,
 	index: u32,

--- a/libwallet/src/api_impl/types.rs
+++ b/libwallet/src/api_impl/types.rs
@@ -20,7 +20,7 @@ use crate::grin_util::secp::pedersen;
 use crate::slate_versions::ser as dalek_ser;
 use crate::slate_versions::SlateVersion;
 use crate::types::OutputData;
-use grin_wallet_util::OnionV3Address;
+use crate::SlatepackAddress;
 
 use ed25519_dalek::Signature as DalekSignature;
 
@@ -64,9 +64,8 @@ pub struct InitTxArgs {
 	#[serde(default)]
 	pub ttl_blocks: Option<u64>,
 	/// If set, require a payment proof for the particular recipient
-	#[serde(with = "dalek_ser::option_ov3_serde")]
 	#[serde(default)]
-	pub payment_proof_recipient_address: Option<OnionV3Address>,
+	pub payment_proof_recipient_address: Option<SlatepackAddress>,
 	/// If true, just return an estimate of the resulting slate, containing fees and amounts
 	/// locked without actually locking outputs or creating the transaction. Note if this is set to
 	/// 'true', the amount field in the slate will contain the total amount locked, not the provided
@@ -203,15 +202,13 @@ pub struct PaymentProof {
 		deserialize_with = "secp_ser::commitment_from_hex"
 	)]
 	pub excess: pedersen::Commitment,
-	/// Recipient Wallet Address (Onion V3)
-	#[serde(with = "dalek_ser::ov3_serde")]
-	pub recipient_address: OnionV3Address,
+	/// Recipient Wallet Address
+	pub recipient_address: SlatepackAddress,
 	/// Recipient Signature
 	#[serde(with = "dalek_ser::dalek_sig_serde")]
 	pub recipient_sig: DalekSignature,
-	/// Sender Wallet Address (Onion V3)
-	#[serde(with = "dalek_ser::ov3_serde")]
-	pub sender_address: OnionV3Address,
+	/// Sender Wallet Address
+	pub sender_address: SlatepackAddress,
 	/// Sender Signature
 	#[serde(with = "dalek_ser::dalek_sig_serde")]
 	pub sender_sig: DalekSignature,

--- a/libwallet/src/error.rs
+++ b/libwallet/src/error.rs
@@ -286,6 +286,10 @@ pub enum ErrorKind {
 	#[fail(display = "Couldn't encrypt Slatepack: {}", _0)]
 	SlatepackEncryption(String),
 
+	/// Slatepack Decryption
+	#[fail(display = "Couldn't decrypt Slatepack: {}", _0)]
+	SlatepackDecryption(String),
+
 	/// age error
 	#[fail(display = "Age error: {}", _0)]
 	Age(String),

--- a/libwallet/src/slate_versions/ser.rs
+++ b/libwallet/src/slate_versions/ser.rs
@@ -262,6 +262,34 @@ pub mod ov3_serde {
 }
 
 /// Serializes an ed25519 PublicKey to and from hex
+pub mod dalek_seckey_serde {
+	use crate::grin_util::{from_hex, ToHex};
+	use ed25519_dalek::SecretKey as DalekSecretKey;
+	use serde::{Deserialize, Deserializer, Serializer};
+
+	///
+	pub fn serialize<S>(key: &DalekSecretKey, serializer: S) -> Result<S::Ok, S::Error>
+	where
+		S: Serializer,
+	{
+		serializer.serialize_str(&key.to_bytes().to_hex())
+	}
+
+	///
+	pub fn deserialize<'de, D>(deserializer: D) -> Result<DalekSecretKey, D::Error>
+	where
+		D: Deserializer<'de>,
+	{
+		use serde::de::Error;
+		String::deserialize(deserializer)
+			.and_then(|string| from_hex(&string).map_err(|err| Error::custom(err.to_string())))
+			.and_then(|bytes: Vec<u8>| {
+				DalekSecretKey::from_bytes(&bytes).map_err(|err| Error::custom(err.to_string()))
+			})
+	}
+}
+
+/// Serializes an ed25519 PublicKey to and from hex
 pub mod dalek_pubkey_serde {
 	use crate::grin_util::{from_hex, ToHex};
 	use ed25519_dalek::PublicKey as DalekPublicKey;

--- a/libwallet/src/slatepack/packer.rs
+++ b/libwallet/src/slatepack/packer.rs
@@ -49,6 +49,10 @@ impl<'a> Slatepacker<'a> {
 	/// return slatepack
 	pub fn deser_slatepack(&self, data: Vec<u8>) -> Result<Slatepack, Error> {
 		// check if data is armored, if so, remove and continue
+		if data.len() < super::armor::HEADER.len() {
+			let msg = format!("Data too short");
+			return Err(ErrorKind::SlatepackDeser(msg).into());
+		}
 		let test_header = Vec::from_iter(data[0..super::armor::HEADER.len()].iter().cloned());
 		let data = match String::from_utf8(test_header) {
 			Ok(s) => {
@@ -103,8 +107,8 @@ impl<'a> Slatepacker<'a> {
 	}
 
 	/// Armor a slatepack
-	pub fn armor_slatepack(&self, slatepack: &Slatepack) -> Result<String, Error> {
-		SlatepackArmor::encode(&slatepack, 3)
+	pub fn armor_slatepack(&self, slatepack: &Slatepack, num_cols: usize) -> Result<String, Error> {
+		SlatepackArmor::encode(&slatepack, num_cols)
 	}
 
 	/// Return/upgrade slate from slatepack

--- a/libwallet/src/slatepack/types.rs
+++ b/libwallet/src/slatepack/types.rs
@@ -24,6 +24,7 @@ use crate::Error;
 use super::SlatepackAddress;
 
 use std::convert::TryInto;
+use std::fmt;
 use std::io::{Read, Write};
 
 pub const SLATEPACK_MAJOR_VERSION: u8 = 1;
@@ -56,6 +57,12 @@ pub struct Slatepack {
 
 fn default_sender_none() -> Option<SlatepackAddress> {
 	None
+}
+
+impl fmt::Display for Slatepack {
+	fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+		write!(f, "{}", serde_json::to_string_pretty(&self).unwrap())
+	}
 }
 
 impl Default for Slatepack {

--- a/src/cmd/wallet_args.rs
+++ b/src/cmd/wallet_args.rs
@@ -28,8 +28,8 @@ use grin_wallet_controller::{Error, ErrorKind};
 use grin_wallet_impls::tor::config::is_tor_address;
 use grin_wallet_impls::{DefaultLCProvider, DefaultWalletImpl};
 use grin_wallet_impls::{PathToSlate, SlateGetter as _};
-use grin_wallet_libwallet::Slate;
 use grin_wallet_libwallet::{IssueInvoiceTxArgs, NodeClient, WalletInst, WalletLCProvider};
+use grin_wallet_libwallet::{Slate, SlatepackAddress};
 use grin_wallet_util::grin_core as core;
 use grin_wallet_util::grin_core::core::amount_to_hr_string;
 use grin_wallet_util::grin_keychain as keychain;
@@ -469,11 +469,11 @@ pub fn parse_send_args(args: &ArgMatches) -> Result<command::SendArgs, ParseErro
 				// if the destination address is a TOR address, we don't need the address
 				// separately
 				match OnionV3Address::try_from(dest) {
-					Ok(a) => Some(a),
+					Ok(a) => Some(SlatepackAddress::try_from(a).unwrap()),
 					Err(_) => {
 						let addr = parse_required(args, "proof_address")?;
 						match OnionV3Address::try_from(addr) {
-							Ok(a) => Some(a),
+							Ok(a) => Some(SlatepackAddress::try_from(a).unwrap()),
 							Err(e) => {
 								let msg = format!("Invalid proof address: {:?}", e);
 								return Err(ParseError::ArgumentError(msg));


### PR DESCRIPTION
This PR aims to:
* Expose Slatepack changes via the OwnerAPI
* Ensure all user-facing instance of addresses in the API use a SlatepackAddress. This means that what was previously either being input/output by the user as a payment proof address or TOR address will now be a Slatepack address.

In detail:

- [x] Change the `get_public_proof_address` Owner API function to `get_slatepack_address` and return a slatepack address instead.
- [x] Remove the `proof_address_from_onionv3` function from the Owner API as it's no longer needed
- [x] As a result of above changes, arguments to `init_send_tx` and other places become a slatepack address.
- [x] Add a new Owner API functions to output a slate as a Slatepack

New API functions are:

* `create_slatepack_message` - returns an (optionally encrypted) armored slatepack string from a slate 
* `slate_from_slatepack_message` - extracts the slate from the given slatepack string, attempting to decrypt from a range of deriviation indices if necessary (takes a vec instead of a single value for future multiple-address use)
* `decode_slatepack_message` - convenience function that returns the Slatepack struct itself, which can be viewed as json.

Notes: 
* The command line might be a bit broken as of this PR, which is fine and will be addressed in the next PR which will implement the command-line slatepack workflow.
* Internally, addresses are still stored in the tx log and appear in the slate as ed25519 keys, for backwards compatibility.

