### PR TITLE
grin output_identifier refactoring

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1171,7 +1171,7 @@ checksum = "9b919933a397b79c37e33b77bb2aa3dc8eb6e165ad809e58ff75bc7db2e34574"
 [[package]]
 name = "grin_api"
 version = "4.1.0-alpha.1"
-source = "git+https://github.com/mimblewimble/grin#caa6b8c747788e32953950a2dfd0a7c1e5d29cd2"
+source = "git+https://github.com/mimblewimble/grin#133089e9855686854c87d6fbe4d67df775918bee"
 dependencies = [
  "bytes",
  "easy-jsonrpc-mw",
@@ -1204,7 +1204,7 @@ dependencies = [
 [[package]]
 name = "grin_chain"
 version = "4.1.0-alpha.1"
-source = "git+https://github.com/mimblewimble/grin#caa6b8c747788e32953950a2dfd0a7c1e5d29cd2"
+source = "git+https://github.com/mimblewimble/grin#133089e9855686854c87d6fbe4d67df775918bee"
 dependencies = [
  "bit-vec",
  "bitflags 1.2.1",
@@ -1228,7 +1228,7 @@ dependencies = [
 [[package]]
 name = "grin_core"
 version = "4.1.0-alpha.1"
-source = "git+https://github.com/mimblewimble/grin#caa6b8c747788e32953950a2dfd0a7c1e5d29cd2"
+source = "git+https://github.com/mimblewimble/grin#133089e9855686854c87d6fbe4d67df775918bee"
 dependencies = [
  "blake2-rfc",
  "byteorder",
@@ -1254,7 +1254,7 @@ dependencies = [
 [[package]]
 name = "grin_keychain"
 version = "4.1.0-alpha.1"
-source = "git+https://github.com/mimblewimble/grin#caa6b8c747788e32953950a2dfd0a7c1e5d29cd2"
+source = "git+https://github.com/mimblewimble/grin#133089e9855686854c87d6fbe4d67df775918bee"
 dependencies = [
  "blake2-rfc",
  "byteorder",
@@ -1276,7 +1276,7 @@ dependencies = [
 [[package]]
 name = "grin_p2p"
 version = "4.1.0-alpha.1"
-source = "git+https://github.com/mimblewimble/grin#caa6b8c747788e32953950a2dfd0a7c1e5d29cd2"
+source = "git+https://github.com/mimblewimble/grin#133089e9855686854c87d6fbe4d67df775918bee"
 dependencies = [
  "bitflags 1.2.1",
  "chrono",
@@ -1297,7 +1297,7 @@ dependencies = [
 [[package]]
 name = "grin_pool"
 version = "4.1.0-alpha.1"
-source = "git+https://github.com/mimblewimble/grin#caa6b8c747788e32953950a2dfd0a7c1e5d29cd2"
+source = "git+https://github.com/mimblewimble/grin#133089e9855686854c87d6fbe4d67df775918bee"
 dependencies = [
  "blake2-rfc",
  "chrono",
@@ -1331,7 +1331,7 @@ dependencies = [
 [[package]]
 name = "grin_store"
 version = "4.1.0-alpha.1"
-source = "git+https://github.com/mimblewimble/grin#caa6b8c747788e32953950a2dfd0a7c1e5d29cd2"
+source = "git+https://github.com/mimblewimble/grin#133089e9855686854c87d6fbe4d67df775918bee"
 dependencies = [
  "byteorder",
  "croaring-mw",
@@ -1351,7 +1351,7 @@ dependencies = [
 [[package]]
 name = "grin_util"
 version = "4.1.0-alpha.1"
-source = "git+https://github.com/mimblewimble/grin#caa6b8c747788e32953950a2dfd0a7c1e5d29cd2"
+source = "git+https://github.com/mimblewimble/grin#133089e9855686854c87d6fbe4d67df775918bee"
 dependencies = [
  "backtrace",
  "base64 0.12.3",

--- a/impls/src/test_framework/mod.rs
+++ b/impls/src/test_framework/mod.rs
@@ -40,9 +40,10 @@ fn get_output_local(chain: &chain::Chain, commit: pedersen::Commitment) -> Optio
 	if chain.get_unspent(commit).unwrap().is_some() {
 		let block_height = chain.get_header_for_output(commit).unwrap().height;
 		let output_pos = chain.get_output_pos(&commit).unwrap_or(0);
-		return Some(api::Output::new(&commit, block_height, output_pos));
+		Some(api::Output::new(&commit, block_height, output_pos))
+	} else {
+		None
 	}
-	None
 }
 
 /// Get a kernel from the chain locally

--- a/libwallet/src/internal/tx.rs
+++ b/libwallet/src/internal/tx.rs
@@ -616,7 +616,7 @@ mod test {
 		.unwrap();
 
 		let inputs: Vec<Input> = tx2.inputs().into();
-		assert_eq!(tx1.outputs()[0].features, inputs[0].features);
+		assert_eq!(tx1.outputs()[0].features(), inputs[0].features);
 		assert_eq!(tx1.outputs()[0].commitment(), inputs[0].commitment());
 	}
 

--- a/libwallet/src/slate.rs
+++ b/libwallet/src/slate.rs
@@ -839,8 +839,8 @@ impl From<&Slate> for Option<Vec<CommitsV4>> {
 		}
 		for o in outs.iter() {
 			ret_vec.push(CommitsV4 {
-				f: o.features.into(),
-				c: o.commit,
+				f: o.features().into(),
+				c: o.commitment(),
 				p: Some(o.proof),
 			});
 		}
@@ -1020,14 +1020,8 @@ pub fn tx_from_slate_v4(slate: &SlateV4) -> Option<Transaction> {
 	let mut tx = Transaction::empty().with_kernel(kernel);
 
 	for c in coms.iter() {
-		match &c.p {
-			Some(p) => {
-				tx = tx.with_output(Output {
-					features: c.f.into(),
-					commit: c.c,
-					proof: p.clone(),
-				})
-			}
+		match c.p {
+			Some(p) => tx = tx.with_output(Output::new(c.f.into(), c.c, p)),
 			None => {
 				tx = tx.with_input(Input {
 					features: c.f.into(),
@@ -1036,7 +1030,7 @@ pub fn tx_from_slate_v4(slate: &SlateV4) -> Option<Transaction> {
 			}
 		}
 	}
-	tx.offset = slate.off.clone();
+	tx = tx.with_offset(slate.off.clone());
 	Some(tx)
 }
 

--- a/libwallet/src/slate_versions/v4.rs
+++ b/libwallet/src/slate_versions/v4.rs
@@ -316,8 +316,8 @@ impl From<&Output> for CbOutputV4 {
 	fn from(output: &Output) -> CbOutputV4 {
 		CbOutputV4 {
 			features: CbOutputFeatures::Coinbase,
-			commit: output.commit,
-			proof: output.proof,
+			commit: output.commitment(),
+			proof: output.proof(),
 		}
 	}
 }


### PR DESCRIPTION
Related: https://github.com/mimblewimble/grin/pull/3371

Grin reworked outputs to wrap a pair of output_identifier and rangeproof. This simplifies some internal code and reduces the amount of magic going on when hashing outputs, comparing outputs etc.
This PR updates the wallet code to match this.

----

Added test coverage for json serialization/deserialization of the transaction in `push_transaction` api call.