### PR TITLE
[DNM] hardcode NRD kernel feature for testing

### DIFF
--- a/libwallet/src/slate.rs
+++ b/libwallet/src/slate.rs
@@ -372,29 +372,34 @@ impl Slate {
 	// 3: NRD (with associated relative_height)
 	// Any other value is invalid.
 	fn kernel_features(&self) -> Result<KernelFeatures, Error> {
-		match self.kernel_features {
-			0 => Ok(KernelFeatures::Plain { fee: self.fee }),
-			1 => Err(ErrorKind::InvalidKernelFeatures(1).into()),
-			2 => Ok(KernelFeatures::HeightLocked {
-				fee: self.fee,
-				lock_height: match &self.kernel_features_args {
-					Some(a) => a.lock_height,
-					None => {
-						return Err(ErrorKind::KernelFeaturesMissing(format!("lock_height")).into())
-					}
-				},
-			}),
-			3 => Ok(KernelFeatures::NoRecentDuplicate {
-				fee: self.fee,
-				relative_height: match &self.kernel_features_args {
-					Some(a) => NRDRelativeHeight::new(a.lock_height)?,
-					None => {
-						return Err(ErrorKind::KernelFeaturesMissing(format!("lock_height")).into())
-					}
-				},
-			}),
-			n => Err(ErrorKind::UnknownKernelFeatures(n).into()),
-		}
+		// match self.kernel_features {
+		// 	0 => Ok(KernelFeatures::Plain { fee: self.fee }),
+		// 	1 => Err(ErrorKind::InvalidKernelFeatures(1).into()),
+		// 	2 => Ok(KernelFeatures::HeightLocked {
+		// 		fee: self.fee,
+		// 		lock_height: match &self.kernel_features_args {
+		// 			Some(a) => a.lock_height,
+		// 			None => {
+		// 				return Err(ErrorKind::KernelFeaturesMissing(format!("lock_height")).into())
+		// 			}
+		// 		},
+		// 	}),
+		// 	3 => Ok(KernelFeatures::NoRecentDuplicate {
+		// 		fee: self.fee,
+		// 		relative_height: match &self.kernel_features_args {
+		// 			Some(a) => NRDRelativeHeight::new(a.lock_height)?,
+		// 			None => {
+		// 				return Err(ErrorKind::KernelFeaturesMissing(format!("lock_height")).into())
+		// 			}
+		// 		},
+		// 	}),
+		// 	n => Err(ErrorKind::UnknownKernelFeatures(n).into()),
+		// }
+
+		Ok(KernelFeatures::NoRecentDuplicate {
+			fee: self.fee,
+			relative_height: NRDRelativeHeight::new(60)?,
+		})
 	}
 
 	// This is the msg that we will sign as part of the tx kernel.


### PR DESCRIPTION
Hardcode NRD kernel features in wallet tx building code.
Every tx initiated with this wallet will use an NRD kernel with relative_height=60.

This NRD kernel variant is valid at HF3 if the feature flag is enable. This is a valid kernel feature variant is at block height 9 in usertesting chain type.

Note: This creates NRD kernels but does not allow for NRD kernels to be deterministic or reusable, each one has a random excess.

TODO - Hardcode the key and offset logic for deterministic reproduction of "known" excess values. We can do this through the use of a deterministic "random" excess during the key splitting, and offset as necessary based on the selected private keys (see the "two half kernels" test in node).



