### PR TITLE
get_unspent api changed to take a commitment directly

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1171,7 +1171,7 @@ checksum = "9b919933a397b79c37e33b77bb2aa3dc8eb6e165ad809e58ff75bc7db2e34574"
 [[package]]
 name = "grin_api"
 version = "4.1.0-alpha.1"
-source = "git+https://github.com/mimblewimble/grin#34adaf797e9cc73b38cc0e5abcfd1969e6e21eac"
+source = "git+https://github.com/mimblewimble/grin#caa6b8c747788e32953950a2dfd0a7c1e5d29cd2"
 dependencies = [
  "bytes",
  "easy-jsonrpc-mw",
@@ -1204,7 +1204,7 @@ dependencies = [
 [[package]]
 name = "grin_chain"
 version = "4.1.0-alpha.1"
-source = "git+https://github.com/mimblewimble/grin#34adaf797e9cc73b38cc0e5abcfd1969e6e21eac"
+source = "git+https://github.com/mimblewimble/grin#caa6b8c747788e32953950a2dfd0a7c1e5d29cd2"
 dependencies = [
  "bit-vec",
  "bitflags 1.2.1",
@@ -1228,7 +1228,7 @@ dependencies = [
 [[package]]
 name = "grin_core"
 version = "4.1.0-alpha.1"
-source = "git+https://github.com/mimblewimble/grin#34adaf797e9cc73b38cc0e5abcfd1969e6e21eac"
+source = "git+https://github.com/mimblewimble/grin#caa6b8c747788e32953950a2dfd0a7c1e5d29cd2"
 dependencies = [
  "blake2-rfc",
  "byteorder",
@@ -1254,7 +1254,7 @@ dependencies = [
 [[package]]
 name = "grin_keychain"
 version = "4.1.0-alpha.1"
-source = "git+https://github.com/mimblewimble/grin#34adaf797e9cc73b38cc0e5abcfd1969e6e21eac"
+source = "git+https://github.com/mimblewimble/grin#caa6b8c747788e32953950a2dfd0a7c1e5d29cd2"
 dependencies = [
  "blake2-rfc",
  "byteorder",
@@ -1276,7 +1276,7 @@ dependencies = [
 [[package]]
 name = "grin_p2p"
 version = "4.1.0-alpha.1"
-source = "git+https://github.com/mimblewimble/grin#34adaf797e9cc73b38cc0e5abcfd1969e6e21eac"
+source = "git+https://github.com/mimblewimble/grin#caa6b8c747788e32953950a2dfd0a7c1e5d29cd2"
 dependencies = [
  "bitflags 1.2.1",
  "chrono",
@@ -1297,7 +1297,7 @@ dependencies = [
 [[package]]
 name = "grin_pool"
 version = "4.1.0-alpha.1"
-source = "git+https://github.com/mimblewimble/grin#34adaf797e9cc73b38cc0e5abcfd1969e6e21eac"
+source = "git+https://github.com/mimblewimble/grin#caa6b8c747788e32953950a2dfd0a7c1e5d29cd2"
 dependencies = [
  "blake2-rfc",
  "chrono",
@@ -1331,7 +1331,7 @@ dependencies = [
 [[package]]
 name = "grin_store"
 version = "4.1.0-alpha.1"
-source = "git+https://github.com/mimblewimble/grin#34adaf797e9cc73b38cc0e5abcfd1969e6e21eac"
+source = "git+https://github.com/mimblewimble/grin#caa6b8c747788e32953950a2dfd0a7c1e5d29cd2"
 dependencies = [
  "byteorder",
  "croaring-mw",
@@ -1351,7 +1351,7 @@ dependencies = [
 [[package]]
 name = "grin_util"
 version = "4.1.0-alpha.1"
-source = "git+https://github.com/mimblewimble/grin#34adaf797e9cc73b38cc0e5abcfd1969e6e21eac"
+source = "git+https://github.com/mimblewimble/grin#caa6b8c747788e32953950a2dfd0a7c1e5d29cd2"
 dependencies = [
  "backtrace",
  "base64 0.12.3",

--- a/impls/src/test_framework/mod.rs
+++ b/impls/src/test_framework/mod.rs
@@ -16,7 +16,7 @@ use crate::api;
 use crate::chain;
 use crate::chain::Chain;
 use crate::core;
-use crate::core::core::{Output, OutputFeatures, OutputIdentifier, Transaction, TxKernel};
+use crate::core::core::{Output, Transaction, TxKernel};
 use crate::core::{consensus, global, pow};
 use crate::keychain;
 use crate::libwallet;
@@ -36,18 +36,11 @@ mod testclient;
 pub use self::{testclient::LocalWalletClient, testclient::WalletProxy};
 
 /// Get an output from the chain locally and present it back as an API output
-fn get_output_local(chain: &chain::Chain, commit: &pedersen::Commitment) -> Option<api::Output> {
-	let outputs = [
-		OutputIdentifier::new(OutputFeatures::Plain, commit),
-		OutputIdentifier::new(OutputFeatures::Coinbase, commit),
-	];
-
-	for x in outputs.iter() {
-		if chain.get_unspent(&x).unwrap().is_some() {
-			let block_height = chain.get_header_for_output(&x).unwrap().height;
-			let output_pos = chain.get_output_pos(&x.commit).unwrap_or(0);
-			return Some(api::Output::new(&commit, block_height, output_pos));
-		}
+fn get_output_local(chain: &chain::Chain, commit: pedersen::Commitment) -> Option<api::Output> {
+	if chain.get_unspent(commit).unwrap().is_some() {
+		let block_height = chain.get_header_for_output(commit).unwrap().height;
+		let output_pos = chain.get_output_pos(&commit).unwrap_or(0);
+		return Some(api::Output::new(&commit, block_height, output_pos));
 	}
 	None
 }

--- a/impls/src/test_framework/testclient.rs
+++ b/impls/src/test_framework/testclient.rs
@@ -276,7 +276,7 @@ where
 			}
 			let c = util::from_hex(&o_str).unwrap();
 			let commit = Commitment::from_vec(c);
-			let out = super::get_output_local(&self.chain.clone(), &commit);
+			let out = super::get_output_local(&self.chain.clone(), commit);
 			if let Some(o) = out {
 				outputs.push(o);
 			}


### PR DESCRIPTION
Related: https://github.com/mimblewimble/grin/pull/3423

Fix call to `chain.get_unspent()`