### PR TITLE
[5.0.x] Fix panic when calling certain API endpoints

### DIFF
--- a/impls/src/client_utils/client.rs
+++ b/impls/src/client_utils/client.rs
@@ -340,6 +340,9 @@ impl Client {
 	}
 
 	pub fn send_request(&self, req: Request<Body>) -> Result<String, Error> {
+		// This client is currently used both outside and inside of a tokio runtime
+		// context. In the latter case we are not allowed to do a blocking call to
+		// our global runtime, which unfortunately means we have to spawn a new thread
 		if Handle::try_current().is_ok() {
 			let rt = RUNTIME.clone();
 			let client = self.clone();


### PR DESCRIPTION
The HTTP client is currently used both outside and inside of a tokio runtime context. In the latter case we are not allowed to do a blocking call to our global runtime, which unfortunately means we have to spawn a new thread.

At the moment we are mixing asynchronous and synchronous contexts all over the place, which is not great. This means that we are blocking inside API calls, reducing the amount of concurrent request we could serve. In practice, this probably is not noticeable since the number of requests to a wallet API is usually not that huge. Additionally a lot of wallet operations require a write lock on the db, which means requests have to be handled in-part sequentially anyway.

Ideally, we'd move to fully asynchronous, but this would require a relatively large refactor of the wallet. Another thing we could look into is if we can wrap each api call in a [`spawn_blocking`](https://docs.rs/tokio/0.2.24/tokio/runtime/struct.Handle.html#method.spawn_blocking), although i suspect that is not really possible since we are using Hyper.

Thanks to @bladedoyle for reporting the issue.