### PR TITLE
Changed pub_nonce_sum and msg_to_sign to be public functions

### DIFF
--- a/libwallet/src/slate.rs
+++ b/libwallet/src/slate.rs
@@ -379,7 +379,7 @@ impl Slate {
 	}
 
 	// This is the msg that we will sign as part of the tx kernel.
-	fn msg_to_sign(&self) -> Result<secp::Message, Error> {
+	pub fn msg_to_sign(&self) -> Result<secp::Message, Error> {
 		let msg = self.kernel_features()?.kernel_sig_msg()?;
 		Ok(msg)
 	}

--- a/libwallet/src/slate.rs
+++ b/libwallet/src/slate.rs
@@ -432,7 +432,7 @@ impl Slate {
 	}
 
 	/// Return the sum of public nonces
-	fn pub_nonce_sum(&self, secp: &secp::Secp256k1) -> Result<PublicKey, Error> {
+	pub fn pub_nonce_sum(&self, secp: &secp::Secp256k1) -> Result<PublicKey, Error> {
 		let pub_nonces: Vec<&PublicKey> = self
 			.participant_data
 			.iter()


### PR DESCRIPTION
Just like `pub_blind_sum(&self, secp: &secp::Secp256k1)` is a public function `pub_nonce_sum(&self, secp: &secp::Secp256k1)` and `msg_to_sign(&self)` should be too, as wallets that generate signatures outside of the slate context (not by using `fill_round_2`) have to have access to those values.

For instance in cases where signing requires a different approach than what is implemented in `fill_round_2` such as where a secret key and nonce for a coin is split between two parties rather than one.