### PR TITLE
build 5.0.0-beta.2

### DIFF
--- a/.ci/windows-release.yml
+++ b/.ci/windows-release.yml
@@ -1,11 +1,11 @@
 steps:
-  - script: 'cargo test --all'
+  - script: 'refreshenv && cargo test --all'
     displayName: Cargo Test All
     condition:  and(succeeded(), contains(variables['Build.SourceBranch'], 'refs/tags/'), eq(variables['CI_JOB'], 'release' ))
   - script: 'cargo clean'
     displayName: Cargo Clean
     condition:  and(succeeded(), contains(variables['Build.SourceBranch'], 'refs/tags/'), eq(variables['CI_JOB'], 'release' ))
-  - script: 'cargo build --release'
+  - script: 'refreshenv && cargo build --release'
     displayName: Build Release
     condition:  and(succeeded(), contains(variables['Build.SourceBranch'], 'refs/tags/'), eq(variables['CI_JOB'], 'release' ))
   - script: |

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1170,8 +1170,8 @@ checksum = "9b919933a397b79c37e33b77bb2aa3dc8eb6e165ad809e58ff75bc7db2e34574"
 
 [[package]]
 name = "grin_api"
-version = "4.2.0-alpha.1"
-source = "git+https://github.com/mimblewimble/grin#48efb693e2e5cdf60449b7f009214491d5bf3646"
+version = "5.0.0-beta.2"
+source = "git+https://github.com/mimblewimble/grin?tag=v5.0.0-beta.2#f48a23655ded65285ab412ad22b8f6a7a0075e56"
 dependencies = [
  "bytes",
  "easy-jsonrpc-mw",
@@ -1203,8 +1203,8 @@ dependencies = [
 
 [[package]]
 name = "grin_chain"
-version = "4.2.0-alpha.1"
-source = "git+https://github.com/mimblewimble/grin#48efb693e2e5cdf60449b7f009214491d5bf3646"
+version = "5.0.0-beta.2"
+source = "git+https://github.com/mimblewimble/grin?tag=v5.0.0-beta.2#f48a23655ded65285ab412ad22b8f6a7a0075e56"
 dependencies = [
  "bit-vec",
  "bitflags 1.2.1",
@@ -1227,8 +1227,8 @@ dependencies = [
 
 [[package]]
 name = "grin_core"
-version = "4.2.0-alpha.1"
-source = "git+https://github.com/mimblewimble/grin#48efb693e2e5cdf60449b7f009214491d5bf3646"
+version = "5.0.0-beta.2"
+source = "git+https://github.com/mimblewimble/grin?tag=v5.0.0-beta.2#f48a23655ded65285ab412ad22b8f6a7a0075e56"
 dependencies = [
  "blake2-rfc",
  "byteorder",
@@ -1254,8 +1254,8 @@ dependencies = [
 
 [[package]]
 name = "grin_keychain"
-version = "4.2.0-alpha.1"
-source = "git+https://github.com/mimblewimble/grin#48efb693e2e5cdf60449b7f009214491d5bf3646"
+version = "5.0.0-beta.2"
+source = "git+https://github.com/mimblewimble/grin?tag=v5.0.0-beta.2#f48a23655ded65285ab412ad22b8f6a7a0075e56"
 dependencies = [
  "blake2-rfc",
  "byteorder",
@@ -1276,8 +1276,8 @@ dependencies = [
 
 [[package]]
 name = "grin_p2p"
-version = "4.2.0-alpha.1"
-source = "git+https://github.com/mimblewimble/grin#48efb693e2e5cdf60449b7f009214491d5bf3646"
+version = "5.0.0-beta.2"
+source = "git+https://github.com/mimblewimble/grin?tag=v5.0.0-beta.2#f48a23655ded65285ab412ad22b8f6a7a0075e56"
 dependencies = [
  "bitflags 1.2.1",
  "bytes",
@@ -1298,8 +1298,8 @@ dependencies = [
 
 [[package]]
 name = "grin_pool"
-version = "4.2.0-alpha.1"
-source = "git+https://github.com/mimblewimble/grin#48efb693e2e5cdf60449b7f009214491d5bf3646"
+version = "5.0.0-beta.2"
+source = "git+https://github.com/mimblewimble/grin?tag=v5.0.0-beta.2#f48a23655ded65285ab412ad22b8f6a7a0075e56"
 dependencies = [
  "blake2-rfc",
  "chrono",
@@ -1332,8 +1332,8 @@ dependencies = [
 
 [[package]]
 name = "grin_store"
-version = "4.2.0-alpha.1"
-source = "git+https://github.com/mimblewimble/grin#48efb693e2e5cdf60449b7f009214491d5bf3646"
+version = "5.0.0-beta.2"
+source = "git+https://github.com/mimblewimble/grin?tag=v5.0.0-beta.2#f48a23655ded65285ab412ad22b8f6a7a0075e56"
 dependencies = [
  "byteorder",
  "croaring-mw",
@@ -1352,8 +1352,8 @@ dependencies = [
 
 [[package]]
 name = "grin_util"
-version = "4.2.0-alpha.1"
-source = "git+https://github.com/mimblewimble/grin#48efb693e2e5cdf60449b7f009214491d5bf3646"
+version = "5.0.0-beta.2"
+source = "git+https://github.com/mimblewimble/grin?tag=v5.0.0-beta.2#f48a23655ded65285ab412ad22b8f6a7a0075e56"
 dependencies = [
  "backtrace",
  "base64 0.12.3",
@@ -1373,7 +1373,7 @@ dependencies = [
 
 [[package]]
 name = "grin_wallet"
-version = "4.1.0-alpha.1"
+version = "5.0.0-beta.2"
 dependencies = [
  "built",
  "clap",
@@ -1401,7 +1401,7 @@ dependencies = [
 
 [[package]]
 name = "grin_wallet_api"
-version = "4.1.0-alpha.1"
+version = "5.0.0-beta.2"
 dependencies = [
  "base64 0.12.3",
  "chrono",
@@ -1425,7 +1425,7 @@ dependencies = [
 
 [[package]]
 name = "grin_wallet_config"
-version = "4.1.0-alpha.1"
+version = "5.0.0-beta.2"
 dependencies = [
  "dirs 2.0.2",
  "grin_wallet_util",
@@ -1438,7 +1438,7 @@ dependencies = [
 
 [[package]]
 name = "grin_wallet_controller"
-version = "4.1.0-alpha.1"
+version = "5.0.0-beta.2"
 dependencies = [
  "chrono",
  "easy-jsonrpc-mw",
@@ -1468,7 +1468,7 @@ dependencies = [
 
 [[package]]
 name = "grin_wallet_impls"
-version = "4.1.0-alpha.1"
+version = "5.0.0-beta.2"
 dependencies = [
  "blake2-rfc",
  "byteorder",
@@ -1503,7 +1503,7 @@ dependencies = [
 
 [[package]]
 name = "grin_wallet_libwallet"
-version = "4.1.0-alpha.1"
+version = "5.0.0-beta.2"
 dependencies = [
  "age",
  "base64 0.9.3",
@@ -1535,7 +1535,7 @@ dependencies = [
 
 [[package]]
 name = "grin_wallet_util"
-version = "4.1.0-alpha.1"
+version = "5.0.0-beta.2"
 dependencies = [
  "data-encoding",
  "ed25519-dalek",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "grin_wallet"
-version = "4.1.0-alpha.1"
+version = "5.0.0-beta.2"
 authors = ["Grin Developers <mimblewimble@lists.launchpad.net>"]
 description = "Simple, private and scalable cryptocurrency implementation based on the MimbleWimble chain format."
 license = "Apache-2.0"
@@ -31,13 +31,13 @@ semver = "0.10"
 rustyline = "6"
 lazy_static = "1"
 
-grin_wallet_api = { path = "./api", version = "4.1.0-alpha.1" }
-grin_wallet_impls = { path = "./impls", version = "4.1.0-alpha.1" }
-grin_wallet_libwallet = { path = "./libwallet", version = "4.1.0-alpha.1" }
-grin_wallet_controller = { path = "./controller", version = "4.1.0-alpha.1" }
-grin_wallet_config = { path = "./config", version = "4.1.0-alpha.1" }
+grin_wallet_api = { path = "./api", version = "5.0.0-beta.2" }
+grin_wallet_impls = { path = "./impls", version = "5.0.0-beta.2" }
+grin_wallet_libwallet = { path = "./libwallet", version = "5.0.0-beta.2" }
+grin_wallet_controller = { path = "./controller", version = "5.0.0-beta.2" }
+grin_wallet_config = { path = "./config", version = "5.0.0-beta.2" }
 
-grin_wallet_util = { path = "./util", version = "4.1.0-alpha.1" }
+grin_wallet_util = { path = "./util", version = "5.0.0-beta.2" }
 
 [build-dependencies]
 built = { version = "0.4", features = ["git2"]}

--- a/api/Cargo.toml
+++ b/api/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "grin_wallet_api"
-version = "4.1.0-alpha.1"
+version = "5.0.0-beta.2"
 authors = ["Grin Developers <mimblewimble@lists.launchpad.net>"]
 description = "Grin Wallet API"
 license = "Apache-2.0"
@@ -24,10 +24,10 @@ ring = "0.16"
 base64 = "0.12"
 ed25519-dalek = "1.0.0-pre.4"
 
-grin_wallet_libwallet = { path = "../libwallet", version = "4.1.0-alpha.1" }
-grin_wallet_config = { path = "../config", version = "4.1.0-alpha.1" }
-grin_wallet_impls = { path = "../impls", version = "4.1.0-alpha.1" }
-grin_wallet_util = { path = "../util", version = "4.1.0-alpha.1" }
+grin_wallet_libwallet = { path = "../libwallet", version = "5.0.0-beta.2" }
+grin_wallet_config = { path = "../config", version = "5.0.0-beta.2" }
+grin_wallet_impls = { path = "../impls", version = "5.0.0-beta.2" }
+grin_wallet_util = { path = "../util", version = "5.0.0-beta.2" }
 
 [dev-dependencies]
 serde_json = "1"

--- a/config/Cargo.toml
+++ b/config/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "grin_wallet_config"
-version = "4.1.0-alpha.1"
+version = "5.0.0-beta.2"
 authors = ["Grin Developers <mimblewimble@lists.launchpad.net>"]
 description = "Configuration for grin wallet , a simple, private and scalable cryptocurrency implementation based on the MimbleWimble chain format."
 license = "Apache-2.0"
@@ -16,7 +16,7 @@ serde_derive = "1"
 toml = "0.5"
 dirs = "2.0"
 
-grin_wallet_util = { path = "../util", version = "4.1.0-alpha.1" }
+grin_wallet_util = { path = "../util", version = "5.0.0-beta.2" }
 
 [dev-dependencies]
 pretty_assertions = "0.6"

--- a/controller/Cargo.toml
+++ b/controller/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "grin_wallet_controller"
-version = "4.1.0-alpha.1"
+version = "5.0.0-beta.2"
 authors = ["Grin Developers <mimblewimble@lists.launchpad.net>"]
 description = "Controllers for grin wallet instantiation"
 license = "Apache-2.0"
@@ -30,12 +30,12 @@ chrono = { version = "0.4.11", features = ["serde"] }
 easy-jsonrpc-mw = "0.5.4"
 lazy_static = "1"
 
-grin_wallet_util = { path = "../util", version = "4.1.0-alpha.1" }
+grin_wallet_util = { path = "../util", version = "5.0.0-beta.2" }
 
-grin_wallet_api = { path = "../api", version = "4.1.0-alpha.1" }
-grin_wallet_impls = { path = "../impls", version = "4.1.0-alpha.1" }
-grin_wallet_libwallet = { path = "../libwallet", version = "4.1.0-alpha.1" }
-grin_wallet_config = { path = "../config", version = "4.1.0-alpha.1" }
+grin_wallet_api = { path = "../api", version = "5.0.0-beta.2" }
+grin_wallet_impls = { path = "../impls", version = "5.0.0-beta.2" }
+grin_wallet_libwallet = { path = "../libwallet", version = "5.0.0-beta.2" }
+grin_wallet_config = { path = "../config", version = "5.0.0-beta.2" }
 
 [dev-dependencies]
 ed25519-dalek = "1.0.0-pre.4"

--- a/impls/Cargo.toml
+++ b/impls/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "grin_wallet_impls"
-version = "4.1.0-alpha.1"
+version = "5.0.0-beta.2"
 authors = ["Grin Developers <mimblewimble@lists.launchpad.net>"]
 description = "Concrete types derived from libwallet traits"
 license = "Apache-2.0"
@@ -41,6 +41,6 @@ regex = "1.3"
 timer = "0.2"
 sysinfo = "0.14"
 
-grin_wallet_util = { path = "../util", version = "4.1.0-alpha.1" }
-grin_wallet_config = { path = "../config", version = "4.1.0-alpha.1" }
-grin_wallet_libwallet = { path = "../libwallet", version = "4.1.0-alpha.1" }
+grin_wallet_util = { path = "../util", version = "5.0.0-beta.2" }
+grin_wallet_config = { path = "../config", version = "5.0.0-beta.2" }
+grin_wallet_libwallet = { path = "../libwallet", version = "5.0.0-beta.2" }

--- a/libwallet/Cargo.toml
+++ b/libwallet/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "grin_wallet_libwallet"
-version = "4.1.0-alpha.1"
+version = "5.0.0-beta.2"
 authors = ["Grin Developers <mimblewimble@lists.launchpad.net>"]
 description = "Simple, private and scalable cryptocurrency implementation based on the MimbleWimble chain format."
 license = "Apache-2.0"
@@ -36,6 +36,6 @@ secrecy = "0.6"
 bech32 = "0.7"
 byteorder = "1.3"
 
-grin_wallet_util = { path = "../util", version = "4.1.0-alpha.1" }
-grin_wallet_config = { path = "../config", version = "4.1.0-alpha.1" }
+grin_wallet_util = { path = "../util", version = "5.0.0-beta.2" }
+grin_wallet_config = { path = "../config", version = "5.0.0-beta.2" }
 

--- a/util/Cargo.toml
+++ b/util/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "grin_wallet_util"
-version = "4.1.0-alpha.1"
+version = "5.0.0-beta.2"
 authors = ["Grin Developers <mimblewimble@lists.launchpad.net>"]
 description = "Util, for generic utilities and to re-export grin crates"
 license = "Apache-2.0"
@@ -18,29 +18,29 @@ data-encoding = "2"
 sha3 = "0.8"
 
 # For Release
-#grin_core = "4.0.0"
-#grin_keychain = "4.0.0"
-#grin_chain = "4.0.0"
-#grin_util = "4.0.0"
-#grin_api = "4.0.0"
-#grin_store = "4.0.0"
+#grin_core = "5.0.0"
+#grin_keychain = "5.0.0"
+#grin_chain = "5.0.0"
+#grin_util = "5.0.0"
+#grin_api = "5.0.0"
+#grin_store = "5.0.0"
 
 # For beta release
 
-# grin_core = { git = "https://github.com/mimblewimble/grin", tag = "v4.0.0-rc.1"}
-# grin_keychain = { git = "https://github.com/mimblewimble/grin", tag = "v4.0.0-rc.1" }
-# grin_chain = { git = "https://github.com/mimblewimble/grin", tag = "v4.0.0-rc.1" }
-# grin_util = { git = "https://github.com/mimblewimble/grin", tag = "v4.0.0-rc.1" }
-# grin_api = { git = "https://github.com/mimblewimble/grin", tag = "v4.0.0-rc.1" }
-# grin_store = { git = "https://github.com/mimblewimble/grin", tag = "v4.0.0-rc.1" }
+grin_core = { git = "https://github.com/mimblewimble/grin", tag = "v5.0.0-beta.2"}
+grin_keychain = { git = "https://github.com/mimblewimble/grin", tag = "v5.0.0-beta.2" }
+grin_chain = { git = "https://github.com/mimblewimble/grin", tag = "v5.0.0-beta.2" }
+grin_util = { git = "https://github.com/mimblewimble/grin", tag = "v5.0.0-beta.2" }
+grin_api = { git = "https://github.com/mimblewimble/grin", tag = "v5.0.0-beta.2" }
+grin_store = { git = "https://github.com/mimblewimble/grin", tag = "v5.0.0-beta.2" }
 
 # For bleeding edge
-grin_core = { git = "https://github.com/mimblewimble/grin", branch = "master" }
-grin_keychain = { git = "https://github.com/mimblewimble/grin", branch = "master" }
-grin_chain = { git = "https://github.com/mimblewimble/grin", branch = "master" }
-grin_util = { git = "https://github.com/mimblewimble/grin", branch = "master" }
-grin_api = { git = "https://github.com/mimblewimble/grin", branch = "master" }
-grin_store = { git = "https://github.com/mimblewimble/grin", branch = "master" }
+# grin_core = { git = "https://github.com/mimblewimble/grin", branch = "master" }
+# grin_keychain = { git = "https://github.com/mimblewimble/grin", branch = "master" }
+# grin_chain = { git = "https://github.com/mimblewimble/grin", branch = "master" }
+# grin_util = { git = "https://github.com/mimblewimble/grin", branch = "master" }
+# grin_api = { git = "https://github.com/mimblewimble/grin", branch = "master" }
+# grin_store = { git = "https://github.com/mimblewimble/grin", branch = "master" }
 
 # For local testing
 # grin_core = { path = "../../grin/core"}


### PR DESCRIPTION
Build `5.0.0-beta.2` ready for tagging.

* build `5.0.0-beta.2`
* use `5.0.0-beta.2` tag for grin crates
* fix wallet release script for windows on CI (`refreshenv`)

Replaces #535 

