### PR TITLE
fix our lmdb iter usage to work with changes in grin

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1170,8 +1170,8 @@ checksum = "9b919933a397b79c37e33b77bb2aa3dc8eb6e165ad809e58ff75bc7db2e34574"
 
 [[package]]
 name = "grin_api"
-version = "4.1.0-alpha.1"
-source = "git+https://github.com/mimblewimble/grin#7dc94576bd448bdca9f4f85eae9a150317b07976"
+version = "4.2.0-alpha.1"
+source = "git+https://github.com/mimblewimble/grin#4c6d1dd4bd55e7ee8ad697d008d3292fbf09f99e"
 dependencies = [
  "bytes",
  "easy-jsonrpc-mw",
@@ -1203,8 +1203,8 @@ dependencies = [
 
 [[package]]
 name = "grin_chain"
-version = "4.1.0-alpha.1"
-source = "git+https://github.com/mimblewimble/grin#7dc94576bd448bdca9f4f85eae9a150317b07976"
+version = "4.2.0-alpha.1"
+source = "git+https://github.com/mimblewimble/grin#4c6d1dd4bd55e7ee8ad697d008d3292fbf09f99e"
 dependencies = [
  "bit-vec",
  "bitflags 1.2.1",
@@ -1227,11 +1227,12 @@ dependencies = [
 
 [[package]]
 name = "grin_core"
-version = "4.1.0-alpha.1"
-source = "git+https://github.com/mimblewimble/grin#7dc94576bd448bdca9f4f85eae9a150317b07976"
+version = "4.2.0-alpha.1"
+source = "git+https://github.com/mimblewimble/grin#4c6d1dd4bd55e7ee8ad697d008d3292fbf09f99e"
 dependencies = [
  "blake2-rfc",
  "byteorder",
+ "bytes",
  "chrono",
  "croaring-mw",
  "enum_primitive",
@@ -1253,8 +1254,8 @@ dependencies = [
 
 [[package]]
 name = "grin_keychain"
-version = "4.1.0-alpha.1"
-source = "git+https://github.com/mimblewimble/grin#7dc94576bd448bdca9f4f85eae9a150317b07976"
+version = "4.2.0-alpha.1"
+source = "git+https://github.com/mimblewimble/grin#4c6d1dd4bd55e7ee8ad697d008d3292fbf09f99e"
 dependencies = [
  "blake2-rfc",
  "byteorder",
@@ -1275,10 +1276,11 @@ dependencies = [
 
 [[package]]
 name = "grin_p2p"
-version = "4.1.0-alpha.1"
-source = "git+https://github.com/mimblewimble/grin#7dc94576bd448bdca9f4f85eae9a150317b07976"
+version = "4.2.0-alpha.1"
+source = "git+https://github.com/mimblewimble/grin#4c6d1dd4bd55e7ee8ad697d008d3292fbf09f99e"
 dependencies = [
  "bitflags 1.2.1",
+ "bytes",
  "chrono",
  "enum_primitive",
  "grin_chain",
@@ -1296,8 +1298,8 @@ dependencies = [
 
 [[package]]
 name = "grin_pool"
-version = "4.1.0-alpha.1"
-source = "git+https://github.com/mimblewimble/grin#7dc94576bd448bdca9f4f85eae9a150317b07976"
+version = "4.2.0-alpha.1"
+source = "git+https://github.com/mimblewimble/grin#4c6d1dd4bd55e7ee8ad697d008d3292fbf09f99e"
 dependencies = [
  "blake2-rfc",
  "chrono",
@@ -1330,8 +1332,8 @@ dependencies = [
 
 [[package]]
 name = "grin_store"
-version = "4.1.0-alpha.1"
-source = "git+https://github.com/mimblewimble/grin#7dc94576bd448bdca9f4f85eae9a150317b07976"
+version = "4.2.0-alpha.1"
+source = "git+https://github.com/mimblewimble/grin#4c6d1dd4bd55e7ee8ad697d008d3292fbf09f99e"
 dependencies = [
  "byteorder",
  "croaring-mw",
@@ -1350,8 +1352,8 @@ dependencies = [
 
 [[package]]
 name = "grin_util"
-version = "4.1.0-alpha.1"
-source = "git+https://github.com/mimblewimble/grin#7dc94576bd448bdca9f4f85eae9a150317b07976"
+version = "4.2.0-alpha.1"
+source = "git+https://github.com/mimblewimble/grin#4c6d1dd4bd55e7ee8ad697d008d3292fbf09f99e"
 dependencies = [
  "backtrace",
  "base64 0.12.3",

--- a/impls/src/backends/lmdb.rs
+++ b/impls/src/backends/lmdb.rs
@@ -303,8 +303,14 @@ where
 			.map_err(|e| e.into())
 	}
 
+	// TODO - fix this awkward conversion between PrefixIterator and our Box<dyn Iterator>
 	fn iter<'a>(&'a self) -> Box<dyn Iterator<Item = OutputData> + 'a> {
-		Box::new(self.db.iter(&[OUTPUT_PREFIX]).unwrap().map(|o| o.1))
+		let protocol_version = self.db.protocol_version();
+		let prefix_iter = self.db.iter(&[OUTPUT_PREFIX], move |_, mut v| {
+			ser::deserialize(&mut v, protocol_version).map_err(From::from)
+		});
+		let iter = prefix_iter.expect("deserialize").into_iter();
+		Box::new(iter)
 	}
 
 	fn get_tx_log_entry(&self, u: &Uuid) -> Result<Option<TxLogEntry>, Error> {
@@ -312,8 +318,14 @@ where
 		self.db.get_ser(&key).map_err(|e| e.into())
 	}
 
+	// TODO - fix this awkward conversion between PrefixIterator and our Box<dyn Iterator>
 	fn tx_log_iter<'a>(&'a self) -> Box<dyn Iterator<Item = TxLogEntry> + 'a> {
-		Box::new(self.db.iter(&[TX_LOG_ENTRY_PREFIX]).unwrap().map(|o| o.1))
+		let protocol_version = self.db.protocol_version();
+		let prefix_iter = self.db.iter(&[TX_LOG_ENTRY_PREFIX], move |_, mut v| {
+			ser::deserialize(&mut v, protocol_version).map_err(From::from)
+		});
+		let iter = prefix_iter.expect("deserialize").into_iter();
+		Box::new(iter)
 	}
 
 	fn get_private_context(
@@ -337,13 +349,16 @@ where
 		Ok(ctx)
 	}
 
+	// TODO - fix this awkward conversion between PrefixIterator and our Box<dyn Iterator>
 	fn acct_path_iter<'a>(&'a self) -> Box<dyn Iterator<Item = AcctPathMapping> + 'a> {
-		Box::new(
-			self.db
-				.iter(&[ACCOUNT_PATH_MAPPING_PREFIX])
-				.unwrap()
-				.map(|o| o.1),
-		)
+		let protocol_version = self.db.protocol_version();
+		let prefix_iter = self
+			.db
+			.iter(&[ACCOUNT_PATH_MAPPING_PREFIX], move |_, mut v| {
+				ser::deserialize(&mut v, protocol_version).map_err(From::from)
+			});
+		let iter = prefix_iter.expect("deserialize").into_iter();
+		Box::new(iter)
 	}
 
 	fn get_acct_path(&self, label: String) -> Result<Option<AcctPathMapping>, Error> {
@@ -522,16 +537,16 @@ where
 		.map_err(|e| e.into())
 	}
 
+	// TODO - fix this awkward conversion between PrefixIterator and our Box<dyn Iterator>
 	fn iter(&self) -> Box<dyn Iterator<Item = OutputData>> {
-		Box::new(
-			self.db
-				.borrow()
-				.as_ref()
-				.unwrap()
-				.iter(&[OUTPUT_PREFIX])
-				.unwrap()
-				.map(|o| o.1),
-		)
+		let db = self.db.borrow();
+		let db = db.as_ref().unwrap();
+		let protocol_version = db.protocol_version();
+		let prefix_iter = db.iter(&[OUTPUT_PREFIX], move |_, mut v| {
+			ser::deserialize(&mut v, protocol_version).map_err(From::from)
+		});
+		let iter = prefix_iter.expect("deserialize").into_iter();
+		Box::new(iter)
 	}
 
 	fn delete(&mut self, id: &Identifier, mmr_index: &Option<u64>) -> Result<(), Error> {
@@ -561,16 +576,16 @@ where
 		Ok(last_tx_log_id)
 	}
 
+	// TODO - fix this awkward conversion between PrefixIterator and our Box<dyn Iterator>
 	fn tx_log_iter(&self) -> Box<dyn Iterator<Item = TxLogEntry>> {
-		Box::new(
-			self.db
-				.borrow()
-				.as_ref()
-				.unwrap()
-				.iter(&[TX_LOG_ENTRY_PREFIX])
-				.unwrap()
-				.map(|o| o.1),
-		)
+		let db = self.db.borrow();
+		let db = db.as_ref().unwrap();
+		let protocol_version = db.protocol_version();
+		let prefix_iter = db.iter(&[TX_LOG_ENTRY_PREFIX], move |_, mut v| {
+			ser::deserialize(&mut v, protocol_version).map_err(From::from)
+		});
+		let iter = prefix_iter.expect("deserialize").into_iter();
+		Box::new(iter)
 	}
 
 	fn save_last_confirmed_height(
@@ -657,16 +672,16 @@ where
 		Ok(())
 	}
 
+	// TODO - fix this awkward conversion between PrefixIterator and our Box<dyn Iterator>
 	fn acct_path_iter(&self) -> Box<dyn Iterator<Item = AcctPathMapping>> {
-		Box::new(
-			self.db
-				.borrow()
-				.as_ref()
-				.unwrap()
-				.iter(&[ACCOUNT_PATH_MAPPING_PREFIX])
-				.unwrap()
-				.map(|o| o.1),
-		)
+		let db = self.db.borrow();
+		let db = db.as_ref().unwrap();
+		let protocol_version = db.protocol_version();
+		let prefix_iter = db.iter(&[ACCOUNT_PATH_MAPPING_PREFIX], move |_, mut v| {
+			ser::deserialize(&mut v, protocol_version).map_err(From::from)
+		});
+		let iter = prefix_iter.expect("deserialize").into_iter();
+		Box::new(iter)
 	}
 
 	fn lock_output(&mut self, out: &mut OutputData) -> Result<(), Error> {


### PR DESCRIPTION
Our low level lmdb iter usage changed in https://github.com/mimblewimble/grin/pull/3450

This PR reworks the wallet usage of `db.iter()` to reflect these changes.

This is just to get everything compiling. We should revisit this as the interface is a little awkward right now.