### PR TITLE
Clean up - Remove invoice state from context

### DIFF
--- a/libwallet/src/api_impl/foreign.rs
+++ b/libwallet/src/api_impl/foreign.rs
@@ -141,8 +141,7 @@ where
 {
 	let mut sl = slate.clone();
 	let context = w.get_private_context(keychain_mask, sl.id.as_bytes())?;
-	let is_invoice = context.is_invoice;
-	if is_invoice {
+	if sl.state == SlateState::Invoice2 {
 		check_ttl(w, &sl)?;
 
 		let mut temp_ctx = context.clone();

--- a/libwallet/src/api_impl/owner.rs
+++ b/libwallet/src/api_impl/owner.rs
@@ -674,7 +674,6 @@ where
 	if let Ok(c) = context_res {
 		context.initial_sec_key = c.initial_sec_key;
 		context.initial_sec_nonce = c.initial_sec_nonce;
-		context.is_invoice = c.is_invoice;
 		context.fee = c.fee;
 		context.amount = c.amount;
 		for o in c.output_ids.iter() {
@@ -953,25 +952,6 @@ where
 			})
 		}
 	}
-}
-
-/// return whether slate was an invoice tx
-pub fn context_is_invoice<'a, L, C, K>(
-	wallet_inst: Arc<Mutex<Box<dyn WalletInst<'a, L, C, K>>>>,
-	keychain_mask: Option<&SecretKey>,
-	slate: &Slate,
-) -> Result<bool, Error>
-where
-	L: WalletLCProvider<'a, C, K>,
-	C: NodeClient + 'a,
-	K: Keychain + 'a,
-{
-	let context = {
-		wallet_lock!(wallet_inst, w);
-		let context = w.get_private_context(keychain_mask, slate.id.as_bytes())?;
-		context
-	};
-	Ok(context.is_invoice)
 }
 
 /// Experimental, wrap the entire definition of how a wallet's state is updated

--- a/libwallet/src/internal/selection.rs
+++ b/libwallet/src/internal/selection.rs
@@ -47,7 +47,6 @@ pub fn build_send_tx<'a, T: ?Sized, C, K>(
 	change_outputs: usize,
 	selection_strategy_is_use_all: bool,
 	parent_key_id: Identifier,
-	is_invoice: bool,
 	use_test_nonce: bool,
 ) -> Result<Context, Error>
 where
@@ -79,7 +78,6 @@ where
 		blinding.secret_key(&keychain.secp()).unwrap(),
 		&parent_key_id,
 		use_test_nonce,
-		is_invoice,
 	);
 
 	context.fee = fee;
@@ -238,7 +236,6 @@ pub fn build_recipient_output<'a, T: ?Sized, C, K>(
 	slate: &mut Slate,
 	current_height: u64,
 	parent_key_id: Identifier,
-	is_invoice: bool,
 	use_test_rng: bool,
 ) -> Result<(Identifier, Context, TxLogEntry), Error>
 where
@@ -268,7 +265,6 @@ where
 			.unwrap(),
 		&parent_key_id,
 		use_test_rng,
-		is_invoice,
 	);
 
 	context.add_output(&key_id, &None, amount);

--- a/libwallet/src/internal/tx.rs
+++ b/libwallet/src/internal/tx.rs
@@ -175,7 +175,6 @@ where
 		num_change_outputs,
 		selection_strategy_is_use_all,
 		parent_key_id.clone(),
-		!is_initiator,
 		use_test_rng,
 	)?;
 
@@ -226,7 +225,6 @@ where
 		slate,
 		current_height,
 		parent_key_id.clone(),
-		is_initiator,
 		use_test_rng,
 	)?;
 

--- a/libwallet/src/types.rs
+++ b/libwallet/src/types.rs
@@ -554,8 +554,6 @@ pub struct Context {
 	pub fee: u64,
 	/// Payment proof sender address derivation path, if needed
 	pub payment_proof_derivation_index: Option<u32>,
-	/// whether this was an invoice transaction
-	pub is_invoice: bool,
 	/// for invoice I2 Only, store the tx excess so we can
 	/// remove it from the slate on return
 	pub calculated_excess: Option<pedersen::Commitment>,
@@ -568,7 +566,6 @@ impl Context {
 		sec_key: SecretKey,
 		parent_key_id: &Identifier,
 		use_test_rng: bool,
-		is_invoice: bool,
 	) -> Context {
 		let sec_nonce = match use_test_rng {
 			false => aggsig::create_secnonce(secp).unwrap(),
@@ -585,7 +582,6 @@ impl Context {
 			amount: 0,
 			fee: 0,
 			payment_proof_derivation_index: None,
-			is_invoice,
 			calculated_excess: None,
 		}
 	}

--- a/libwallet/tests/libwallet.rs
+++ b/libwallet/tests/libwallet.rs
@@ -74,7 +74,7 @@ fn aggsig_sender_receiver_interaction() {
 
 		let blind = blinding_factor.secret_key(&keychain.secp()).unwrap();
 
-		s_cx = Context::new(&keychain.secp(), blind, &parent, false, false);
+		s_cx = Context::new(&keychain.secp(), blind, &parent, false);
 		s_cx.get_public_keys(&keychain.secp())
 	};
 
@@ -88,7 +88,7 @@ fn aggsig_sender_receiver_interaction() {
 		// let blind = blind_sum.secret_key(&keychain.secp())?;
 		let blind = keychain.derive_key(0, &key_id, switch).unwrap();
 
-		rx_cx = Context::new(&keychain.secp(), blind, &parent, false, false);
+		rx_cx = Context::new(&keychain.secp(), blind, &parent, false);
 		let (pub_excess, pub_nonce) = rx_cx.get_public_keys(&keychain.secp());
 		rx_cx.add_output(&key_id, &None, 0);
 
@@ -293,7 +293,7 @@ fn aggsig_sender_receiver_interaction_offset() {
 
 		let blind = blinding_factor.secret_key(&keychain.secp()).unwrap();
 
-		s_cx = Context::new(&keychain.secp(), blind, &parent, false, false);
+		s_cx = Context::new(&keychain.secp(), blind, &parent, false);
 		s_cx.get_public_keys(&keychain.secp())
 	};
 
@@ -306,7 +306,7 @@ fn aggsig_sender_receiver_interaction_offset() {
 
 		let blind = keychain.derive_key(0, &key_id, switch).unwrap();
 
-		rx_cx = Context::new(&keychain.secp(), blind, &parent, false, false);
+		rx_cx = Context::new(&keychain.secp(), blind, &parent, false);
 		let (pub_excess, pub_nonce) = rx_cx.get_public_keys(&keychain.secp());
 		rx_cx.add_output(&key_id, &None, 0);
 


### PR DESCRIPTION
Now that slates contain their transaction state( S1, I2 etc), there should be no need for wallet to retain information about the type of transaction its dealing with. This removes this information from the stored context and simplifies some confusing leftover logic that was previously needed to determine what type and what stage a transaction was at.