### PR TITLE
Update hyper-socks2 to versioned crate

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1487,7 +1487,7 @@ dependencies = [
  "http 0.1.21",
  "hyper",
  "hyper-rustls 0.19.1",
- "hyper-socks2",
+ "hyper-socks2-mw",
  "hyper-timeout",
  "log",
  "rand 0.5.6",
@@ -1728,9 +1728,10 @@ dependencies = [
 ]
 
 [[package]]
-name = "hyper-socks2"
-version = "0.4.3"
-source = "git+https://github.com/yeastplume/hyper-socks2#08c3e5f6e8fb642110abe61e8a381195ac60cb6c"
+name = "hyper-socks2-mw"
+version = "0.4.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1d7267805b50714db2ebe2904b1e70158ba6ba8eafdaf7c9d7735aca3273c4f8"
 dependencies = [
  "async-socks5",
  "futures 0.3.5",

--- a/impls/Cargo.toml
+++ b/impls/Cargo.toml
@@ -33,8 +33,7 @@ hyper-timeout = "0.3"
 #Socks/Tor
 byteorder = "1"
 hyper = "0.13"
-#hyper-socks2 = "0.4"
-hyper-socks2 = { git = "https://github.com/yeastplume/hyper-socks2", branch = "master" }
+hyper-socks2-mw = "0.4"
 ed25519-dalek = "1.0.0-pre.1"
 x25519-dalek = "0.6"
 data-encoding = "2"

--- a/impls/src/client_utils/client.rs
+++ b/impls/src/client_utils/client.rs
@@ -292,7 +292,7 @@ impl Client {
 			let auth = format!("{}:{}", addr.ip(), addr.port());
 
 			let https = hyper_rustls::HttpsConnector::new();
-			let socks = hyper_socks2::SocksConnector {
+			let socks = hyper_socks2_mw::SocksConnector {
 				proxy_addr: hyper::Uri::builder()
 					.scheme("socks5")
 					.authority(auth.as_str())


### PR DESCRIPTION
Update to use new MW fork of hyper-socks2 crate