### PR TITLE
Fix: height locked feature value should be 2.

### DIFF
--- a/libwallet/src/slate_versions/v4.rs
+++ b/libwallet/src/slate_versions/v4.rs
@@ -500,7 +500,7 @@ impl From<SlateV3> for SlateV4 {
 		};
 		let (feat, feat_args) = match lock_height {
 			0 => (0, None),
-			n => (1, Some(KernelFeaturesArgsV4 { lock_hgt: n })),
+			n => (2, Some(KernelFeaturesArgsV4 { lock_hgt: n })),
 		};
 		SlateV4 {
 			ver,

--- a/libwallet/src/slate_versions/v4_bin.rs
+++ b/libwallet/src/slate_versions/v4_bin.rs
@@ -431,7 +431,7 @@ impl Writeable for SlateV4Bin {
 		}
 		.write(writer)?;
 		// Write lock height for height locked kernels
-		if v4.feat == 1 {
+		if v4.feat == 2 {
 			let lock_hgt = match &v4.feat_args {
 				Some(l) => l.lock_hgt,
 				None => 0,
@@ -456,7 +456,7 @@ impl Readable for SlateV4Bin {
 		let sigs = SigsWrap::read(reader)?.0;
 		let opt_structs = SlateOptStructs::read(reader)?;
 
-		let feat_args = if opts.feat == 1 {
+		let feat_args = if opts.feat == 2 {
 			Some(KernelFeaturesArgsV4 {
 				lock_hgt: reader.read_u64()?,
 			})


### PR DESCRIPTION
// Match on kernel feature variant:
// 0: plain
// 1: coinbase (invalid)
// 2: height locked (with associated lock_height)
// 3: NRD (with associated relative_height)
// Anything else is unknown.