### PR TITLE
Rename Floonet to Testnet

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1170,7 +1170,8 @@ checksum = "9b919933a397b79c37e33b77bb2aa3dc8eb6e165ad809e58ff75bc7db2e34574"
 
 [[package]]
 name = "grin_api"
-version = "4.2.0-alpha.1"
+version = "4.1.0-alpha.1"
+source = "git+https://github.com/mimblewimble/grin#7dc94576bd448bdca9f4f85eae9a150317b07976"
 dependencies = [
  "bytes",
  "easy-jsonrpc-mw",
@@ -1202,7 +1203,8 @@ dependencies = [
 
 [[package]]
 name = "grin_chain"
-version = "4.2.0-alpha.1"
+version = "4.1.0-alpha.1"
+source = "git+https://github.com/mimblewimble/grin#7dc94576bd448bdca9f4f85eae9a150317b07976"
 dependencies = [
  "bit-vec",
  "bitflags 1.2.1",
@@ -1225,11 +1227,11 @@ dependencies = [
 
 [[package]]
 name = "grin_core"
-version = "4.2.0-alpha.1"
+version = "4.1.0-alpha.1"
+source = "git+https://github.com/mimblewimble/grin#7dc94576bd448bdca9f4f85eae9a150317b07976"
 dependencies = [
  "blake2-rfc",
  "byteorder",
- "bytes",
  "chrono",
  "croaring-mw",
  "enum_primitive",
@@ -1251,7 +1253,8 @@ dependencies = [
 
 [[package]]
 name = "grin_keychain"
-version = "4.2.0-alpha.1"
+version = "4.1.0-alpha.1"
+source = "git+https://github.com/mimblewimble/grin#7dc94576bd448bdca9f4f85eae9a150317b07976"
 dependencies = [
  "blake2-rfc",
  "byteorder",
@@ -1272,10 +1275,10 @@ dependencies = [
 
 [[package]]
 name = "grin_p2p"
-version = "4.2.0-alpha.1"
+version = "4.1.0-alpha.1"
+source = "git+https://github.com/mimblewimble/grin#7dc94576bd448bdca9f4f85eae9a150317b07976"
 dependencies = [
  "bitflags 1.2.1",
- "bytes",
  "chrono",
  "enum_primitive",
  "grin_chain",
@@ -1293,7 +1296,8 @@ dependencies = [
 
 [[package]]
 name = "grin_pool"
-version = "4.2.0-alpha.1"
+version = "4.1.0-alpha.1"
+source = "git+https://github.com/mimblewimble/grin#7dc94576bd448bdca9f4f85eae9a150317b07976"
 dependencies = [
  "blake2-rfc",
  "chrono",
@@ -1326,7 +1330,8 @@ dependencies = [
 
 [[package]]
 name = "grin_store"
-version = "4.2.0-alpha.1"
+version = "4.1.0-alpha.1"
+source = "git+https://github.com/mimblewimble/grin#7dc94576bd448bdca9f4f85eae9a150317b07976"
 dependencies = [
  "byteorder",
  "croaring-mw",
@@ -1345,7 +1350,8 @@ dependencies = [
 
 [[package]]
 name = "grin_util"
-version = "4.2.0-alpha.1"
+version = "4.1.0-alpha.1"
+source = "git+https://github.com/mimblewimble/grin#7dc94576bd448bdca9f4f85eae9a150317b07976"
 dependencies = [
  "backtrace",
  "base64 0.12.3",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1170,8 +1170,7 @@ checksum = "9b919933a397b79c37e33b77bb2aa3dc8eb6e165ad809e58ff75bc7db2e34574"
 
 [[package]]
 name = "grin_api"
-version = "4.1.0-alpha.1"
-source = "git+https://github.com/mimblewimble/grin#7dc94576bd448bdca9f4f85eae9a150317b07976"
+version = "4.2.0-alpha.1"
 dependencies = [
  "bytes",
  "easy-jsonrpc-mw",
@@ -1203,8 +1202,7 @@ dependencies = [
 
 [[package]]
 name = "grin_chain"
-version = "4.1.0-alpha.1"
-source = "git+https://github.com/mimblewimble/grin#7dc94576bd448bdca9f4f85eae9a150317b07976"
+version = "4.2.0-alpha.1"
 dependencies = [
  "bit-vec",
  "bitflags 1.2.1",
@@ -1227,11 +1225,11 @@ dependencies = [
 
 [[package]]
 name = "grin_core"
-version = "4.1.0-alpha.1"
-source = "git+https://github.com/mimblewimble/grin#7dc94576bd448bdca9f4f85eae9a150317b07976"
+version = "4.2.0-alpha.1"
 dependencies = [
  "blake2-rfc",
  "byteorder",
+ "bytes",
  "chrono",
  "croaring-mw",
  "enum_primitive",
@@ -1253,8 +1251,7 @@ dependencies = [
 
 [[package]]
 name = "grin_keychain"
-version = "4.1.0-alpha.1"
-source = "git+https://github.com/mimblewimble/grin#7dc94576bd448bdca9f4f85eae9a150317b07976"
+version = "4.2.0-alpha.1"
 dependencies = [
  "blake2-rfc",
  "byteorder",
@@ -1275,10 +1272,10 @@ dependencies = [
 
 [[package]]
 name = "grin_p2p"
-version = "4.1.0-alpha.1"
-source = "git+https://github.com/mimblewimble/grin#7dc94576bd448bdca9f4f85eae9a150317b07976"
+version = "4.2.0-alpha.1"
 dependencies = [
  "bitflags 1.2.1",
+ "bytes",
  "chrono",
  "enum_primitive",
  "grin_chain",
@@ -1296,8 +1293,7 @@ dependencies = [
 
 [[package]]
 name = "grin_pool"
-version = "4.1.0-alpha.1"
-source = "git+https://github.com/mimblewimble/grin#7dc94576bd448bdca9f4f85eae9a150317b07976"
+version = "4.2.0-alpha.1"
 dependencies = [
  "blake2-rfc",
  "chrono",
@@ -1330,8 +1326,7 @@ dependencies = [
 
 [[package]]
 name = "grin_store"
-version = "4.1.0-alpha.1"
-source = "git+https://github.com/mimblewimble/grin#7dc94576bd448bdca9f4f85eae9a150317b07976"
+version = "4.2.0-alpha.1"
 dependencies = [
  "byteorder",
  "croaring-mw",
@@ -1350,8 +1345,7 @@ dependencies = [
 
 [[package]]
 name = "grin_util"
-version = "4.1.0-alpha.1"
-source = "git+https://github.com/mimblewimble/grin#7dc94576bd448bdca9f4f85eae9a150317b07976"
+version = "4.2.0-alpha.1"
 dependencies = [
  "backtrace",
  "base64 0.12.3",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1170,8 +1170,8 @@ checksum = "9b919933a397b79c37e33b77bb2aa3dc8eb6e165ad809e58ff75bc7db2e34574"
 
 [[package]]
 name = "grin_api"
-version = "4.1.0-alpha.1"
-source = "git+https://github.com/mimblewimble/grin#7dc94576bd448bdca9f4f85eae9a150317b07976"
+version = "4.2.0-alpha.1"
+source = "git+https://github.com/mimblewimble/grin#cf2a65242d9805b0688e40f2432250461aa56561"
 dependencies = [
  "bytes",
  "easy-jsonrpc-mw",
@@ -1203,8 +1203,8 @@ dependencies = [
 
 [[package]]
 name = "grin_chain"
-version = "4.1.0-alpha.1"
-source = "git+https://github.com/mimblewimble/grin#7dc94576bd448bdca9f4f85eae9a150317b07976"
+version = "4.2.0-alpha.1"
+source = "git+https://github.com/mimblewimble/grin#cf2a65242d9805b0688e40f2432250461aa56561"
 dependencies = [
  "bit-vec",
  "bitflags 1.2.1",
@@ -1227,11 +1227,12 @@ dependencies = [
 
 [[package]]
 name = "grin_core"
-version = "4.1.0-alpha.1"
-source = "git+https://github.com/mimblewimble/grin#7dc94576bd448bdca9f4f85eae9a150317b07976"
+version = "4.2.0-alpha.1"
+source = "git+https://github.com/mimblewimble/grin#cf2a65242d9805b0688e40f2432250461aa56561"
 dependencies = [
  "blake2-rfc",
  "byteorder",
+ "bytes",
  "chrono",
  "croaring-mw",
  "enum_primitive",
@@ -1253,8 +1254,8 @@ dependencies = [
 
 [[package]]
 name = "grin_keychain"
-version = "4.1.0-alpha.1"
-source = "git+https://github.com/mimblewimble/grin#7dc94576bd448bdca9f4f85eae9a150317b07976"
+version = "4.2.0-alpha.1"
+source = "git+https://github.com/mimblewimble/grin#cf2a65242d9805b0688e40f2432250461aa56561"
 dependencies = [
  "blake2-rfc",
  "byteorder",
@@ -1275,10 +1276,11 @@ dependencies = [
 
 [[package]]
 name = "grin_p2p"
-version = "4.1.0-alpha.1"
-source = "git+https://github.com/mimblewimble/grin#7dc94576bd448bdca9f4f85eae9a150317b07976"
+version = "4.2.0-alpha.1"
+source = "git+https://github.com/mimblewimble/grin#cf2a65242d9805b0688e40f2432250461aa56561"
 dependencies = [
  "bitflags 1.2.1",
+ "bytes",
  "chrono",
  "enum_primitive",
  "grin_chain",
@@ -1296,8 +1298,8 @@ dependencies = [
 
 [[package]]
 name = "grin_pool"
-version = "4.1.0-alpha.1"
-source = "git+https://github.com/mimblewimble/grin#7dc94576bd448bdca9f4f85eae9a150317b07976"
+version = "4.2.0-alpha.1"
+source = "git+https://github.com/mimblewimble/grin#cf2a65242d9805b0688e40f2432250461aa56561"
 dependencies = [
  "blake2-rfc",
  "chrono",
@@ -1330,8 +1332,8 @@ dependencies = [
 
 [[package]]
 name = "grin_store"
-version = "4.1.0-alpha.1"
-source = "git+https://github.com/mimblewimble/grin#7dc94576bd448bdca9f4f85eae9a150317b07976"
+version = "4.2.0-alpha.1"
+source = "git+https://github.com/mimblewimble/grin#cf2a65242d9805b0688e40f2432250461aa56561"
 dependencies = [
  "byteorder",
  "croaring-mw",
@@ -1350,8 +1352,8 @@ dependencies = [
 
 [[package]]
 name = "grin_util"
-version = "4.1.0-alpha.1"
-source = "git+https://github.com/mimblewimble/grin#7dc94576bd448bdca9f4f85eae9a150317b07976"
+version = "4.2.0-alpha.1"
+source = "git+https://github.com/mimblewimble/grin#cf2a65242d9805b0688e40f2432250461aa56561"
 dependencies = [
  "backtrace",
  "base64 0.12.3",

--- a/api/src/owner.rs
+++ b/api/src/owner.rs
@@ -1410,7 +1410,7 @@ where
 	/// * `chain_type`: The chain type to use in creation of the configuration file. This can be
 	///     * `AutomatedTesting`
 	///     * `UserTesting`
-	///     * `Floonet`
+	///     * `Testnet`
 	///     * `Mainnet`
 	///
 	/// # Returns

--- a/config/src/config.rs
+++ b/config/src/config.rs
@@ -213,7 +213,7 @@ impl GlobalWalletConfig {
 
 		match *chain_type {
 			global::ChainTypes::Mainnet => {}
-			global::ChainTypes::Floonet => {
+			global::ChainTypes::Testnet => {
 				defaults.api_listen_port = 13415;
 				defaults.check_node_api_http_addr = "http://127.0.0.1:13413".to_owned();
 			}

--- a/impls/src/lifecycle/default.rs
+++ b/impls/src/lifecycle/default.rs
@@ -236,7 +236,7 @@ where
 			ErrorKind::Lifecycle("Error opening wallet (is password correct?)".into()),
 		)?;
 		let keychain = wallet_seed
-			.derive_keychain(global::is_floonet())
+			.derive_keychain(global::is_testnet())
 			.context(ErrorKind::Lifecycle("Error deriving keychain".into()))?;
 
 		let mask = wallet.set_keychain(Box::new(keychain), create_mask, use_test_rng)?;

--- a/impls/src/lifecycle/seed.rs
+++ b/impls/src/lifecycle/seed.rs
@@ -71,8 +71,8 @@ impl WalletSeed {
 		seed.as_bytes().to_vec()
 	}
 
-	pub fn derive_keychain<K: Keychain>(&self, is_floonet: bool) -> Result<K, Error> {
-		let result = K::from_seed(&self.0, is_floonet)?;
+	pub fn derive_keychain<K: Keychain>(&self, is_testnet: bool) -> Result<K, Error> {
+		let result = K::from_seed(&self.0, is_testnet)?;
 		Ok(result)
 	}
 

--- a/libwallet/src/types.rs
+++ b/libwallet/src/types.rs
@@ -56,11 +56,11 @@ where
 	K: Keychain + 'a,
 {
 	/// Sets the top level system wallet directory
-	/// default is assumed to be ~/.grin/main/wallet_data (or floonet equivalent)
+	/// default is assumed to be ~/.grin/main/wallet_data (or testnet equivalent)
 	fn set_top_level_directory(&mut self, dir: &str) -> Result<(), Error>;
 
 	/// Sets the top level system wallet directory
-	/// default is assumed to be ~/.grin/main/wallet_data (or floonet equivalent)
+	/// default is assumed to be ~/.grin/main/wallet_data (or testnet equivalent)
 	fn get_top_level_directory(&self) -> Result<String, Error>;
 
 	/// Output a grin-wallet.toml file into the current top-level system wallet directory

--- a/src/bin/grin-wallet.rs
+++ b/src/bin/grin-wallet.rs
@@ -72,7 +72,7 @@ fn real_main() -> i32 {
 		.version(built_info::PKG_VERSION)
 		.get_matches();
 
-	let chain_type = if args.is_present("testet") {
+	let chain_type = if args.is_present("testnet") {
 		global::ChainTypes::Testnet
 	} else if args.is_present("usernet") {
 		global::ChainTypes::UserTesting

--- a/src/bin/grin-wallet.rs
+++ b/src/bin/grin-wallet.rs
@@ -72,8 +72,8 @@ fn real_main() -> i32 {
 		.version(built_info::PKG_VERSION)
 		.get_matches();
 
-	let chain_type = if args.is_present("floonet") {
-		global::ChainTypes::Floonet
+	let chain_type = if args.is_present("testet") {
+		global::ChainTypes::Testnet
 	} else if args.is_present("usernet") {
 		global::ChainTypes::UserTesting
 	} else {

--- a/src/bin/grin-wallet.yml
+++ b/src/bin/grin-wallet.yml
@@ -3,9 +3,9 @@ about: Reference Grin Wallet
 author: The Grin Team
 
 args:
-  - floonet:
-      help: Run grin against the Floonet (as opposed to mainnet)
-      long: floonet
+  - testnet:
+      help: Run grin against the Testnet (as opposed to mainnet)
+      long: testnet
       takes_value: false
   - usernet:
       help: Run grin as a local-only network. Doesn't block peer connections but will not connect to any peer or seed

--- a/util/Cargo.toml
+++ b/util/Cargo.toml
@@ -35,20 +35,20 @@ sha3 = "0.8"
 # grin_store = { git = "https://github.com/mimblewimble/grin", tag = "v4.0.0-rc.1" }
 
 # For bleeding edge
-grin_core = { git = "https://github.com/mimblewimble/grin", branch = "master" }
-grin_keychain = { git = "https://github.com/mimblewimble/grin", branch = "master" }
-grin_chain = { git = "https://github.com/mimblewimble/grin", branch = "master" }
-grin_util = { git = "https://github.com/mimblewimble/grin", branch = "master" }
-grin_api = { git = "https://github.com/mimblewimble/grin", branch = "master" }
-grin_store = { git = "https://github.com/mimblewimble/grin", branch = "master" }
+#grin_core = { git = "https://github.com/mimblewimble/grin", branch = "master" }
+#grin_keychain = { git = "https://github.com/mimblewimble/grin", branch = "master" }
+#grin_chain = { git = "https://github.com/mimblewimble/grin", branch = "master" }
+#grin_util = { git = "https://github.com/mimblewimble/grin", branch = "master" }
+#grin_api = { git = "https://github.com/mimblewimble/grin", branch = "master" }
+#grin_store = { git = "https://github.com/mimblewimble/grin", branch = "master" }
 
 # For local testing
-# grin_core = { path = "../../grin/core"}
-# grin_keychain = { path = "../../grin/keychain"}
-# grin_chain = { path = "../../grin/chain"}
-# grin_util = { path = "../../grin/util"}
-# grin_api = { path = "../../grin/api"}
-# grin_store = { path = "../../grin/store"}
+grin_core = { path = "../../grin/core"}
+grin_keychain = { path = "../../grin/keychain"}
+grin_chain = { path = "../../grin/chain"}
+grin_util = { path = "../../grin/util"}
+grin_api = { path = "../../grin/api"}
+grin_store = { path = "../../grin/store"}
 
 [dev-dependencies]
 pretty_assertions = "0.6"

--- a/util/Cargo.toml
+++ b/util/Cargo.toml
@@ -35,20 +35,20 @@ sha3 = "0.8"
 # grin_store = { git = "https://github.com/mimblewimble/grin", tag = "v4.0.0-rc.1" }
 
 # For bleeding edge
-#grin_core = { git = "https://github.com/mimblewimble/grin", branch = "master" }
-#grin_keychain = { git = "https://github.com/mimblewimble/grin", branch = "master" }
-#grin_chain = { git = "https://github.com/mimblewimble/grin", branch = "master" }
-#grin_util = { git = "https://github.com/mimblewimble/grin", branch = "master" }
-#grin_api = { git = "https://github.com/mimblewimble/grin", branch = "master" }
-#grin_store = { git = "https://github.com/mimblewimble/grin", branch = "master" }
+grin_core = { git = "https://github.com/mimblewimble/grin", branch = "master" }
+grin_keychain = { git = "https://github.com/mimblewimble/grin", branch = "master" }
+grin_chain = { git = "https://github.com/mimblewimble/grin", branch = "master" }
+grin_util = { git = "https://github.com/mimblewimble/grin", branch = "master" }
+grin_api = { git = "https://github.com/mimblewimble/grin", branch = "master" }
+grin_store = { git = "https://github.com/mimblewimble/grin", branch = "master" }
 
 # For local testing
-grin_core = { path = "../../grin/core"}
-grin_keychain = { path = "../../grin/keychain"}
-grin_chain = { path = "../../grin/chain"}
-grin_util = { path = "../../grin/util"}
-grin_api = { path = "../../grin/api"}
-grin_store = { path = "../../grin/store"}
+# grin_core = { path = "../../grin/core"}
+# grin_keychain = { path = "../../grin/keychain"}
+# grin_chain = { path = "../../grin/chain"}
+# grin_util = { path = "../../grin/util"}
+# grin_api = { path = "../../grin/api"}
+# grin_store = { path = "../../grin/store"}
 
 [dev-dependencies]
 pretty_assertions = "0.6"


### PR DESCRIPTION
Equivalent of https://github.com/mimblewimble/grin/pull/3431. Tests won't pass until merged.
There is no migration setup so user will need to move/restore in the new `test` dir.
