### PR TITLE
[3.1.x] Fix Tor send

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -394,18 +394,18 @@ dependencies = [
 ]
 
 [[package]]
-name = "croaring"
-version = "0.4.4"
+name = "croaring-mw"
+version = "0.4.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "byteorder 1.3.4 (registry+https://github.com/rust-lang/crates.io-index)",
- "croaring-sys 0.4.4 (registry+https://github.com/rust-lang/crates.io-index)",
+ "croaring-sys-mw 0.4.5 (registry+https://github.com/rust-lang/crates.io-index)",
  "libc 0.2.67 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
-name = "croaring-sys"
-version = "0.4.4"
+name = "croaring-sys-mw"
+version = "0.4.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "bindgen 0.52.0 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -858,7 +858,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
 name = "grin_api"
-version = "3.1.0"
+version = "3.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "bytes 0.5.4 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -866,12 +866,12 @@ dependencies = [
  "failure 0.1.6 (registry+https://github.com/rust-lang/crates.io-index)",
  "failure_derive 0.1.6 (registry+https://github.com/rust-lang/crates.io-index)",
  "futures 0.3.4 (registry+https://github.com/rust-lang/crates.io-index)",
- "grin_chain 3.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "grin_core 3.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "grin_p2p 3.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "grin_pool 3.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "grin_store 3.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "grin_util 3.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "grin_chain 3.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "grin_core 3.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "grin_p2p 3.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "grin_pool 3.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "grin_store 3.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "grin_util 3.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "http 0.1.21 (registry+https://github.com/rust-lang/crates.io-index)",
  "hyper 0.13.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "hyper-rustls 0.19.1 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -891,20 +891,20 @@ dependencies = [
 
 [[package]]
 name = "grin_chain"
-version = "3.1.0"
+version = "3.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "bit-vec 0.6.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "bitflags 1.2.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "byteorder 1.3.4 (registry+https://github.com/rust-lang/crates.io-index)",
  "chrono 0.4.10 (registry+https://github.com/rust-lang/crates.io-index)",
- "croaring 0.4.4 (registry+https://github.com/rust-lang/crates.io-index)",
+ "croaring-mw 0.4.5 (registry+https://github.com/rust-lang/crates.io-index)",
  "failure 0.1.6 (registry+https://github.com/rust-lang/crates.io-index)",
  "failure_derive 0.1.6 (registry+https://github.com/rust-lang/crates.io-index)",
- "grin_core 3.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "grin_keychain 3.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "grin_store 3.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "grin_util 3.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "grin_core 3.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "grin_keychain 3.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "grin_store 3.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "grin_util 3.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "lazy_static 1.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "log 0.4.8 (registry+https://github.com/rust-lang/crates.io-index)",
  "lru-cache 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -914,18 +914,18 @@ dependencies = [
 
 [[package]]
 name = "grin_core"
-version = "3.1.0"
+version = "3.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "blake2-rfc 0.2.18 (registry+https://github.com/rust-lang/crates.io-index)",
  "byteorder 1.3.4 (registry+https://github.com/rust-lang/crates.io-index)",
  "chrono 0.4.10 (registry+https://github.com/rust-lang/crates.io-index)",
- "croaring 0.4.4 (registry+https://github.com/rust-lang/crates.io-index)",
+ "croaring-mw 0.4.5 (registry+https://github.com/rust-lang/crates.io-index)",
  "enum_primitive 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "failure 0.1.6 (registry+https://github.com/rust-lang/crates.io-index)",
  "failure_derive 0.1.6 (registry+https://github.com/rust-lang/crates.io-index)",
- "grin_keychain 3.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "grin_util 3.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "grin_keychain 3.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "grin_util 3.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "lazy_static 1.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "log 0.4.8 (registry+https://github.com/rust-lang/crates.io-index)",
  "lru-cache 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -940,13 +940,13 @@ dependencies = [
 
 [[package]]
 name = "grin_keychain"
-version = "3.1.0"
+version = "3.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "blake2-rfc 0.2.18 (registry+https://github.com/rust-lang/crates.io-index)",
  "byteorder 1.3.4 (registry+https://github.com/rust-lang/crates.io-index)",
  "digest 0.7.6 (registry+https://github.com/rust-lang/crates.io-index)",
- "grin_util 3.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "grin_util 3.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "hmac 0.6.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "lazy_static 1.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "log 0.4.8 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -962,16 +962,16 @@ dependencies = [
 
 [[package]]
 name = "grin_p2p"
-version = "3.1.0"
+version = "3.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "bitflags 1.2.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "chrono 0.4.10 (registry+https://github.com/rust-lang/crates.io-index)",
  "enum_primitive 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "grin_chain 3.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "grin_core 3.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "grin_store 3.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "grin_util 3.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "grin_chain 3.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "grin_core 3.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "grin_store 3.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "grin_util 3.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "log 0.4.8 (registry+https://github.com/rust-lang/crates.io-index)",
  "lru-cache 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "num 0.1.42 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -983,16 +983,16 @@ dependencies = [
 
 [[package]]
 name = "grin_pool"
-version = "3.1.0"
+version = "3.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "blake2-rfc 0.2.18 (registry+https://github.com/rust-lang/crates.io-index)",
  "chrono 0.4.10 (registry+https://github.com/rust-lang/crates.io-index)",
  "failure 0.1.6 (registry+https://github.com/rust-lang/crates.io-index)",
  "failure_derive 0.1.6 (registry+https://github.com/rust-lang/crates.io-index)",
- "grin_core 3.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "grin_keychain 3.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "grin_util 3.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "grin_core 3.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "grin_keychain 3.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "grin_util 3.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "log 0.4.8 (registry+https://github.com/rust-lang/crates.io-index)",
  "rand 0.6.5 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde 1.0.104 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -1016,15 +1016,15 @@ dependencies = [
 
 [[package]]
 name = "grin_store"
-version = "3.1.0"
+version = "3.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "byteorder 1.3.4 (registry+https://github.com/rust-lang/crates.io-index)",
- "croaring 0.4.4 (registry+https://github.com/rust-lang/crates.io-index)",
+ "croaring-mw 0.4.5 (registry+https://github.com/rust-lang/crates.io-index)",
  "failure 0.1.6 (registry+https://github.com/rust-lang/crates.io-index)",
  "failure_derive 0.1.6 (registry+https://github.com/rust-lang/crates.io-index)",
- "grin_core 3.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "grin_util 3.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "grin_core 3.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "grin_util 3.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "libc 0.2.67 (registry+https://github.com/rust-lang/crates.io-index)",
  "lmdb-zero 0.4.4 (registry+https://github.com/rust-lang/crates.io-index)",
  "log 0.4.8 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -1036,7 +1036,7 @@ dependencies = [
 
 [[package]]
 name = "grin_util"
-version = "3.1.0"
+version = "3.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "backtrace 0.3.44 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -1212,12 +1212,12 @@ version = "3.1.2"
 dependencies = [
  "data-encoding 2.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "ed25519-dalek 1.0.0-pre.3 (registry+https://github.com/rust-lang/crates.io-index)",
- "grin_api 3.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "grin_chain 3.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "grin_core 3.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "grin_keychain 3.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "grin_store 3.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "grin_util 3.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "grin_api 3.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "grin_chain 3.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "grin_core 3.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "grin_keychain 3.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "grin_store 3.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "grin_util 3.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "pretty_assertions 0.5.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "rand 0.5.6 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde 1.0.104 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -3440,8 +3440,8 @@ dependencies = [
 "checksum core-foundation 0.6.4 (registry+https://github.com/rust-lang/crates.io-index)" = "25b9e03f145fd4f2bf705e07b900cd41fc636598fe5dc452fd0db1441c3f496d"
 "checksum core-foundation-sys 0.6.2 (registry+https://github.com/rust-lang/crates.io-index)" = "e7ca8a5221364ef15ce201e8ed2f609fc312682a8f4e0e3d4aa5879764e0fa3b"
 "checksum crc32fast 1.2.0 (registry+https://github.com/rust-lang/crates.io-index)" = "ba125de2af0df55319f41944744ad91c71113bf74a4646efff39afe1f6842db1"
-"checksum croaring 0.4.4 (registry+https://github.com/rust-lang/crates.io-index)" = "52e9057c1caf8e9debd6f938a12ff24028f3c7f85d24f502f46f3c9601905464"
-"checksum croaring-sys 0.4.4 (registry+https://github.com/rust-lang/crates.io-index)" = "b7d3b66d75dc466ec547604de0517eb4e1a51fd79a83eaff4409f81167dacdc8"
+"checksum croaring-mw 0.4.5 (registry+https://github.com/rust-lang/crates.io-index)" = "bcdee571ce4bf3e49c382de29c38bd33b9fa871e1358c7749b9dcc5dc2776221"
+"checksum croaring-sys-mw 0.4.5 (registry+https://github.com/rust-lang/crates.io-index)" = "ea52c177269fa54c526b054dac8e623721de18143ebfd2ea84ffc023d6c271ee"
 "checksum crossbeam-deque 0.7.3 (registry+https://github.com/rust-lang/crates.io-index)" = "9f02af974daeee82218205558e51ec8768b48cf524bd01d550abe5573a608285"
 "checksum crossbeam-epoch 0.8.2 (registry+https://github.com/rust-lang/crates.io-index)" = "058ed274caafc1f60c4997b5fc07bf7dc7cca454af7c6e81edffe5f33f70dace"
 "checksum crossbeam-queue 0.2.1 (registry+https://github.com/rust-lang/crates.io-index)" = "c695eeca1e7173472a32221542ae469b3e9aac3a4fc81f7696bcad82029493db"
@@ -3494,15 +3494,15 @@ dependencies = [
 "checksum getrandom 0.1.14 (registry+https://github.com/rust-lang/crates.io-index)" = "7abc8dd8451921606d809ba32e95b6111925cd2906060d2dcc29c070220503eb"
 "checksum git2 0.10.2 (registry+https://github.com/rust-lang/crates.io-index)" = "7c1af51ea8a906616af45a4ce78eacf25860f7a13ae7bf8a814693f0f4037a26"
 "checksum glob 0.3.0 (registry+https://github.com/rust-lang/crates.io-index)" = "9b919933a397b79c37e33b77bb2aa3dc8eb6e165ad809e58ff75bc7db2e34574"
-"checksum grin_api 3.1.0 (registry+https://github.com/rust-lang/crates.io-index)" = "80fd5dd5ccc5bdcb4d2ea546bc27d85d444692512abaef3cdff390474b6f9bfc"
-"checksum grin_chain 3.1.0 (registry+https://github.com/rust-lang/crates.io-index)" = "260586a9a718de2d6bf8ce331a41009c9b0a6d48587887bcec4b80df566c4b58"
-"checksum grin_core 3.1.0 (registry+https://github.com/rust-lang/crates.io-index)" = "8821bc0a9441018f44018ab98d7c206f3dbf6a748528db5f6198559569990845"
-"checksum grin_keychain 3.1.0 (registry+https://github.com/rust-lang/crates.io-index)" = "d62113eca73786f3d0037775c2a193c184209c11eb41c214f75fcbcf903e37ee"
-"checksum grin_p2p 3.1.0 (registry+https://github.com/rust-lang/crates.io-index)" = "99d76ea20c7916fd9ca20746463266f227b024dd2908fc0d7d8f7c63bdee9033"
-"checksum grin_pool 3.1.0 (registry+https://github.com/rust-lang/crates.io-index)" = "a1d1892699ec9b3b4109e0f1246c76696a8a0d2038d30017dd1ab8ba103063a1"
+"checksum grin_api 3.1.1 (registry+https://github.com/rust-lang/crates.io-index)" = "70bde4b3b7f0a0cf4a6b5e5f4d64ebdbf83e47bb8eba6453f521ce40eec9c828"
+"checksum grin_chain 3.1.1 (registry+https://github.com/rust-lang/crates.io-index)" = "79f938a205aa6118361b6d93250a15b9dfee0a120725727826b0caa6e7d0214c"
+"checksum grin_core 3.1.1 (registry+https://github.com/rust-lang/crates.io-index)" = "7b1c128a510d24397d859e7f10b93a29c9adacd49882b23b8d290372456e400d"
+"checksum grin_keychain 3.1.1 (registry+https://github.com/rust-lang/crates.io-index)" = "c9b46069fed347638ec321133df2a8e98f6fe686b918b629a26f692888201c14"
+"checksum grin_p2p 3.1.1 (registry+https://github.com/rust-lang/crates.io-index)" = "10e7516dd800e2f3ced3ef749b6d30f91637d813c2f54ef0a7c12517db2071c8"
+"checksum grin_pool 3.1.1 (registry+https://github.com/rust-lang/crates.io-index)" = "a202aec65019caa4ce8314345870d42107f4398d92f2bcbaa7cf35693314547a"
 "checksum grin_secp256k1zkp 0.7.7 (registry+https://github.com/rust-lang/crates.io-index)" = "23027a7673df2c2b20fb9589d742ff400a10a9c3e4c769a77e9fa3bd19586822"
-"checksum grin_store 3.1.0 (registry+https://github.com/rust-lang/crates.io-index)" = "2356f87415943d303b12296c7b2ea3184674d7c106d1eda1685f3860105914f2"
-"checksum grin_util 3.1.0 (registry+https://github.com/rust-lang/crates.io-index)" = "e34c570edcdc419e0e083fdc850d60deb45054533cd6da33df3e4e4d246a98f7"
+"checksum grin_store 3.1.1 (registry+https://github.com/rust-lang/crates.io-index)" = "9a74c2247ea6061abe2806122e8e16f2d62e5748db93d9ca7cc4033a76fee6da"
+"checksum grin_util 3.1.1 (registry+https://github.com/rust-lang/crates.io-index)" = "af0b61809f2ffd625ffbbe92097680cdaa9dfd818f9a9c318ffc03428f7a6961"
 "checksum h2 0.2.1 (registry+https://github.com/rust-lang/crates.io-index)" = "b9433d71e471c1736fd5a61b671fc0b148d7a2992f666c958d03cd8feb3b88d1"
 "checksum heck 0.3.1 (registry+https://github.com/rust-lang/crates.io-index)" = "20564e78d53d2bb135c343b3f47714a56af2061f1c928fdb541dc7b9fdd94205"
 "checksum hermit-abi 0.1.8 (registry+https://github.com/rust-lang/crates.io-index)" = "1010591b26bbfe835e9faeabeb11866061cc7dcebffd56ad7d0942d0e61aefd8"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1057,19 +1057,19 @@ dependencies = [
 
 [[package]]
 name = "grin_wallet"
-version = "3.1.1"
+version = "3.1.2"
 dependencies = [
  "built 0.3.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "clap 2.33.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "easy-jsonrpc 0.5.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "failure 0.1.6 (registry+https://github.com/rust-lang/crates.io-index)",
  "failure_derive 0.1.6 (registry+https://github.com/rust-lang/crates.io-index)",
- "grin_wallet_api 3.1.1",
- "grin_wallet_config 3.1.1",
- "grin_wallet_controller 3.1.1",
- "grin_wallet_impls 3.1.1",
- "grin_wallet_libwallet 3.1.1",
- "grin_wallet_util 3.1.1",
+ "grin_wallet_api 3.1.2",
+ "grin_wallet_config 3.1.2",
+ "grin_wallet_controller 3.1.2",
+ "grin_wallet_impls 3.1.2",
+ "grin_wallet_libwallet 3.1.2",
+ "grin_wallet_util 3.1.2",
  "lazy_static 1.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "linefeed 0.5.4 (registry+https://github.com/rust-lang/crates.io-index)",
  "log 0.4.8 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -1085,7 +1085,7 @@ dependencies = [
 
 [[package]]
 name = "grin_wallet_api"
-version = "3.1.1"
+version = "3.1.2"
 dependencies = [
  "base64 0.9.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "chrono 0.4.10 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -1093,10 +1093,10 @@ dependencies = [
  "ed25519-dalek 1.0.0-pre.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "failure 0.1.6 (registry+https://github.com/rust-lang/crates.io-index)",
  "failure_derive 0.1.6 (registry+https://github.com/rust-lang/crates.io-index)",
- "grin_wallet_config 3.1.1",
- "grin_wallet_impls 3.1.1",
- "grin_wallet_libwallet 3.1.1",
- "grin_wallet_util 3.1.1",
+ "grin_wallet_config 3.1.2",
+ "grin_wallet_impls 3.1.2",
+ "grin_wallet_libwallet 3.1.2",
+ "grin_wallet_util 3.1.2",
  "log 0.4.8 (registry+https://github.com/rust-lang/crates.io-index)",
  "rand 0.5.6 (registry+https://github.com/rust-lang/crates.io-index)",
  "ring 0.16.11 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -1109,10 +1109,10 @@ dependencies = [
 
 [[package]]
 name = "grin_wallet_config"
-version = "3.1.1"
+version = "3.1.2"
 dependencies = [
  "dirs 1.0.5 (registry+https://github.com/rust-lang/crates.io-index)",
- "grin_wallet_util 3.1.1",
+ "grin_wallet_util 3.1.2",
  "pretty_assertions 0.5.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "rand 0.5.6 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde 1.0.104 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -1122,18 +1122,18 @@ dependencies = [
 
 [[package]]
 name = "grin_wallet_controller"
-version = "3.1.1"
+version = "3.1.2"
 dependencies = [
  "chrono 0.4.10 (registry+https://github.com/rust-lang/crates.io-index)",
  "easy-jsonrpc-mw 0.5.4 (registry+https://github.com/rust-lang/crates.io-index)",
  "failure 0.1.6 (registry+https://github.com/rust-lang/crates.io-index)",
  "failure_derive 0.1.6 (registry+https://github.com/rust-lang/crates.io-index)",
  "futures 0.3.4 (registry+https://github.com/rust-lang/crates.io-index)",
- "grin_wallet_api 3.1.1",
- "grin_wallet_config 3.1.1",
- "grin_wallet_impls 3.1.1",
- "grin_wallet_libwallet 3.1.1",
- "grin_wallet_util 3.1.1",
+ "grin_wallet_api 3.1.2",
+ "grin_wallet_config 3.1.2",
+ "grin_wallet_impls 3.1.2",
+ "grin_wallet_libwallet 3.1.2",
+ "grin_wallet_util 3.1.2",
  "hyper 0.13.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "lazy_static 1.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "log 0.4.8 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -1151,7 +1151,7 @@ dependencies = [
 
 [[package]]
 name = "grin_wallet_impls"
-version = "3.1.1"
+version = "3.1.2"
 dependencies = [
  "blake2-rfc 0.2.18 (registry+https://github.com/rust-lang/crates.io-index)",
  "byteorder 1.3.4 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -1162,9 +1162,9 @@ dependencies = [
  "failure 0.1.6 (registry+https://github.com/rust-lang/crates.io-index)",
  "failure_derive 0.1.6 (registry+https://github.com/rust-lang/crates.io-index)",
  "futures 0.3.4 (registry+https://github.com/rust-lang/crates.io-index)",
- "grin_wallet_config 3.1.1",
- "grin_wallet_libwallet 3.1.1",
- "grin_wallet_util 3.1.1",
+ "grin_wallet_config 3.1.2",
+ "grin_wallet_libwallet 3.1.2",
+ "grin_wallet_util 3.1.2",
  "http 0.1.21 (registry+https://github.com/rust-lang/crates.io-index)",
  "hyper 0.13.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "hyper-rustls 0.19.1 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -1185,7 +1185,7 @@ dependencies = [
 
 [[package]]
 name = "grin_wallet_libwallet"
-version = "3.1.1"
+version = "3.1.2"
 dependencies = [
  "blake2-rfc 0.2.18 (registry+https://github.com/rust-lang/crates.io-index)",
  "byteorder 1.3.4 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -1193,8 +1193,8 @@ dependencies = [
  "ed25519-dalek 1.0.0-pre.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "failure 0.1.6 (registry+https://github.com/rust-lang/crates.io-index)",
  "failure_derive 0.1.6 (registry+https://github.com/rust-lang/crates.io-index)",
- "grin_wallet_config 3.1.1",
- "grin_wallet_util 3.1.1",
+ "grin_wallet_config 3.1.2",
+ "grin_wallet_util 3.1.2",
  "lazy_static 1.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "log 0.4.8 (registry+https://github.com/rust-lang/crates.io-index)",
  "rand 0.5.6 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -1208,7 +1208,7 @@ dependencies = [
 
 [[package]]
 name = "grin_wallet_util"
-version = "3.1.1"
+version = "3.1.2"
 dependencies = [
  "data-encoding 2.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "ed25519-dalek 1.0.0-pre.3 (registry+https://github.com/rust-lang/crates.io-index)",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1168,7 +1168,7 @@ dependencies = [
  "http 0.1.21 (registry+https://github.com/rust-lang/crates.io-index)",
  "hyper 0.13.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "hyper-rustls 0.19.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "hyper-socks2 0.4.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "hyper-socks2 0.4.3 (git+https://github.com/yeastplume/hyper-socks2)",
  "hyper-timeout 0.3.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "log 0.4.8 (registry+https://github.com/rust-lang/crates.io-index)",
  "rand 0.5.6 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -1351,8 +1351,8 @@ dependencies = [
 
 [[package]]
 name = "hyper-socks2"
-version = "0.4.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
+version = "0.4.3"
+source = "git+https://github.com/yeastplume/hyper-socks2#08c3e5f6e8fb642110abe61e8a381195ac60cb6c"
 dependencies = [
  "async-socks5 0.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "futures 0.3.4 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -3514,7 +3514,7 @@ dependencies = [
 "checksum humantime 1.3.0 (registry+https://github.com/rust-lang/crates.io-index)" = "df004cfca50ef23c36850aaaa59ad52cc70d0e90243c3c7737a4dd32dc7a3c4f"
 "checksum hyper 0.13.2 (registry+https://github.com/rust-lang/crates.io-index)" = "fa1c527bbc634be72aa7ba31e4e4def9bbb020f5416916279b7c705cd838893e"
 "checksum hyper-rustls 0.19.1 (registry+https://github.com/rust-lang/crates.io-index)" = "f6ea6215c7314d450ee45970ab8b3851ab447a0e6bafdd19e31b20a42dbb7faf"
-"checksum hyper-socks2 0.4.2 (registry+https://github.com/rust-lang/crates.io-index)" = "b950dc6d3ea74cbb1f4c4ad217c20ca3e846b3f39468baef13d222c80a386bd6"
+"checksum hyper-socks2 0.4.3 (git+https://github.com/yeastplume/hyper-socks2)" = "<none>"
 "checksum hyper-timeout 0.3.1 (registry+https://github.com/rust-lang/crates.io-index)" = "0d1f9b0b8258e3ef8f45928021d3ef14096c2b93b99e4b8cfcabf1f58ec84b0a"
 "checksum hyper-tls 0.4.1 (registry+https://github.com/rust-lang/crates.io-index)" = "3adcd308402b9553630734e9c36b77a7e48b3821251ca2493e8cd596763aafaa"
 "checksum idna 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)" = "38f09e0f0b1fb55fdee1f17470ad800da77af5186a1a76c026b679358b7e844e"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "grin_wallet"
-version = "3.1.1"
+version = "3.1.2"
 authors = ["Grin Developers <mimblewimble@lists.launchpad.net>"]
 description = "Simple, private and scalable cryptocurrency implementation based on the MimbleWimble chain format."
 license = "Apache-2.0"
@@ -31,13 +31,13 @@ semver = "0.9"
 rustyline = "6"
 lazy_static = "1"
 
-grin_wallet_api = { path = "./api", version = "3.1.1" }
-grin_wallet_impls = { path = "./impls", version = "3.1.1" }
-grin_wallet_libwallet = { path = "./libwallet", version = "3.1.1" }
-grin_wallet_controller = { path = "./controller", version = "3.1.1" }
-grin_wallet_config = { path = "./config", version = "3.1.1" }
+grin_wallet_api = { path = "./api", version = "3.1.2" }
+grin_wallet_impls = { path = "./impls", version = "3.1.2" }
+grin_wallet_libwallet = { path = "./libwallet", version = "3.1.2" }
+grin_wallet_controller = { path = "./controller", version = "3.1.2" }
+grin_wallet_config = { path = "./config", version = "3.1.2" }
 
-grin_wallet_util = { path = "./util", version = "3.1.1" }
+grin_wallet_util = { path = "./util", version = "3.1.2" }
 
 [build-dependencies]
 built = "0.3"

--- a/api/Cargo.toml
+++ b/api/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "grin_wallet_api"
-version = "3.1.1"
+version = "3.1.2"
 authors = ["Grin Developers <mimblewimble@lists.launchpad.net>"]
 description = "Grin Wallet API"
 license = "Apache-2.0"
@@ -24,10 +24,10 @@ ring = "0.16"
 base64 = "0.9"
 ed25519-dalek = "1.0.0-pre.1"
 
-grin_wallet_libwallet = { path = "../libwallet", version = "3.1.1" }
-grin_wallet_config = { path = "../config", version = "3.1.1" }
-grin_wallet_impls = { path = "../impls", version = "3.1.1" }
-grin_wallet_util = { path = "../util", version = "3.1.1" }
+grin_wallet_libwallet = { path = "../libwallet", version = "3.1.2" }
+grin_wallet_config = { path = "../config", version = "3.1.2" }
+grin_wallet_impls = { path = "../impls", version = "3.1.2" }
+grin_wallet_util = { path = "../util", version = "3.1.2" }
 
 [dev-dependencies]
 serde_json = "1"

--- a/config/Cargo.toml
+++ b/config/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "grin_wallet_config"
-version = "3.1.1"
+version = "3.1.2"
 authors = ["Grin Developers <mimblewimble@lists.launchpad.net>"]
 description = "Configuration for grin wallet , a simple, private and scalable cryptocurrency implementation based on the MimbleWimble chain format."
 license = "Apache-2.0"
@@ -16,7 +16,7 @@ serde_derive = "1"
 toml = "0.4"
 dirs = "1.0.3"
 
-grin_wallet_util = { path = "../util", version = "3.1.1" }
+grin_wallet_util = { path = "../util", version = "3.1.2" }
 
 [dev-dependencies]
 pretty_assertions = "0.5.1"

--- a/controller/Cargo.toml
+++ b/controller/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "grin_wallet_controller"
-version = "3.1.1"
+version = "3.1.2"
 authors = ["Grin Developers <mimblewimble@lists.launchpad.net>"]
 description = "Controllers for grin wallet instantiation"
 license = "Apache-2.0"
@@ -30,9 +30,9 @@ chrono = { version = "0.4.4", features = ["serde"] }
 easy-jsonrpc-mw = "0.5.3"
 lazy_static = "1"
 
-grin_wallet_util = { path = "../util", version = "3.1.1" }
+grin_wallet_util = { path = "../util", version = "3.1.2" }
 
-grin_wallet_api = { path = "../api", version = "3.1.1" }
-grin_wallet_impls = { path = "../impls", version = "3.1.1" }
-grin_wallet_libwallet = { path = "../libwallet", version = "3.1.1" }
-grin_wallet_config = { path = "../config", version = "3.1.1" }
+grin_wallet_api = { path = "../api", version = "3.1.2" }
+grin_wallet_impls = { path = "../impls", version = "3.1.2" }
+grin_wallet_libwallet = { path = "../libwallet", version = "3.1.2" }
+grin_wallet_config = { path = "../config", version = "3.1.2" }

--- a/impls/Cargo.toml
+++ b/impls/Cargo.toml
@@ -33,7 +33,7 @@ hyper-timeout = "0.3"
 #Socks/Tor
 byteorder = "1"
 hyper = "0.13"
-hyper-socks2 = "0.4"
+hyper-socks2 = { git = "https://github.com/yeastplume/hyper-socks2", branch = "master" }
 ed25519-dalek = "1.0.0-pre.1"
 data-encoding = "2"
 regex = "1.3"

--- a/impls/Cargo.toml
+++ b/impls/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "grin_wallet_impls"
-version = "3.1.1"
+version = "3.1.2"
 authors = ["Grin Developers <mimblewimble@lists.launchpad.net>"]
 description = "Concrete types derived from libwallet traits"
 license = "Apache-2.0"
@@ -40,6 +40,6 @@ regex = "1.3"
 timer = "0.2"
 sysinfo = "0.9"
 
-grin_wallet_util = { path = "../util", version = "3.1.1" }
-grin_wallet_config = { path = "../config", version = "3.1.1" }
-grin_wallet_libwallet = { path = "../libwallet", version = "3.1.1" }
+grin_wallet_util = { path = "../util", version = "3.1.2" }
+grin_wallet_config = { path = "../config", version = "3.1.2" }
+grin_wallet_libwallet = { path = "../libwallet", version = "3.1.2" }

--- a/libwallet/Cargo.toml
+++ b/libwallet/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "grin_wallet_libwallet"
-version = "3.1.1"
+version = "3.1.2"
 authors = ["Grin Developers <mimblewimble@lists.launchpad.net>"]
 description = "Simple, private and scalable cryptocurrency implementation based on the MimbleWimble chain format."
 license = "Apache-2.0"
@@ -27,5 +27,5 @@ strum_macros = "0.15"
 ed25519-dalek = "1.0.0-pre.1"
 byteorder = "1"
 
-grin_wallet_util = { path = "../util", version = "3.1.1" }
-grin_wallet_config = { path = "../config", version = "3.1.1" }
+grin_wallet_util = { path = "../util", version = "3.1.2" }
+grin_wallet_config = { path = "../config", version = "3.1.2" }

--- a/util/Cargo.toml
+++ b/util/Cargo.toml
@@ -18,12 +18,12 @@ data-encoding = "2"
 sha3 = "0.8"
 
 # For Release
-grin_core = "3.1.0"
-grin_keychain = "3.1.0"
-grin_chain = "3.1.0"
-grin_util = "3.1.0"
-grin_api = "3.1.0"
-grin_store = "3.1.0"
+grin_core = "3.1.1"
+grin_keychain = "3.1.1"
+grin_chain = "3.1.1"
+grin_util = "3.1.1"
+grin_api = "3.1.1"
+grin_store = "3.1.1"
 
 # For beta release
 

--- a/util/Cargo.toml
+++ b/util/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "grin_wallet_util"
-version = "3.1.1"
+version = "3.1.2"
 authors = ["Grin Developers <mimblewimble@lists.launchpad.net>"]
 description = "Util, for generic utilities and to re-export grin crates"
 license = "Apache-2.0"
@@ -27,12 +27,12 @@ grin_store = "3.1.0"
 
 # For beta release
 
-# grin_core = { git = "https://github.com/mimblewimble/grin", tag = "v3.1.0-beta.1"}
-# grin_keychain = { git = "https://github.com/mimblewimble/grin", tag = "v3.1.0-beta.1" }
-# grin_chain = { git = "https://github.com/mimblewimble/grin", tag = "v3.1.0-beta.1" }
-# grin_util = { git = "https://github.com/mimblewimble/grin", tag = "v3.1.0-beta.1" }
-# grin_api = { git = "https://github.com/mimblewimble/grin", tag = "v3.1.0-beta.1" }
-# grin_store = { git = "https://github.com/mimblewimble/grin", tag = "v3.1.0-beta.1" }
+# grin_core = { git = "https://github.com/mimblewimble/grin", tag = "v3.1.1-beta.1"}
+# grin_keychain = { git = "https://github.com/mimblewimble/grin", tag = "v3.1.1-beta.1" }
+# grin_chain = { git = "https://github.com/mimblewimble/grin", tag = "v3.1.1-beta.1" }
+# grin_util = { git = "https://github.com/mimblewimble/grin", tag = "v3.1.1-beta.1" }
+# grin_api = { git = "https://github.com/mimblewimble/grin", tag = "v3.1.1-beta.1" }
+# grin_store = { git = "https://github.com/mimblewimble/grin", tag = "v3.1.1-beta.1" }
 
 # For bleeding edge
 #grin_core = { git = "https://github.com/mimblewimble/grin", branch = "master" }


### PR DESCRIPTION
Equivalent of #422 for current/v3.1.x + version bump to 3.1.2.

Do Not Merge because it would be much better to release grin-wallet v3.1.2 with grin v3.1.1 which is still no published on crates.io.