### PR TITLE
Request Payment Proof by default

### DIFF
--- a/src/bin/grin-wallet.yml
+++ b/src/bin/grin-wallet.yml
@@ -123,10 +123,10 @@ subcommands:
             short: d
             long: dest
             takes_value: true
-        - request_payment_proof:
-            help: Request a payment proof from the recipient. If present, the destination must be provided as a slatepack address.
-            short: y
-            long: request_payment_proof
+        - no_payment_proof:
+            help: Don't request a payment proof, even if the Recipient's Slatepack address is provided in the -dest argument
+            short: n
+            long: no_payment_proof
         - fluff:
             help: Fluff the transaction (ignore Dandelion relay protocol)
             short: f
@@ -322,7 +322,7 @@ subcommands:
   - recover:
       about: Displays a recovery phrase for the wallet. (use `init -r` to perform recovery)
   - address:
-      about: Display the wallet's payment proof address
+      about: Display the wallet's Slatepack address
   - scan:
       about: Checks a wallet's outputs against a live node, repairing and restoring missing outputs if required
       args:

--- a/src/cmd/wallet_args.rs
+++ b/src/cmd/wallet_args.rs
@@ -31,7 +31,6 @@ use grin_wallet_libwallet::{IssueInvoiceTxArgs, NodeClient, WalletInst, WalletLC
 use grin_wallet_util::grin_core as core;
 use grin_wallet_util::grin_core::core::amount_to_hr_string;
 use grin_wallet_util::grin_keychain as keychain;
-use grin_wallet_util::OnionV3Address;
 use linefeed::terminal::Signal;
 use linefeed::{Interface, ReadResult};
 use rpassword;
@@ -503,27 +502,15 @@ pub fn parse_send_args(args: &ArgMatches) -> Result<command::SendArgs, ParseErro
 	};
 
 	let payment_proof_address = {
-		match args.is_present("request_payment_proof") {
-			true => match OnionV3Address::try_from(dest) {
-				Ok(a) => Some(SlatepackAddress::try_from(a).unwrap()),
+		match args.is_present("no_payment_proof") {
+			false => match SlatepackAddress::try_from(dest) {
+				Ok(a) => Some(a),
 				Err(_) => {
-					let addr = match parse_required(args, "dest") {
-						Ok(a) => a,
-						Err(_) => {
-							let msg = format!("Destination Slatepack address must be provided (-d) if payment proof is requested");
-							return Err(ParseError::ArgumentError(msg));
-						}
-					};
-					match SlatepackAddress::try_from(addr) {
-						Ok(a) => Some(a),
-						Err(e) => {
-							let msg = format!("Invalid slatepack address: {:?}", e);
-							return Err(ParseError::ArgumentError(msg));
-						}
-					}
+					println!("No recipient Slatepack address. No payment proof will be requested.");
+					None
 				}
 			},
-			false => None,
+			true => None,
 		}
 	};
 


### PR DESCRIPTION
If a Slatepack address is provided, request a payment proof by default during the send command. If a proof is not desired, the user can pass the `-n` `--no-payment-proof` flag. 