### PR TITLE
we expect unspent outputs but play it safe

### DIFF
--- a/impls/src/node_clients/http.rs
+++ b/impls/src/node_clients/http.rs
@@ -321,7 +321,8 @@ impl NodeClient for HTTPNodeClient {
 
 		let params = json!([start_index, end_index, max_outputs, Some(true)]);
 		let res = self.send_json_request::<OutputListing>("get_unspent_outputs", &params)?;
-		for out in res.outputs {
+		// We asked for unspent outputs via the api but defensively filter out spent outputs just in case.
+		for out in res.outputs.into_iter().filter(|out| out.spent == false) {
 			let is_coinbase = match out.output_type {
 				api::OutputType::Coinbase => true,
 				api::OutputType::Transaction => false,


### PR DESCRIPTION
Related: #516 

We call the `get_unspent_outputs` api and expect to receive a collection of unspent outputs.
This is a reasonable assumption but we are brittle on the receiving/parsing side as each output in the response _must_ contain a block height. If we receive a _spent_ output for any reason the wallet is rendered inoperable as we can no longer refresh outputs.

This PR adds a (hopefully redundant) level of robustness by explicitly filtering out spent outputs from the list returned by the api.

See #516 for some background where the node api was inadvertently changed to return spent and unspent outputs, causing the wallet to fail.

