### PR TITLE
fix yet another instance of fee fields at height 0

### DIFF
--- a/libwallet/src/api_impl/owner.rs
+++ b/libwallet/src/api_impl/owner.rs
@@ -907,7 +907,7 @@ where
 		Some(tx) => {
 			let mut slate = Slate::blank(2, false);
 			slate.tx = Some(tx.clone());
-			slate.fee_fields = tx.aggregate_fee_fields(0).unwrap();
+			slate.fee_fields = tx.aggregate_fee_fields(2 * YEAR_HEIGHT).unwrap(); // apply fee mask past HF4
 			slate.id = id.clone();
 			slate.offset = tx.offset;
 			slate.state = SlateState::Standard3;


### PR DESCRIPTION
The former aggregate_fee_fields(0) call would fail on huge fees.
The fixed one will always apply the fee mask.
It can still fail on a tx with multiple kernels whose fees add up to a huge one.
Merging this is not that urgent. Merge whenever convenient.