### PR TITLE
Add flag to override location of slatepack output file

### DIFF
--- a/controller/src/command.rs
+++ b/controller/src/command.rs
@@ -258,6 +258,7 @@ pub struct SendArgs {
 	pub payment_proof_address: Option<SlatepackAddress>,
 	pub ttl_blocks: Option<u64>,
 	pub skip_tor: bool,
+	pub outfile: Option<String>,
 	//TODO: Remove HF3
 	pub output_v4_slate: bool,
 }
@@ -486,6 +487,7 @@ where
 				keychain_mask,
 				&slate,
 				args.dest.as_str(),
+				args.outfile,
 				true,
 				false,
 				is_pre_fork,
@@ -501,6 +503,7 @@ pub fn output_slatepack<L, C, K>(
 	keychain_mask: Option<&SecretKey>,
 	slate: &Slate,
 	dest: &str,
+	out_file_override: Option<String>,
 	lock: bool,
 	finalizing: bool,
 	is_pre_fork: bool,
@@ -532,7 +535,10 @@ where
 	// create a directory to which files will be output
 	let slate_dir = format!("{}/{}", tld, "slatepack");
 	let _ = std::fs::create_dir_all(slate_dir.clone());
-	let out_file_name = format!("{}/{}.{}.slatepack", slate_dir, slate.id, slate.state);
+	let out_file_name = match out_file_override {
+		None => format!("{}/{}.{}.slatepack", slate_dir, slate.id, slate.state),
+		Some(f) => f,
+	};
 
 	if lock {
 		controller::owner_single_use(None, keychain_mask, Some(owner_api), |api, m| {
@@ -663,6 +669,7 @@ pub struct ReceiveArgs {
 	pub input_file: Option<String>,
 	pub input_slatepack_message: Option<String>,
 	pub skip_tor: bool,
+	pub outfile: Option<String>,
 }
 
 pub fn receive<L, C, K>(
@@ -726,6 +733,7 @@ where
 				keychain_mask,
 				&slate,
 				&dest,
+				args.outfile,
 				false,
 				false,
 				slate.version_info.version < 4,
@@ -821,6 +829,7 @@ pub struct FinalizeArgs {
 	pub input_slatepack_message: Option<String>,
 	pub fluff: bool,
 	pub nopost: bool,
+	pub outfile: Option<String>,
 }
 
 pub fn finalize<L, C, K>(
@@ -893,6 +902,7 @@ where
 		keychain_mask,
 		&slate,
 		"",
+		args.outfile,
 		false,
 		true,
 		slate.version_info.version < 4,
@@ -903,12 +913,14 @@ where
 
 /// Issue Invoice Args
 pub struct IssueInvoiceArgs {
-	/// output file
+	/// Slatepack address
 	pub dest: String,
 	/// issue invoice tx args
 	pub issue_args: IssueInvoiceTxArgs,
 	/// whether to output a V4 slate
 	pub output_v4_slate: bool,
+	/// output file override
+	pub outfile: Option<String>,
 }
 
 pub fn issue_invoice_tx<L, C, K>(
@@ -964,6 +976,7 @@ where
 		keychain_mask,
 		&slate,
 		args.dest.as_str(),
+		args.outfile,
 		false,
 		false,
 		is_pre_fork,
@@ -981,6 +994,7 @@ pub struct ProcessInvoiceArgs {
 	pub estimate_selection_strategies: bool,
 	pub ttl_blocks: Option<u64>,
 	pub skip_tor: bool,
+	pub outfile: Option<String>,
 }
 
 /// Process invoice
@@ -1081,6 +1095,7 @@ where
 				keychain_mask,
 				&slate,
 				&dest,
+				args.outfile,
 				true,
 				false,
 				slate.version_info.version < 4,

--- a/src/bin/grin-wallet.yml
+++ b/src/bin/grin-wallet.yml
@@ -145,6 +145,11 @@ subcommands:
             help: If present, don't attempt to send the resulting Slatepack via TOR
             short: m
             long: manual
+        - outfile:
+            help: If present, overrides the filename and location of the output Slatepack file.
+            short: u
+            long: outfile
+            takes_value: true
         #TODO: Remove HF3
         - v4:
             help: Output a V4 slate prior to HF3 block
@@ -170,6 +175,11 @@ subcommands:
             help: If present, don't attempt to send the resulting Slatepack via TOR
             short: m
             long: manual
+        - outfile:
+            help: If present, overrides the filename and location of the output Slatepack file.
+            short: u
+            long: outfile
+            takes_value: true
   - finalize:
       about: Processes a Slatepack Message to finalize a transfer.
       args:
@@ -186,6 +196,11 @@ subcommands:
             help: Do not post the transaction.
             short: n
             long: nopost
+        - outfile:
+            help: If present, overrides the filename and location of the output Slatepack file.
+            short: u
+            long: outfile
+            takes_value: true
   - invoice:
       about: Initialize an invoice transaction, outputting a Slatepack Message with the result
       args:
@@ -196,6 +211,11 @@ subcommands:
             help: Intended recipient's Slatepack Address
             short: d
             long: dest
+            takes_value: true
+        - outfile:
+            help: If present, overrides the filename and location of the output Slatepack file.
+            short: u
+            long: outfile
             takes_value: true
        #TODO: Remove HF3
         - v4:
@@ -243,6 +263,11 @@ subcommands:
             help: If present, don't attempt to send the resulting Slatepack via TOR
             short: m
             long: manual
+        - outfile:
+            help: If present, overrides the filename and location of the output Slatepack file.
+            short: u
+            long: outfile
+            takes_value: true
   - outputs:
       about: Raw wallet output info (list of outputs)
   - txs:

--- a/src/cmd/wallet_args.rs
+++ b/src/cmd/wallet_args.rs
@@ -283,6 +283,21 @@ fn parse_required<'a>(args: &'a ArgMatches, name: &str) -> Result<&'a str, Parse
 	}
 }
 
+// parses an optional value, throws error if value isn't provided
+fn parse_optional(args: &ArgMatches, name: &str) -> Result<Option<String>, ParseError> {
+	if !args.is_present(name) {
+		return Ok(None);
+	}
+	let arg = args.value_of(name);
+	match arg {
+		Some(ar) => Ok(Some(ar.into())),
+		None => {
+			let msg = format!("Value for argument '{}' is required in this context", name,);
+			Err(ParseError::ArgumentError(msg))
+		}
+	}
+}
+
 // parses a number, or throws error with message otherwise
 fn parse_u64(arg: &str, name: &str) -> Result<u64, ParseError> {
 	let val = arg.parse::<u64>();
@@ -514,6 +529,8 @@ pub fn parse_send_args(args: &ArgMatches) -> Result<command::SendArgs, ParseErro
 		}
 	};
 
+	let outfile = parse_optional(args, "outfile")?;
+
 	Ok(command::SendArgs {
 		amount: amount,
 		minimum_confirmations: min_c,
@@ -527,6 +544,7 @@ pub fn parse_send_args(args: &ArgMatches) -> Result<command::SendArgs, ParseErro
 		ttl_blocks,
 		target_slate_version: target_slate_version,
 		output_v4_slate,
+		outfile,
 		skip_tor: args.is_present("manual"),
 	})
 }
@@ -551,10 +569,13 @@ pub fn parse_receive_args(args: &ArgMatches) -> Result<command::ReceiveArgs, Par
 		input_slatepack_message = Some(prompt_slatepack()?);
 	}
 
+	let outfile = parse_optional(args, "outfile")?;
+
 	Ok(command::ReceiveArgs {
 		input_file,
 		input_slatepack_message,
 		skip_tor: args.is_present("manual"),
+		outfile,
 	})
 }
 
@@ -578,10 +599,13 @@ pub fn parse_unpack_args(args: &ArgMatches) -> Result<command::ReceiveArgs, Pars
 		input_slatepack_message = Some(prompt_slatepack()?);
 	}
 
+	let outfile = parse_optional(args, "outfile")?;
+
 	Ok(command::ReceiveArgs {
 		input_file,
 		input_slatepack_message,
 		skip_tor: args.is_present("manual"),
+		outfile,
 	})
 }
 
@@ -607,11 +631,14 @@ pub fn parse_finalize_args(args: &ArgMatches) -> Result<command::FinalizeArgs, P
 		input_slatepack_message = Some(prompt_slatepack()?);
 	}
 
+	let outfile = parse_optional(args, "outfile")?;
+
 	Ok(command::FinalizeArgs {
 		input_file,
 		input_slatepack_message,
 		fluff: fluff,
 		nopost: nopost,
+		outfile,
 	})
 }
 
@@ -651,6 +678,8 @@ pub fn parse_issue_invoice_args(
 		None => "default",
 	};
 
+	let outfile = parse_optional(args, "outfile")?;
+
 	Ok(command::IssueInvoiceArgs {
 		dest: dest.into(),
 		output_v4_slate,
@@ -659,6 +688,7 @@ pub fn parse_issue_invoice_args(
 			amount,
 			target_slate_version,
 		},
+		outfile,
 	})
 }
 
@@ -732,6 +762,8 @@ pub fn parse_process_invoice_args(
 		prompt_pay_invoice(&slate, &dest)?;
 	}
 
+	let outfile = parse_optional(args, "outfile")?;
+
 	Ok(command::ProcessInvoiceArgs {
 		minimum_confirmations: min_c,
 		selection_strategy: selection_strategy.to_owned(),
@@ -741,6 +773,7 @@ pub fn parse_process_invoice_args(
 		max_outputs,
 		ttl_blocks,
 		skip_tor: args.is_present("manual"),
+		outfile,
 	})
 }
 


### PR DESCRIPTION
Adds the `outfile` flag to all commands that output a slatepack. If provided, the backup slatepack file will be output to the specified location instead of the default `slatepack/[uuid].slatepack` location