### PR TITLE
default to smallest strategy for paying invoices

### DIFF
--- a/src/bin/grin-wallet.yml
+++ b/src/bin/grin-wallet.yml
@@ -228,7 +228,7 @@ subcommands:
             possible_values:
               - all
               - smallest
-            default_value: all
+            default_value: smallest
             takes_value: true
         - estimate_selection_strategies:
             help: Estimates all possible Coin/Output selection strategies.


### PR DESCRIPTION
We use the `smallest` coin selection strategy by default when sending funds.
But we were defaulting to `all` when paying an invoice.

This PR standardizes both payments to use `smallest` consistently.

