### PR TITLE
refactor to pass slice &[u8] around and not &Vec<u8>

### DIFF
--- a/controller/src/display.rs
+++ b/controller/src/display.rs
@@ -128,7 +128,7 @@ pub fn txs(
 	account: &str,
 	cur_height: u64,
 	validated: bool,
-	txs: &Vec<TxLogEntry>,
+	txs: &[TxLogEntry],
 	include_status: bool,
 	dark_background_color_scheme: bool,
 ) -> Result<(), Error> {

--- a/impls/src/adapters/slatepack.rs
+++ b/impls/src/adapters/slatepack.rs
@@ -47,7 +47,7 @@ impl<'a> PathToSlatepack<'a> {
 
 	pub fn get_slatepack(&self, decrypt: bool) -> Result<Slatepack, Error> {
 		let data = self.get_slatepack_file_contents()?;
-		self.packer.deser_slatepack(data, decrypt)
+		self.packer.deser_slatepack(&data, decrypt)
 	}
 }
 
@@ -80,7 +80,7 @@ impl<'a> SlatePutter for PathToSlatepack<'a> {
 impl<'a> SlateGetter for PathToSlatepack<'a> {
 	fn get_tx(&self) -> Result<(Slate, bool), Error> {
 		let data = self.get_slatepack_file_contents()?;
-		let slatepack = self.packer.deser_slatepack(data, true)?;
+		let slatepack = self.packer.deser_slatepack(&data, true)?;
 		Ok((self.packer.get_slate(&slatepack)?, true))
 	}
 }

--- a/integration/tests/simulnet.rs
+++ b/integration/tests/simulnet.rs
@@ -574,7 +574,7 @@ fn long_fork_test_mining(blocks: u64, n: u16, s: &servers::Server) {
 	);
 }
 
-fn long_fork_test_case_1(s: &Vec<servers::Server>) {
+fn long_fork_test_case_1(s: &[servers::Server]) {
 	println!("\ntest case 1 start");
 
 	// Mine state_sync_threshold-7 blocks on s0
@@ -621,7 +621,7 @@ fn long_fork_test_case_1(s: &Vec<servers::Server>) {
 	println!("test case 1 passed")
 }
 
-fn long_fork_test_case_2(s: &Vec<servers::Server>) {
+fn long_fork_test_case_2(s: &[servers::Server]) {
 	println!("\ntest case 2 start");
 
 	// Mine 20 blocks on s0
@@ -670,7 +670,7 @@ fn long_fork_test_case_2(s: &Vec<servers::Server>) {
 	println!("test case 2 passed")
 }
 
-fn long_fork_test_case_3(s: &Vec<servers::Server>) {
+fn long_fork_test_case_3(s: &[servers::Server]) {
 	println!("\ntest case 3 start");
 
 	// Mine cut_through_horizon+1 blocks on s4
@@ -736,7 +736,7 @@ fn long_fork_test_case_3(s: &Vec<servers::Server>) {
 	println!("test case 3 passed")
 }
 
-fn long_fork_test_case_4(s: &Vec<servers::Server>) {
+fn long_fork_test_case_4(s: &[servers::Server]) {
 	println!("\ntest case 4 start");
 
 	let _ = s[1].chain.compact();
@@ -783,7 +783,7 @@ fn long_fork_test_case_4(s: &Vec<servers::Server>) {
 	println!("test case 4 passed")
 }
 
-fn long_fork_test_case_5(s: &Vec<servers::Server>) {
+fn long_fork_test_case_5(s: &[servers::Server]) {
 	println!("\ntest case 5 start");
 
 	let _ = s[1].chain.compact();
@@ -831,7 +831,7 @@ fn long_fork_test_case_5(s: &Vec<servers::Server>) {
 }
 
 #[allow(dead_code)]
-fn long_fork_test_case_6(s: &Vec<servers::Server>) {
+fn long_fork_test_case_6(s: &[servers::Server]) {
 	println!("\ntest case 6 start");
 
 	let _ = s[1].chain.compact();

--- a/libwallet/src/api_impl/owner.rs
+++ b/libwallet/src/api_impl/owner.rs
@@ -167,7 +167,7 @@ where
 			recipients: vec![],
 			dec_key: None,
 		});
-		let slatepack = packer.deser_slatepack(slatepack.as_bytes().to_vec(), true)?;
+		let slatepack = packer.deser_slatepack(slatepack.as_bytes(), true)?;
 		return packer.get_slate(&slatepack);
 	} else {
 		for index in secret_indices {
@@ -181,7 +181,7 @@ where
 				recipients: vec![],
 				dec_key: (&dec_key).as_ref(),
 			});
-			let res = packer.deser_slatepack(slatepack.as_bytes().to_vec(), true);
+			let res = packer.deser_slatepack(slatepack.as_bytes(), true);
 			let slatepack = match res {
 				Ok(sp) => sp,
 				Err(_) => {
@@ -218,7 +218,7 @@ where
 		dec_key: None,
 	});
 	if secret_indices.is_empty() {
-		packer.deser_slatepack(slatepack.as_bytes().to_vec(), false)
+		packer.deser_slatepack(slatepack.as_bytes(), false)
 	} else {
 		for index in secret_indices {
 			let dec_key = Some(get_slatepack_secret_key(
@@ -231,7 +231,7 @@ where
 				recipients: vec![],
 				dec_key: (&dec_key).as_ref(),
 			});
-			let res = packer.deser_slatepack(slatepack.as_bytes().to_vec(), true);
+			let res = packer.deser_slatepack(slatepack.as_bytes(), true);
 			let slatepack = match res {
 				Ok(sp) => sp,
 				Err(_) => {
@@ -240,7 +240,7 @@ where
 			};
 			return Ok(slatepack);
 		}
-		packer.deser_slatepack(slatepack.as_bytes().to_vec(), false)
+		packer.deser_slatepack(slatepack.as_bytes(), false)
 	}
 }
 

--- a/libwallet/src/slate_versions/v4.rs
+++ b/libwallet/src/slate_versions/v4.rs
@@ -294,7 +294,7 @@ pub struct TransactionBodyV4 {
 	pub kers: Vec<TxKernelV4>,
 }
 
-fn inputs_are_empty(v: &Vec<InputV4>) -> bool {
+fn inputs_are_empty(v: &[InputV4]) -> bool {
 	v.len() == 0
 }
 
@@ -302,7 +302,7 @@ fn default_inputs() -> Vec<InputV4> {
 	vec![]
 }
 
-fn outputs_are_empty(v: &Vec<OutputV4>) -> bool {
+fn outputs_are_empty(v: &[OutputV4]) -> bool {
 	v.len() == 0
 }
 

--- a/libwallet/src/slatepack/types.rs
+++ b/libwallet/src/slatepack/types.rs
@@ -226,7 +226,7 @@ impl Slatepack {
 	}
 
 	/// retrieve recipients
-	pub fn recipients(&self) -> &Vec<SlatepackAddress> {
+	pub fn recipients(&self) -> &[SlatepackAddress] {
 		&self.encrypted_meta.recipients
 	}
 
@@ -453,7 +453,7 @@ pub struct SlatepackEncMetadata {
 	recipients: Vec<SlatepackAddress>,
 }
 
-fn recipients_empty(value: &Vec<SlatepackAddress>) -> bool {
+fn recipients_empty(value: &[SlatepackAddress]) -> bool {
 	value.is_empty()
 }
 

--- a/src/cmd/wallet_args.rs
+++ b/src/cmd/wallet_args.rs
@@ -151,7 +151,7 @@ fn prompt_slatepack() -> Result<String, ParseError> {
 				}
 			}
 			ReadResult::Input(line) => {
-				if SlatepackArmor::decode(&line).is_ok() {
+				if SlatepackArmor::decode(line.as_bytes()).is_ok() {
 					message = line;
 					break;
 				} else {


### PR DESCRIPTION
* refactor to pass slice `&[u8]` around and not `&Vec<u8>`
* cleaned up a couple of `unwrap()` calls in `check_header()` and `check_footer()`

It is more idiomatic in rust to pass a slice into a fn.
This ends up cleaning up some of the surrounding code as the fn is a little more flexible this way.

I noticed this when reviewing the proposed slatepack size checks in #495.