### PR TITLE
Allowing the creation of height locked Slates Fixes #564

### DIFF
--- a/libwallet/src/slate.rs
+++ b/libwallet/src/slate.rs
@@ -258,7 +258,7 @@ impl Slate {
 	/// Create a new slate with custom kernel_feature and lock height
 	/// If a lock_height is set kernel_features will have to be either HeightLocked (2) or NoRecentDuplicate (3)
 	/// otherwise the value passed as lock_height will be ignored and a plain kernel will be created
-	/// Invalid arguments for kernel_features (>3) will be set to 0 (Plain)
+	/// Invalid arguments for kernel_features (>3) are not allowed and will make the function panic
 	pub fn blank_with_kernel_features(
 		num_participants: u8,
 		is_invoice: bool,

--- a/libwallet/src/slate.rs
+++ b/libwallet/src/slate.rs
@@ -273,11 +273,10 @@ impl Slate {
 			true => SlateState::Invoice1,
 			false => SlateState::Standard1,
 		};
-		let kernel_features = if kernel_feat_param > 3 {
-			0
-		} else {
-			kernel_feat_param
-		};
+		if kernel_feat_param > 3 {
+			panic!("Invalid value passed as kernel_feat_param to blank_with_kernel_features");
+		}
+		let kernel_features = kernel_feat_param;
 		let is_height_locked =
 			lock_height_param.is_some() && (kernel_features == 2 || kernel_features == 3);
 		let kernel_feat_args = if is_height_locked {


### PR DESCRIPTION
Created new function `blank_with_kernel_features` which takes (compared to the regular `blank(num_participants: u8, is_invoice: bool))` the additional parameters `kernel_feat_param: u8,` and `lock_height_param: Option<u64>` such that one can create a slate with a height locked kernel.

This fixes the issue https://github.com/mimblewimble/grin-wallet/issues/564

I have adjusted `blank(num_participants: u8, is_invoice: bool)` to use this new function to avoid code duplication.