### PR TITLE
Change to proper spelling of Tor

### DIFF
--- a/controller/src/controller.rs
+++ b/controller/src/controller.rs
@@ -104,7 +104,7 @@ where
 		.map_err(|e| ErrorKind::TorConfig(format!("{:?}", e).into()))?;
 	let sp_address = SlatepackAddress::try_from(onion_address.clone())?;
 	warn!(
-		"Starting TOR Hidden Service for API listener at address {}, binding to {}",
+		"Starting Tor Hidden Service for API listener at address {}, binding to {}",
 		onion_address, addr
 	);
 	tor_config::output_tor_listener_config(&tor_dir, addr, &vec![sec_key])

--- a/src/bin/grin-wallet.yml
+++ b/src/bin/grin-wallet.yml
@@ -66,7 +66,7 @@ subcommands:
             default_value: http
             takes_value: true
         - no_tor:
-            help: Don't start TOR listener when starting HTTP listener
+            help: Don't start Tor listener when starting HTTP listener
             short: n
             long: no_tor
             takes_value: false


### PR DESCRIPTION
From https://support.torproject.org/about/#why-is-it-called-tor
> Note: even though it originally came from an acronym, Tor is not spelled "TOR". Only the first letter is capitalized. In fact, we can usually spot people who haven't read any of our website (and have instead learned everything they know about Tor from news articles) by the fact that they spell it wrong.