### PR TITLE
Add option to skip Tor send attempts in TorConfig

### DIFF
--- a/config/src/types.rs
+++ b/config/src/types.rs
@@ -145,6 +145,8 @@ impl fmt::Display for ConfigError {
 /// Tor configuration
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
 pub struct TorConfig {
+	/// whether to skip any attempts to send via TOR
+	pub skip_send_attempt: Option<bool>,
 	/// Whether to start tor listener on listener startup (default true)
 	pub use_tor_listener: bool,
 	/// Just the address of the socks proxy for now
@@ -156,6 +158,7 @@ pub struct TorConfig {
 impl Default for TorConfig {
 	fn default() -> TorConfig {
 		TorConfig {
+			skip_send_attempt: Some(false),
 			use_tor_listener: true,
 			socks_proxy_addr: "127.0.0.1:59050".to_owned(),
 			send_config_dir: ".".into(),

--- a/controller/src/command.rs
+++ b/controller/src/command.rs
@@ -257,6 +257,7 @@ pub struct SendArgs {
 	pub target_slate_version: Option<u16>,
 	pub payment_proof_address: Option<SlatepackAddress>,
 	pub ttl_blocks: Option<u64>,
+	pub skip_tor: bool,
 	//TODO: Remove HF3
 	pub output_v4_slate: bool,
 }
@@ -449,6 +450,14 @@ where
 		}
 		Ok(())
 	})?;
+
+	let tor_config = match tor_config {
+		Some(mut c) => {
+			c.skip_send_attempt = Some(args.skip_tor);
+			Some(c)
+		}
+		None => None,
+	};
 
 	let res =
 		try_slatepack_sync_workflow(&slate, &args.dest, tor_config, tor_sender, false, test_mode);
@@ -653,6 +662,7 @@ where
 pub struct ReceiveArgs {
 	pub input_file: Option<String>,
 	pub input_slatepack_message: Option<String>,
+	pub skip_tor: bool,
 }
 
 pub fn receive<L, C, K>(
@@ -678,6 +688,14 @@ where
 	let km = match keychain_mask.as_ref() {
 		None => None,
 		Some(&m) => Some(m.to_owned()),
+	};
+
+	let tor_config = match tor_config {
+		Some(mut c) => {
+			c.skip_send_attempt = Some(args.skip_tor);
+			Some(c)
+		}
+		None => None,
 	};
 
 	controller::foreign_single_use(owner_api.wallet_inst.clone(), km, |api| {
@@ -962,6 +980,7 @@ pub struct ProcessInvoiceArgs {
 	pub slate: Slate,
 	pub estimate_selection_strategies: bool,
 	pub ttl_blocks: Option<u64>,
+	pub skip_tor: bool,
 }
 
 /// Process invoice
@@ -1035,6 +1054,14 @@ where
 		}
 		Ok(())
 	})?;
+
+	let tor_config = match tor_config {
+		Some(mut c) => {
+			c.skip_send_attempt = Some(args.skip_tor);
+			Some(c)
+		}
+		None => None,
+	};
 
 	let res = try_slatepack_sync_workflow(&slate, &dest, tor_config, None, true, test_mode);
 

--- a/libwallet/src/api_impl/types.rs
+++ b/libwallet/src/api_impl/types.rs
@@ -86,6 +86,8 @@ pub struct InitTxSendArgs {
 	pub post_tx: bool,
 	/// Whether to use dandelion when posting. If false, skip the dandelion relay
 	pub fluff: bool,
+	/// If set, skip the Slatepack TOR send attempt
+	pub skip_tor: bool,
 }
 
 impl Default for InitTxArgs {

--- a/src/bin/grin-wallet.yml
+++ b/src/bin/grin-wallet.yml
@@ -141,6 +141,10 @@ subcommands:
             short: b
             long: ttl_blocks
             takes_value: true
+        - manual:
+            help: If present, don't attempt to send the resulting Slatepack via TOR
+            short: m
+            long: manual
         #TODO: Remove HF3
         - v4:
             help: Output a V4 slate prior to HF3 block
@@ -162,6 +166,10 @@ subcommands:
             short: i
             long: input
             takes_value: true
+        - manual:
+            help: If present, don't attempt to send the resulting Slatepack via TOR
+            short: m
+            long: manual
   - finalize:
       about: Processes a Slatepack Message to finalize a transfer.
       args:
@@ -231,6 +239,10 @@ subcommands:
             short: b
             long: ttl_blocks
             takes_value: true
+        - manual:
+            help: If present, don't attempt to send the resulting Slatepack via TOR
+            short: m
+            long: manual
   - outputs:
       about: Raw wallet output info (list of outputs)
   - txs:

--- a/src/cmd/wallet_args.rs
+++ b/src/cmd/wallet_args.rs
@@ -506,7 +506,7 @@ pub fn parse_send_args(args: &ArgMatches) -> Result<command::SendArgs, ParseErro
 			false => match SlatepackAddress::try_from(dest) {
 				Ok(a) => Some(a),
 				Err(_) => {
-					println!("No recipient Slatepack address. No payment proof will be requested.");
+					println!("No recipient Slatepack address or provided address invalid. No payment proof will be requested.");
 					None
 				}
 			},
@@ -527,6 +527,7 @@ pub fn parse_send_args(args: &ArgMatches) -> Result<command::SendArgs, ParseErro
 		ttl_blocks,
 		target_slate_version: target_slate_version,
 		output_v4_slate,
+		skip_tor: args.is_present("manual"),
 	})
 }
 
@@ -553,6 +554,7 @@ pub fn parse_receive_args(args: &ArgMatches) -> Result<command::ReceiveArgs, Par
 	Ok(command::ReceiveArgs {
 		input_file,
 		input_slatepack_message,
+		skip_tor: args.is_present("manual"),
 	})
 }
 
@@ -579,6 +581,7 @@ pub fn parse_unpack_args(args: &ArgMatches) -> Result<command::ReceiveArgs, Pars
 	Ok(command::ReceiveArgs {
 		input_file,
 		input_slatepack_message,
+		skip_tor: args.is_present("manual"),
 	})
 }
 
@@ -737,6 +740,7 @@ pub fn parse_process_invoice_args(
 		slate,
 		max_outputs,
 		ttl_blocks,
+		skip_tor: args.is_present("manual"),
 	})
 }
 


### PR DESCRIPTION
Addresses #451. This is really the only non-breaking way to implement this (anything else would mean adding parameters to the `receive_tx` foreign API function, which would break backwards compatibility.

* Adds a `skip_send_attempt` field to the `TorConfig` struct. If set to `Some(true)`, the slatepack workflow will skip the Tor send attempt.
* To turn off TOR sends, via the API's, use the `set_tor_config` API function (included in both the Owner and Foreign APIs), setting `skip_send_attempt` to `true`
* In addition, all command-line functions that can send via Tor now take a `--manual, -m` flag. If present, the Tor send attempt will be skipped.

