### PR TITLE
[5.0.x] bump version to 5.0.1

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1170,9 +1170,8 @@ checksum = "9b919933a397b79c37e33b77bb2aa3dc8eb6e165ad809e58ff75bc7db2e34574"
 
 [[package]]
 name = "grin_api"
-version = "5.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e0e0e4274dc2d3928a1ff59591b01fcf82d547e9b1ffa09d922bb15f856dd4c3"
+version = "5.0.1"
+source = "git+https://github.com/mimblewimble/grin?tag=v5.0.1#298accb6f382ab9e96c73ea3fae70ab88d2372a9"
 dependencies = [
  "bytes",
  "easy-jsonrpc-mw",
@@ -1204,9 +1203,8 @@ dependencies = [
 
 [[package]]
 name = "grin_chain"
-version = "5.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f2b23b039a03720b6a879be3cb8be5644949dfe3a871cbb0122d3ea42241cc4f"
+version = "5.0.1"
+source = "git+https://github.com/mimblewimble/grin?tag=v5.0.1#298accb6f382ab9e96c73ea3fae70ab88d2372a9"
 dependencies = [
  "bit-vec",
  "bitflags 1.2.1",
@@ -1229,9 +1227,8 @@ dependencies = [
 
 [[package]]
 name = "grin_core"
-version = "5.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c553a6842c56646eb0f7984b707771cb3bc326c664ebe36b6f2c8f30d5f0d982"
+version = "5.0.1"
+source = "git+https://github.com/mimblewimble/grin?tag=v5.0.1#298accb6f382ab9e96c73ea3fae70ab88d2372a9"
 dependencies = [
  "blake2-rfc",
  "byteorder",
@@ -1257,9 +1254,8 @@ dependencies = [
 
 [[package]]
 name = "grin_keychain"
-version = "5.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bef5125f71800a4ea26ce51ea32c4a6bf7f97735f3e8d0b13ac2aa30e49d1235"
+version = "5.0.1"
+source = "git+https://github.com/mimblewimble/grin?tag=v5.0.1#298accb6f382ab9e96c73ea3fae70ab88d2372a9"
 dependencies = [
  "blake2-rfc",
  "byteorder",
@@ -1280,9 +1276,8 @@ dependencies = [
 
 [[package]]
 name = "grin_p2p"
-version = "5.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "852e843888e0e3f5827ad84ad4264fe07a20d9db4bdb9b575a0e3ececb721d3c"
+version = "5.0.1"
+source = "git+https://github.com/mimblewimble/grin?tag=v5.0.1#298accb6f382ab9e96c73ea3fae70ab88d2372a9"
 dependencies = [
  "bitflags 1.2.1",
  "bytes",
@@ -1303,9 +1298,8 @@ dependencies = [
 
 [[package]]
 name = "grin_pool"
-version = "5.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1cadb0f360c96216e5ec5b2e42ca82b849bfd8d3cd72b3e4850ab59a06d1d44a"
+version = "5.0.1"
+source = "git+https://github.com/mimblewimble/grin?tag=v5.0.1#298accb6f382ab9e96c73ea3fae70ab88d2372a9"
 dependencies = [
  "blake2-rfc",
  "chrono",
@@ -1338,9 +1332,8 @@ dependencies = [
 
 [[package]]
 name = "grin_store"
-version = "5.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "765ceb4e5ab112889934115bc40e48b7b58ae8d0e082e9b67032358d606abbf2"
+version = "5.0.1"
+source = "git+https://github.com/mimblewimble/grin?tag=v5.0.1#298accb6f382ab9e96c73ea3fae70ab88d2372a9"
 dependencies = [
  "byteorder",
  "croaring-mw",
@@ -1359,9 +1352,8 @@ dependencies = [
 
 [[package]]
 name = "grin_util"
-version = "5.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "de5cc3883b3e3dda4dd154c95d37e7679acedc9238ae26eff1b1e9bd97c00aff"
+version = "5.0.1"
+source = "git+https://github.com/mimblewimble/grin?tag=v5.0.1#298accb6f382ab9e96c73ea3fae70ab88d2372a9"
 dependencies = [
  "backtrace",
  "base64 0.12.3",
@@ -1381,7 +1373,7 @@ dependencies = [
 
 [[package]]
 name = "grin_wallet"
-version = "5.0.0"
+version = "5.0.1"
 dependencies = [
  "built",
  "clap",
@@ -1409,7 +1401,7 @@ dependencies = [
 
 [[package]]
 name = "grin_wallet_api"
-version = "5.0.0"
+version = "5.0.1"
 dependencies = [
  "base64 0.12.3",
  "chrono",
@@ -1433,7 +1425,7 @@ dependencies = [
 
 [[package]]
 name = "grin_wallet_config"
-version = "5.0.0"
+version = "5.0.1"
 dependencies = [
  "dirs 2.0.2",
  "grin_wallet_util",
@@ -1446,7 +1438,7 @@ dependencies = [
 
 [[package]]
 name = "grin_wallet_controller"
-version = "5.0.0"
+version = "5.0.1"
 dependencies = [
  "chrono",
  "easy-jsonrpc-mw",
@@ -1476,7 +1468,7 @@ dependencies = [
 
 [[package]]
 name = "grin_wallet_impls"
-version = "5.0.0"
+version = "5.0.1"
 dependencies = [
  "blake2-rfc",
  "byteorder",
@@ -1511,7 +1503,7 @@ dependencies = [
 
 [[package]]
 name = "grin_wallet_libwallet"
-version = "5.0.0"
+version = "5.0.1"
 dependencies = [
  "age",
  "base64 0.9.3",
@@ -1543,7 +1535,7 @@ dependencies = [
 
 [[package]]
 name = "grin_wallet_util"
-version = "5.0.0"
+version = "5.0.1"
 dependencies = [
  "data-encoding",
  "ed25519-dalek",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1170,8 +1170,9 @@ checksum = "9b919933a397b79c37e33b77bb2aa3dc8eb6e165ad809e58ff75bc7db2e34574"
 
 [[package]]
 name = "grin_api"
-version = "5.0.0-rc.1"
-source = "git+https://github.com/mimblewimble/grin?tag=v5.0.0-rc.1#8302f2381aadfaa9e451ce6cfaa98728e64dffb5"
+version = "5.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e0e0e4274dc2d3928a1ff59591b01fcf82d547e9b1ffa09d922bb15f856dd4c3"
 dependencies = [
  "bytes",
  "easy-jsonrpc-mw",
@@ -1203,8 +1204,9 @@ dependencies = [
 
 [[package]]
 name = "grin_chain"
-version = "5.0.0-rc.1"
-source = "git+https://github.com/mimblewimble/grin?tag=v5.0.0-rc.1#8302f2381aadfaa9e451ce6cfaa98728e64dffb5"
+version = "5.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f2b23b039a03720b6a879be3cb8be5644949dfe3a871cbb0122d3ea42241cc4f"
 dependencies = [
  "bit-vec",
  "bitflags 1.2.1",
@@ -1227,8 +1229,9 @@ dependencies = [
 
 [[package]]
 name = "grin_core"
-version = "5.0.0-rc.1"
-source = "git+https://github.com/mimblewimble/grin?tag=v5.0.0-rc.1#8302f2381aadfaa9e451ce6cfaa98728e64dffb5"
+version = "5.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c553a6842c56646eb0f7984b707771cb3bc326c664ebe36b6f2c8f30d5f0d982"
 dependencies = [
  "blake2-rfc",
  "byteorder",
@@ -1254,8 +1257,9 @@ dependencies = [
 
 [[package]]
 name = "grin_keychain"
-version = "5.0.0-rc.1"
-source = "git+https://github.com/mimblewimble/grin?tag=v5.0.0-rc.1#8302f2381aadfaa9e451ce6cfaa98728e64dffb5"
+version = "5.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bef5125f71800a4ea26ce51ea32c4a6bf7f97735f3e8d0b13ac2aa30e49d1235"
 dependencies = [
  "blake2-rfc",
  "byteorder",
@@ -1276,8 +1280,9 @@ dependencies = [
 
 [[package]]
 name = "grin_p2p"
-version = "5.0.0-rc.1"
-source = "git+https://github.com/mimblewimble/grin?tag=v5.0.0-rc.1#8302f2381aadfaa9e451ce6cfaa98728e64dffb5"
+version = "5.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "852e843888e0e3f5827ad84ad4264fe07a20d9db4bdb9b575a0e3ececb721d3c"
 dependencies = [
  "bitflags 1.2.1",
  "bytes",
@@ -1298,8 +1303,9 @@ dependencies = [
 
 [[package]]
 name = "grin_pool"
-version = "5.0.0-rc.1"
-source = "git+https://github.com/mimblewimble/grin?tag=v5.0.0-rc.1#8302f2381aadfaa9e451ce6cfaa98728e64dffb5"
+version = "5.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1cadb0f360c96216e5ec5b2e42ca82b849bfd8d3cd72b3e4850ab59a06d1d44a"
 dependencies = [
  "blake2-rfc",
  "chrono",
@@ -1332,8 +1338,9 @@ dependencies = [
 
 [[package]]
 name = "grin_store"
-version = "5.0.0-rc.1"
-source = "git+https://github.com/mimblewimble/grin?tag=v5.0.0-rc.1#8302f2381aadfaa9e451ce6cfaa98728e64dffb5"
+version = "5.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "765ceb4e5ab112889934115bc40e48b7b58ae8d0e082e9b67032358d606abbf2"
 dependencies = [
  "byteorder",
  "croaring-mw",
@@ -1352,8 +1359,9 @@ dependencies = [
 
 [[package]]
 name = "grin_util"
-version = "5.0.0-rc.1"
-source = "git+https://github.com/mimblewimble/grin?tag=v5.0.0-rc.1#8302f2381aadfaa9e451ce6cfaa98728e64dffb5"
+version = "5.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "de5cc3883b3e3dda4dd154c95d37e7679acedc9238ae26eff1b1e9bd97c00aff"
 dependencies = [
  "backtrace",
  "base64 0.12.3",
@@ -1373,7 +1381,7 @@ dependencies = [
 
 [[package]]
 name = "grin_wallet"
-version = "5.0.0-rc.1"
+version = "5.0.0"
 dependencies = [
  "built",
  "clap",
@@ -1401,7 +1409,7 @@ dependencies = [
 
 [[package]]
 name = "grin_wallet_api"
-version = "5.0.0-rc.1"
+version = "5.0.0"
 dependencies = [
  "base64 0.12.3",
  "chrono",
@@ -1425,7 +1433,7 @@ dependencies = [
 
 [[package]]
 name = "grin_wallet_config"
-version = "5.0.0-rc.1"
+version = "5.0.0"
 dependencies = [
  "dirs 2.0.2",
  "grin_wallet_util",
@@ -1438,7 +1446,7 @@ dependencies = [
 
 [[package]]
 name = "grin_wallet_controller"
-version = "5.0.0-rc.1"
+version = "5.0.0"
 dependencies = [
  "chrono",
  "easy-jsonrpc-mw",
@@ -1468,7 +1476,7 @@ dependencies = [
 
 [[package]]
 name = "grin_wallet_impls"
-version = "5.0.0-rc.1"
+version = "5.0.0"
 dependencies = [
  "blake2-rfc",
  "byteorder",
@@ -1503,7 +1511,7 @@ dependencies = [
 
 [[package]]
 name = "grin_wallet_libwallet"
-version = "5.0.0-rc.1"
+version = "5.0.0"
 dependencies = [
  "age",
  "base64 0.9.3",
@@ -1535,7 +1543,7 @@ dependencies = [
 
 [[package]]
 name = "grin_wallet_util"
-version = "5.0.0-rc.1"
+version = "5.0.0"
 dependencies = [
  "data-encoding",
  "ed25519-dalek",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "grin_wallet"
-version = "5.0.0"
+version = "5.0.1"
 authors = ["Grin Developers <mimblewimble@lists.launchpad.net>"]
 description = "Simple, private and scalable cryptocurrency implementation based on the MimbleWimble chain format."
 license = "Apache-2.0"
@@ -31,13 +31,13 @@ semver = "0.10"
 rustyline = "6"
 lazy_static = "1"
 
-grin_wallet_api = { path = "./api", version = "5.0.0" }
-grin_wallet_impls = { path = "./impls", version = "5.0.0" }
-grin_wallet_libwallet = { path = "./libwallet", version = "5.0.0" }
-grin_wallet_controller = { path = "./controller", version = "5.0.0" }
-grin_wallet_config = { path = "./config", version = "5.0.0" }
+grin_wallet_api = { path = "./api", version = "5.0.1" }
+grin_wallet_impls = { path = "./impls", version = "5.0.1" }
+grin_wallet_libwallet = { path = "./libwallet", version = "5.0.1" }
+grin_wallet_controller = { path = "./controller", version = "5.0.1" }
+grin_wallet_config = { path = "./config", version = "5.0.1" }
 
-grin_wallet_util = { path = "./util", version = "5.0.0" }
+grin_wallet_util = { path = "./util", version = "5.0.1" }
 
 [build-dependencies]
 built = { version = "0.4", features = ["git2"]}

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "grin_wallet"
-version = "5.0.0-rc.1"
+version = "5.0.0"
 authors = ["Grin Developers <mimblewimble@lists.launchpad.net>"]
 description = "Simple, private and scalable cryptocurrency implementation based on the MimbleWimble chain format."
 license = "Apache-2.0"
@@ -31,13 +31,13 @@ semver = "0.10"
 rustyline = "6"
 lazy_static = "1"
 
-grin_wallet_api = { path = "./api", version = "5.0.0-rc.1" }
-grin_wallet_impls = { path = "./impls", version = "5.0.0-rc.1" }
-grin_wallet_libwallet = { path = "./libwallet", version = "5.0.0-rc.1" }
-grin_wallet_controller = { path = "./controller", version = "5.0.0-rc.1" }
-grin_wallet_config = { path = "./config", version = "5.0.0-rc.1" }
+grin_wallet_api = { path = "./api", version = "5.0.0" }
+grin_wallet_impls = { path = "./impls", version = "5.0.0" }
+grin_wallet_libwallet = { path = "./libwallet", version = "5.0.0" }
+grin_wallet_controller = { path = "./controller", version = "5.0.0" }
+grin_wallet_config = { path = "./config", version = "5.0.0" }
 
-grin_wallet_util = { path = "./util", version = "5.0.0-rc.1" }
+grin_wallet_util = { path = "./util", version = "5.0.0" }
 
 [build-dependencies]
 built = { version = "0.4", features = ["git2"]}

--- a/api/Cargo.toml
+++ b/api/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "grin_wallet_api"
-version = "5.0.0-rc.1"
+version = "5.0.0"
 authors = ["Grin Developers <mimblewimble@lists.launchpad.net>"]
 description = "Grin Wallet API"
 license = "Apache-2.0"
@@ -24,10 +24,10 @@ ring = "0.16"
 base64 = "0.12"
 ed25519-dalek = "1.0.0-pre.4"
 
-grin_wallet_libwallet = { path = "../libwallet", version = "5.0.0-rc.1" }
-grin_wallet_config = { path = "../config", version = "5.0.0-rc.1" }
-grin_wallet_impls = { path = "../impls", version = "5.0.0-rc.1" }
-grin_wallet_util = { path = "../util", version = "5.0.0-rc.1" }
+grin_wallet_libwallet = { path = "../libwallet", version = "5.0.0" }
+grin_wallet_config = { path = "../config", version = "5.0.0" }
+grin_wallet_impls = { path = "../impls", version = "5.0.0" }
+grin_wallet_util = { path = "../util", version = "5.0.0" }
 
 [dev-dependencies]
 serde_json = "1"

--- a/api/Cargo.toml
+++ b/api/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "grin_wallet_api"
-version = "5.0.0"
+version = "5.0.1"
 authors = ["Grin Developers <mimblewimble@lists.launchpad.net>"]
 description = "Grin Wallet API"
 license = "Apache-2.0"
@@ -24,10 +24,10 @@ ring = "0.16"
 base64 = "0.12"
 ed25519-dalek = "1.0.0-pre.4"
 
-grin_wallet_libwallet = { path = "../libwallet", version = "5.0.0" }
-grin_wallet_config = { path = "../config", version = "5.0.0" }
-grin_wallet_impls = { path = "../impls", version = "5.0.0" }
-grin_wallet_util = { path = "../util", version = "5.0.0" }
+grin_wallet_libwallet = { path = "../libwallet", version = "5.0.1" }
+grin_wallet_config = { path = "../config", version = "5.0.1" }
+grin_wallet_impls = { path = "../impls", version = "5.0.1" }
+grin_wallet_util = { path = "../util", version = "5.0.1" }
 
 [dev-dependencies]
 serde_json = "1"

--- a/config/Cargo.toml
+++ b/config/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "grin_wallet_config"
-version = "5.0.0-rc.1"
+version = "5.0.0"
 authors = ["Grin Developers <mimblewimble@lists.launchpad.net>"]
 description = "Configuration for grin wallet , a simple, private and scalable cryptocurrency implementation based on the MimbleWimble chain format."
 license = "Apache-2.0"
@@ -16,7 +16,7 @@ serde_derive = "1"
 toml = "0.5"
 dirs = "2.0"
 
-grin_wallet_util = { path = "../util", version = "5.0.0-rc.1" }
+grin_wallet_util = { path = "../util", version = "5.0.0" }
 
 [dev-dependencies]
 pretty_assertions = "0.6"

--- a/config/Cargo.toml
+++ b/config/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "grin_wallet_config"
-version = "5.0.0"
+version = "5.0.1"
 authors = ["Grin Developers <mimblewimble@lists.launchpad.net>"]
 description = "Configuration for grin wallet , a simple, private and scalable cryptocurrency implementation based on the MimbleWimble chain format."
 license = "Apache-2.0"
@@ -16,7 +16,7 @@ serde_derive = "1"
 toml = "0.5"
 dirs = "2.0"
 
-grin_wallet_util = { path = "../util", version = "5.0.0" }
+grin_wallet_util = { path = "../util", version = "5.0.1" }
 
 [dev-dependencies]
 pretty_assertions = "0.6"

--- a/controller/Cargo.toml
+++ b/controller/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "grin_wallet_controller"
-version = "5.0.0-rc.1"
+version = "5.0.0"
 authors = ["Grin Developers <mimblewimble@lists.launchpad.net>"]
 description = "Controllers for grin wallet instantiation"
 license = "Apache-2.0"
@@ -30,12 +30,12 @@ chrono = { version = "0.4.11", features = ["serde"] }
 easy-jsonrpc-mw = "0.5.4"
 lazy_static = "1"
 
-grin_wallet_util = { path = "../util", version = "5.0.0-rc.1" }
+grin_wallet_util = { path = "../util", version = "5.0.0" }
 
-grin_wallet_api = { path = "../api", version = "5.0.0-rc.1" }
-grin_wallet_impls = { path = "../impls", version = "5.0.0-rc.1" }
-grin_wallet_libwallet = { path = "../libwallet", version = "5.0.0-rc.1" }
-grin_wallet_config = { path = "../config", version = "5.0.0-rc.1" }
+grin_wallet_api = { path = "../api", version = "5.0.0" }
+grin_wallet_impls = { path = "../impls", version = "5.0.0" }
+grin_wallet_libwallet = { path = "../libwallet", version = "5.0.0" }
+grin_wallet_config = { path = "../config", version = "5.0.0" }
 
 [dev-dependencies]
 ed25519-dalek = "1.0.0-pre.4"

--- a/controller/Cargo.toml
+++ b/controller/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "grin_wallet_controller"
-version = "5.0.0"
+version = "5.0.1"
 authors = ["Grin Developers <mimblewimble@lists.launchpad.net>"]
 description = "Controllers for grin wallet instantiation"
 license = "Apache-2.0"
@@ -30,12 +30,12 @@ chrono = { version = "0.4.11", features = ["serde"] }
 easy-jsonrpc-mw = "0.5.4"
 lazy_static = "1"
 
-grin_wallet_util = { path = "../util", version = "5.0.0" }
+grin_wallet_util = { path = "../util", version = "5.0.1" }
 
-grin_wallet_api = { path = "../api", version = "5.0.0" }
-grin_wallet_impls = { path = "../impls", version = "5.0.0" }
-grin_wallet_libwallet = { path = "../libwallet", version = "5.0.0" }
-grin_wallet_config = { path = "../config", version = "5.0.0" }
+grin_wallet_api = { path = "../api", version = "5.0.1" }
+grin_wallet_impls = { path = "../impls", version = "5.0.1" }
+grin_wallet_libwallet = { path = "../libwallet", version = "5.0.1" }
+grin_wallet_config = { path = "../config", version = "5.0.1" }
 
 [dev-dependencies]
 ed25519-dalek = "1.0.0-pre.4"

--- a/impls/Cargo.toml
+++ b/impls/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "grin_wallet_impls"
-version = "5.0.0-rc.1"
+version = "5.0.0"
 authors = ["Grin Developers <mimblewimble@lists.launchpad.net>"]
 description = "Concrete types derived from libwallet traits"
 license = "Apache-2.0"
@@ -41,6 +41,6 @@ regex = "1.3"
 timer = "0.2"
 sysinfo = "0.14"
 
-grin_wallet_util = { path = "../util", version = "5.0.0-rc.1" }
-grin_wallet_config = { path = "../config", version = "5.0.0-rc.1" }
-grin_wallet_libwallet = { path = "../libwallet", version = "5.0.0-rc.1" }
+grin_wallet_util = { path = "../util", version = "5.0.0" }
+grin_wallet_config = { path = "../config", version = "5.0.0" }
+grin_wallet_libwallet = { path = "../libwallet", version = "5.0.0" }

--- a/impls/Cargo.toml
+++ b/impls/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "grin_wallet_impls"
-version = "5.0.0"
+version = "5.0.1"
 authors = ["Grin Developers <mimblewimble@lists.launchpad.net>"]
 description = "Concrete types derived from libwallet traits"
 license = "Apache-2.0"
@@ -41,6 +41,6 @@ regex = "1.3"
 timer = "0.2"
 sysinfo = "0.14"
 
-grin_wallet_util = { path = "../util", version = "5.0.0" }
-grin_wallet_config = { path = "../config", version = "5.0.0" }
-grin_wallet_libwallet = { path = "../libwallet", version = "5.0.0" }
+grin_wallet_util = { path = "../util", version = "5.0.1" }
+grin_wallet_config = { path = "../config", version = "5.0.1" }
+grin_wallet_libwallet = { path = "../libwallet", version = "5.0.1" }

--- a/libwallet/Cargo.toml
+++ b/libwallet/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "grin_wallet_libwallet"
-version = "5.0.0"
+version = "5.0.1"
 authors = ["Grin Developers <mimblewimble@lists.launchpad.net>"]
 description = "Simple, private and scalable cryptocurrency implementation based on the MimbleWimble chain format."
 license = "Apache-2.0"
@@ -36,6 +36,6 @@ secrecy = "0.6"
 bech32 = "0.7"
 byteorder = "1.3"
 
-grin_wallet_util = { path = "../util", version = "5.0.0" }
-grin_wallet_config = { path = "../config", version = "5.0.0" }
+grin_wallet_util = { path = "../util", version = "5.0.1" }
+grin_wallet_config = { path = "../config", version = "5.0.1" }
 

--- a/libwallet/Cargo.toml
+++ b/libwallet/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "grin_wallet_libwallet"
-version = "5.0.0-rc.1"
+version = "5.0.0"
 authors = ["Grin Developers <mimblewimble@lists.launchpad.net>"]
 description = "Simple, private and scalable cryptocurrency implementation based on the MimbleWimble chain format."
 license = "Apache-2.0"
@@ -36,6 +36,6 @@ secrecy = "0.6"
 bech32 = "0.7"
 byteorder = "1.3"
 
-grin_wallet_util = { path = "../util", version = "5.0.0-rc.1" }
-grin_wallet_config = { path = "../config", version = "5.0.0-rc.1" }
+grin_wallet_util = { path = "../util", version = "5.0.0" }
+grin_wallet_config = { path = "../config", version = "5.0.0" }
 

--- a/util/Cargo.toml
+++ b/util/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "grin_wallet_util"
-version = "5.0.0"
+version = "5.0.1"
 authors = ["Grin Developers <mimblewimble@lists.launchpad.net>"]
 description = "Util, for generic utilities and to re-export grin crates"
 license = "Apache-2.0"
@@ -18,20 +18,20 @@ data-encoding = "2"
 sha3 = "0.8"
 
 # For Release
-grin_core = "5.0.0"
-grin_keychain = "5.0.0"
-grin_chain = "5.0.0"
-grin_util = "5.0.0"
-grin_api = "5.0.0"
-grin_store = "5.0.0"
+grin_core = "5.0.1"
+grin_keychain = "5.0.1"
+grin_chain = "5.0.1"
+grin_util = "5.0.1"
+grin_api = "5.0.1"
+grin_store = "5.0.1"
 
 # For beta release
-# grin_core = { git = "https://github.com/mimblewimble/grin", tag = "v5.0.0"}
-# grin_keychain = { git = "https://github.com/mimblewimble/grin", tag = "v5.0.0" }
-# grin_chain = { git = "https://github.com/mimblewimble/grin", tag = "v5.0.0" }
-# grin_util = { git = "https://github.com/mimblewimble/grin", tag = "v5.0.0" }
-# grin_api = { git = "https://github.com/mimblewimble/grin", tag = "v5.0.0" }
-# grin_store = { git = "https://github.com/mimblewimble/grin", tag = "v5.0.0" }
+# grin_core = { git = "https://github.com/mimblewimble/grin", tag = "v5.0.1"}
+# grin_keychain = { git = "https://github.com/mimblewimble/grin", tag = "v5.0.1" }
+# grin_chain = { git = "https://github.com/mimblewimble/grin", tag = "v5.0.1" }
+# grin_util = { git = "https://github.com/mimblewimble/grin", tag = "v5.0.1" }
+# grin_api = { git = "https://github.com/mimblewimble/grin", tag = "v5.0.1" }
+# grin_store = { git = "https://github.com/mimblewimble/grin", tag = "v5.0.1" }
 
 # For bleeding edge
 # grin_core = { git = "https://github.com/mimblewimble/grin", branch = "master" }

--- a/util/Cargo.toml
+++ b/util/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "grin_wallet_util"
-version = "5.0.0-rc.1"
+version = "5.0.0"
 authors = ["Grin Developers <mimblewimble@lists.launchpad.net>"]
 description = "Util, for generic utilities and to re-export grin crates"
 license = "Apache-2.0"
@@ -18,21 +18,20 @@ data-encoding = "2"
 sha3 = "0.8"
 
 # For Release
-#grin_core = "5.0.0"
-#grin_keychain = "5.0.0"
-#grin_chain = "5.0.0"
-#grin_util = "5.0.0"
-#grin_api = "5.0.0"
-#grin_store = "5.0.0"
+grin_core = "5.0.0"
+grin_keychain = "5.0.0"
+grin_chain = "5.0.0"
+grin_util = "5.0.0"
+grin_api = "5.0.0"
+grin_store = "5.0.0"
 
 # For beta release
-
-grin_core = { git = "https://github.com/mimblewimble/grin", tag = "v5.0.0-rc.1"}
-grin_keychain = { git = "https://github.com/mimblewimble/grin", tag = "v5.0.0-rc.1" }
-grin_chain = { git = "https://github.com/mimblewimble/grin", tag = "v5.0.0-rc.1" }
-grin_util = { git = "https://github.com/mimblewimble/grin", tag = "v5.0.0-rc.1" }
-grin_api = { git = "https://github.com/mimblewimble/grin", tag = "v5.0.0-rc.1" }
-grin_store = { git = "https://github.com/mimblewimble/grin", tag = "v5.0.0-rc.1" }
+# grin_core = { git = "https://github.com/mimblewimble/grin", tag = "v5.0.0"}
+# grin_keychain = { git = "https://github.com/mimblewimble/grin", tag = "v5.0.0" }
+# grin_chain = { git = "https://github.com/mimblewimble/grin", tag = "v5.0.0" }
+# grin_util = { git = "https://github.com/mimblewimble/grin", tag = "v5.0.0" }
+# grin_api = { git = "https://github.com/mimblewimble/grin", tag = "v5.0.0" }
+# grin_store = { git = "https://github.com/mimblewimble/grin", tag = "v5.0.0" }
 
 # For bleeding edge
 # grin_core = { git = "https://github.com/mimblewimble/grin", branch = "master" }


### PR DESCRIPTION
~Hold off on merging this. We have a possible 5.0.1 for node.~

----

* bump version to ~`5.0.0`~ `5.0.1`
* point to published ~`5.0.0`~ `5.0.1` crates on crates.io for node deps