### PR TITLE
Clippy easy wins

### DIFF
--- a/controller/src/command.rs
+++ b/controller/src/command.rs
@@ -189,7 +189,7 @@ where
 		config.owner_api_listen_addr().as_str(),
 		g_args.api_secret.clone(),
 		g_args.tls_conf.clone(),
-		config.owner_api_include_foreign.clone(),
+		config.owner_api_include_foreign,
 		Some(tor_config.clone()),
 		test_mode,
 	);

--- a/controller/src/controller.rs
+++ b/controller/src/controller.rs
@@ -337,38 +337,17 @@ pub struct OwnerV3Helpers;
 impl OwnerV3Helpers {
 	/// Checks whether a request is to init the secure API
 	pub fn is_init_secure_api(val: &serde_json::Value) -> bool {
-		if let Some(m) = val["method"].as_str() {
-			match m {
-				"init_secure_api" => true,
-				_ => false,
-			}
-		} else {
-			false
-		}
+		matches!(val["method"].as_str(), Some("init_secure_api"))
 	}
 
 	/// Checks whether a request is to open the wallet
 	pub fn is_open_wallet(val: &serde_json::Value) -> bool {
-		if let Some(m) = val["method"].as_str() {
-			match m {
-				"open_wallet" => true,
-				_ => false,
-			}
-		} else {
-			false
-		}
+		matches!(val["method"].as_str(), Some("open_wallet"))
 	}
 
 	/// Checks whether a request is an encrypted request
 	pub fn is_encrypted_request(val: &serde_json::Value) -> bool {
-		if let Some(m) = val["method"].as_str() {
-			match m {
-				"encrypted_request_v3" => true,
-				_ => false,
-			}
-		} else {
-			false
-		}
+		matches!(val["method"].as_str(), Some("encrypted_request_v3"))
 	}
 
 	/// whether encryption is enabled

--- a/impls/src/adapters/file.rs
+++ b/impls/src/adapters/file.rs
@@ -63,10 +63,8 @@ impl SlateGetter for PathToSlate {
 		let bin_res = byte_ser::from_bytes::<VersionedBinSlate>(&data);
 		if let Err(e) = bin_res {
 			debug!("Not a valid binary slate: {} - Will try JSON", e);
-		} else {
-			if let Ok(s) = bin_res {
-				return Ok((Slate::upgrade(s.into())?, true));
-			}
+		} else if let Ok(s) = bin_res {
+			return Ok((Slate::upgrade(s.into())?, true));
 		}
 
 		// Otherwise try json

--- a/libwallet/src/api_impl/owner.rs
+++ b/libwallet/src/api_impl/owner.rs
@@ -908,7 +908,7 @@ where
 			let mut slate = Slate::blank(2, false);
 			slate.tx = Some(tx.clone());
 			slate.fee_fields = tx.aggregate_fee_fields(2 * YEAR_HEIGHT).unwrap(); // apply fee mask past HF4
-			slate.id = id.clone();
+			slate.id = id;
 			slate.offset = tx.offset;
 			slate.state = SlateState::Standard3;
 			Ok(Some(slate))

--- a/libwallet/src/slate_versions/v4_bin.rs
+++ b/libwallet/src/slate_versions/v4_bin.rs
@@ -192,7 +192,7 @@ impl<'a> Writeable for SigsWrapRef<'a> {
 			}
 			s.xs.write(writer)?;
 			s.nonce.write(writer)?;
-			if let Some(s) = s.part.clone() {
+			if let Some(s) = s.part {
 				s.write(writer)?;
 			}
 		}
@@ -295,7 +295,7 @@ impl<'a> Writeable for ComsWrapRef<'a> {
 			}
 			OutputFeatures::from(o.f).write(writer)?;
 			o.c.write(writer)?;
-			if let Some(p) = o.p.clone() {
+			if let Some(p) = o.p {
 				p.write(writer)?;
 			}
 		}

--- a/src/cmd/wallet_args.rs
+++ b/src/cmd/wallet_args.rs
@@ -951,14 +951,10 @@ where
 
 	// for backwards compatibility: If tor config doesn't exist in the file, assume
 	// the top level directory for data
-	let tor_config = match tor_config {
-		Some(tc) => tc,
-		None => {
-			let mut tc = TorConfig::default();
-			tc.send_config_dir = wallet_config.data_file_dir.clone();
-			tc
-		}
-	};
+	let tor_config = tor_config.unwrap_or_else(|| TorConfig {
+		send_config_dir: wallet_config.data_file_dir.clone(),
+		..Default::default()
+	});
 
 	// Instantiate wallet (doesn't open the wallet)
 	let wallet =


### PR DESCRIPTION
To make these easy to review, these are nice obvious wins that make the code smaller and cleaner. :)

All of the removed `clone()`s are unnecessary, usually because that type implements `Copy`.

`cargo test --all` passes locally.