### PR TITLE
TxLock and finalize

### DIFF
--- a/api/src/owner.rs
+++ b/api/src/owner.rs
@@ -701,7 +701,9 @@ where
 								}
 							}
 						} else {
-							return Ok(slate);
+							self.tx_lock_outputs(keychain_mask, &s)?;
+							let ret_slate = self.finalize_tx(keychain_mask, &s)?;
+							return Ok(ret_slate);
 						}
 					}
 					Ok(None) => Ok(slate),


### PR DESCRIPTION
Past behavior of the `init_send_tx` method with InitSendTxArgs (only when the recipient wallet was reachable):
1. Sender sends transaction to recipient
2. Recipients receives it and send back
3. Sender lock outputs
4. Sender `finalise` iff InitSendTxArgs contains `finalize=true` and returns the final slate
5. Sender `post_tx`  iff InitSendTxArgs contains `post_tx=true`  and returns the final slate

Current behavior with the same condition:
1. Sender sends transaction to recipient
2. Recipients receives it and send back
3. A. If `post_tx=true` Sender lock outputs, finalize and post_tx iff `post_tx=true`  and returns the final slate
3. B. If `post_tx=false` Sender returns the first slate

This PR locks outputs, finalise and return the final transaction but do not post when `post_tx=false`.

Fixes https://github.com/mimblewimble/grin-wallet/issues/480.

Might not be the best solution though. Thoughts @yeastplume ?