### PR TITLE
Sync to latest grin master and fix missing verifier_cache

### DIFF
--- a/.ci/release.yml
+++ b/.ci/release.yml
@@ -2,7 +2,10 @@ steps:
   - script: 'cargo test --all'
     displayName: Cargo Test All
     condition:  and(succeeded(), contains(variables['Build.SourceBranch'], 'refs/tags/'), eq(variables['CI_JOB'], 'release' ))
-  - script: 'cargo build --release'
+  - script: |
+      cargo clean
+      ROARING_ARCH=x86-64-v2
+      cargo build --release
     displayName: Build Release
     condition:  and(succeeded(), contains(variables['Build.SourceBranch'], 'refs/tags/'), eq(variables['CI_JOB'], 'release' ))
   - script: |

--- a/.ci/test.yml
+++ b/.ci/test.yml
@@ -1,11 +1,15 @@
 steps:
   - script: |
-      refreshenv && cargo test --all
+      refreshenv
+      LIBCLANG_PATH=C:\Program Files\LLVM\lib
+      LLVM_CONFIG_PATH=C:\Program Files\LLVM\bin\llvm-config
+      ROARING_ARCH=x86-64-v2
+      cargo test --all
     displayName: Windows Cargo Test
     condition: and(eq( variables['Agent.OS'], 'Windows_NT' ), eq( variables['CI_JOB'], 'test-all' ))
-  - script: 'cargo test --all'
+  - script: 'ROARING_ARCH=x86-64-v2 cargo test --all'
     displayName: macOS Cargo Test
     condition: and(eq( variables['Agent.OS'], 'Darwin' ), eq( variables['CI_JOB'], 'test-all' ))
-  - script: '.ci/general-jobs'
+  - script: 'ROARING_ARCH=x86-64-v2 .ci/general-jobs'
     displayName: Linux Cargo Test
     condition: eq( variables['Agent.OS'], 'Linux' )

--- a/.ci/windows-release.yml
+++ b/.ci/windows-release.yml
@@ -1,11 +1,22 @@
 steps:
-  - script: 'cargo test --all'
+  - script: |
+      refreshenv
+      LIBCLANG_PATH=C:\Program Files\LLVM\lib
+      LLVM_CONFIG_PATH=C:\Program Files\LLVM\bin\llvm-config
+      ROARING_ARCH=x86-64-v2
+      cargo test --all
     displayName: Cargo Test All
     condition:  and(succeeded(), contains(variables['Build.SourceBranch'], 'refs/tags/'), eq(variables['CI_JOB'], 'release' ))
   - script: 'cargo clean'
     displayName: Cargo Clean
     condition:  and(succeeded(), contains(variables['Build.SourceBranch'], 'refs/tags/'), eq(variables['CI_JOB'], 'release' ))
-  - script: 'cargo build --release'
+  - script: |
+      cargo clean
+      refreshenv
+      LIBCLANG_PATH=C:\Program Files\LLVM\lib
+      LLVM_CONFIG_PATH=C:\Program Files\LLVM\bin\llvm-config
+      ROARING_ARCH=x86-64-v2
+      cargo build --release
     displayName: Build Release
     condition:  and(succeeded(), contains(variables['Build.SourceBranch'], 'refs/tags/'), eq(variables['CI_JOB'], 'release' ))
   - script: |

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -89,7 +89,7 @@ dependencies = [
  "curve25519-dalek",
  "hkdf",
  "hmac 0.7.1",
- "nom 5.1.2",
+ "nom",
  "radix64",
  "rand 0.7.3",
  "scrypt",
@@ -108,7 +108,7 @@ checksum = "9edc5c56a290116d446475265057ff5bc44490f681ee15cb27111ed47d4afe78"
 dependencies = [
  "base64 0.11.0",
  "cookie-factory",
- "nom 5.1.2",
+ "nom",
 ]
 
 [[package]]
@@ -269,13 +269,12 @@ checksum = "cdcf67bb7ba7797a081cd19009948ab533af7c355d5caf1d08c777582d351e9c"
 
 [[package]]
 name = "bindgen"
-version = "0.52.0"
+version = "0.56.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f1c85344eb535a31b62f0af37be84441ba9e7f0f4111eb0530f43d15e513fe57"
+checksum = "2da379dbebc0b76ef63ca68d8fc6e71c0f13e59432e0987e508c1820e6ab5239"
 dependencies = [
  "bitflags 1.2.1",
  "cexpr",
- "cfg-if 0.1.10",
  "clang-sys",
  "clap",
  "env_logger",
@@ -483,11 +482,11 @@ dependencies = [
 
 [[package]]
 name = "cexpr"
-version = "0.3.6"
+version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fce5b5fb86b0c57c20c834c1b412fd09c77c8a59b9473f86272709e78874cd1d"
+checksum = "f4aedb84272dbe89af497cf81375129abda4fc0a9e7c5d317498c15cc30c0d27"
 dependencies = [
- "nom 4.2.3",
+ "nom",
 ]
 
 [[package]]
@@ -528,9 +527,9 @@ dependencies = [
 
 [[package]]
 name = "clang-sys"
-version = "0.28.1"
+version = "1.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "81de550971c976f176130da4b2978d3b524eaa0fd9ac31f3ceb5ae1231fb4853"
+checksum = "f54d78e30b388d4815220c8dd03fea5656b6c6d32adb59e89061552a102f8da1"
 dependencies = [
  "glob",
  "libc",
@@ -600,21 +599,21 @@ dependencies = [
 ]
 
 [[package]]
-name = "croaring-mw"
-version = "0.4.5"
+name = "croaring"
+version = "0.4.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bcdee571ce4bf3e49c382de29c38bd33b9fa871e1358c7749b9dcc5dc2776221"
+checksum = "a00d14ad7d8cc067d7a5c93e8563791bfec3f7182361db955530db11d94ed63c"
 dependencies = [
  "byteorder",
- "croaring-sys-mw",
+ "croaring-sys",
  "libc",
 ]
 
 [[package]]
-name = "croaring-sys-mw"
-version = "0.4.5"
+name = "croaring-sys"
+version = "0.4.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ea52c177269fa54c526b054dac8e623721de18143ebfd2ea84ffc023d6c271ee"
+checksum = "c5d6a46501bb403a61e43bc7cd19977b4f9c54efd703949b00259cc61afb5a86"
 dependencies = [
  "bindgen",
  "cc",
@@ -919,12 +918,12 @@ dependencies = [
 
 [[package]]
 name = "env_logger"
-version = "0.7.1"
+version = "0.8.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "44533bbbb3bb3c1fa17d9f2e4e38bbbaf8396ba82193c4cb1b6445d711445d36"
+checksum = "17392a012ea30ef05a610aa97dfb49496e71c9f676b27879922ea5bdf60d9d3f"
 dependencies = [
  "atty",
- "humantime",
+ "humantime 2.1.0",
  "log",
  "regex",
  "termcolor",
@@ -1176,8 +1175,8 @@ checksum = "9b919933a397b79c37e33b77bb2aa3dc8eb6e165ad809e58ff75bc7db2e34574"
 
 [[package]]
 name = "grin_api"
-version = "5.0.0-beta.2"
-source = "git+https://github.com/mimblewimble/grin?branch=master#f48a23655ded65285ab412ad22b8f6a7a0075e56"
+version = "5.1.0-alpha.1"
+source = "git+https://github.com/mimblewimble/grin?branch=master#f6ec77a592de04fcc4a78127822932ec7e18525c"
 dependencies = [
  "bytes",
  "easy-jsonrpc-mw",
@@ -1209,14 +1208,14 @@ dependencies = [
 
 [[package]]
 name = "grin_chain"
-version = "5.0.0-beta.2"
-source = "git+https://github.com/mimblewimble/grin?branch=master#f48a23655ded65285ab412ad22b8f6a7a0075e56"
+version = "5.1.0-alpha.1"
+source = "git+https://github.com/mimblewimble/grin?branch=master#f6ec77a592de04fcc4a78127822932ec7e18525c"
 dependencies = [
  "bit-vec",
  "bitflags 1.2.1",
  "byteorder",
  "chrono",
- "croaring-mw",
+ "croaring",
  "enum_primitive",
  "failure",
  "failure_derive",
@@ -1233,14 +1232,14 @@ dependencies = [
 
 [[package]]
 name = "grin_core"
-version = "5.0.0-beta.2"
-source = "git+https://github.com/mimblewimble/grin?branch=master#f48a23655ded65285ab412ad22b8f6a7a0075e56"
+version = "5.1.0-alpha.1"
+source = "git+https://github.com/mimblewimble/grin?branch=master#f6ec77a592de04fcc4a78127822932ec7e18525c"
 dependencies = [
  "blake2-rfc",
  "byteorder",
  "bytes",
  "chrono",
- "croaring-mw",
+ "croaring",
  "enum_primitive",
  "failure",
  "failure_derive",
@@ -1260,8 +1259,8 @@ dependencies = [
 
 [[package]]
 name = "grin_keychain"
-version = "5.0.0-beta.2"
-source = "git+https://github.com/mimblewimble/grin?branch=master#f48a23655ded65285ab412ad22b8f6a7a0075e56"
+version = "5.1.0-alpha.1"
+source = "git+https://github.com/mimblewimble/grin?branch=master#f6ec77a592de04fcc4a78127822932ec7e18525c"
 dependencies = [
  "blake2-rfc",
  "byteorder",
@@ -1282,8 +1281,8 @@ dependencies = [
 
 [[package]]
 name = "grin_p2p"
-version = "5.0.0-beta.2"
-source = "git+https://github.com/mimblewimble/grin?branch=master#f48a23655ded65285ab412ad22b8f6a7a0075e56"
+version = "5.1.0-alpha.1"
+source = "git+https://github.com/mimblewimble/grin?branch=master#f6ec77a592de04fcc4a78127822932ec7e18525c"
 dependencies = [
  "bitflags 1.2.1",
  "bytes",
@@ -1304,8 +1303,8 @@ dependencies = [
 
 [[package]]
 name = "grin_pool"
-version = "5.0.0-beta.2"
-source = "git+https://github.com/mimblewimble/grin?branch=master#f48a23655ded65285ab412ad22b8f6a7a0075e56"
+version = "5.1.0-alpha.1"
+source = "git+https://github.com/mimblewimble/grin?branch=master#f6ec77a592de04fcc4a78127822932ec7e18525c"
 dependencies = [
  "blake2-rfc",
  "chrono",
@@ -1322,9 +1321,9 @@ dependencies = [
 
 [[package]]
 name = "grin_secp256k1zkp"
-version = "0.7.9"
+version = "0.7.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a4c2e7431d1999f02112c2383c9d33e7a6212947abfba92c87ab7283ba667a8b"
+checksum = "daca5852d12dbd4df8b7b760eaad791d191ea546bf80c46b033bbcc650b35a5c"
 dependencies = [
  "arrayvec 0.3.25",
  "cc",
@@ -1338,11 +1337,11 @@ dependencies = [
 
 [[package]]
 name = "grin_store"
-version = "5.0.0-beta.2"
-source = "git+https://github.com/mimblewimble/grin?branch=master#f48a23655ded65285ab412ad22b8f6a7a0075e56"
+version = "5.1.0-alpha.1"
+source = "git+https://github.com/mimblewimble/grin?branch=master#f6ec77a592de04fcc4a78127822932ec7e18525c"
 dependencies = [
  "byteorder",
- "croaring-mw",
+ "croaring",
  "failure",
  "failure_derive",
  "grin_core",
@@ -1358,8 +1357,8 @@ dependencies = [
 
 [[package]]
 name = "grin_util"
-version = "5.0.0-beta.2"
-source = "git+https://github.com/mimblewimble/grin?branch=master#f48a23655ded65285ab412ad22b8f6a7a0075e56"
+version = "5.1.0-alpha.1"
+source = "git+https://github.com/mimblewimble/grin?branch=master#f6ec77a592de04fcc4a78127822932ec7e18525c"
 dependencies = [
  "backtrace",
  "base64 0.12.3",
@@ -1671,6 +1670,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "humantime"
+version = "2.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9a3a5bfb195931eeb336b2a7b4d761daec841b97f947d34394601737a7bba5e4"
+
+[[package]]
 name = "hyper"
 version = "0.13.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1890,11 +1895,11 @@ dependencies = [
 
 [[package]]
 name = "libloading"
-version = "0.5.2"
+version = "0.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f2b111a074963af1d37a139918ac6d49ad1d0d5e47f72fd55388619691a7d753"
+checksum = "6f84d96438c15fcd6c3f244c8fce01d1e2b9c6b5623e9c711dc9286d8fc92d6a"
 dependencies = [
- "cc",
+ "cfg-if 1.0.0",
  "winapi 0.3.9",
 ]
 
@@ -1974,7 +1979,7 @@ dependencies = [
  "chrono",
  "flate2",
  "fnv",
- "humantime",
+ "humantime 1.3.0",
  "libc",
  "log",
  "log-mdc",
@@ -2174,23 +2179,13 @@ checksum = "72ef4a56884ca558e5ddb05a1d1e7e1bfd9a68d9ed024c21704cc98872dae1bb"
 
 [[package]]
 name = "nom"
-version = "4.2.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2ad2a91a8e869eeb30b9cb3119ae87773a8f4ae617f41b1eb9c154b2905f7bd6"
-dependencies = [
- "memchr",
- "version_check 0.1.5",
-]
-
-[[package]]
-name = "nom"
 version = "5.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ffb4262d26ed83a1c0a33a38fe2bb15797329c85770da05e6b828ddb782627af"
 dependencies = [
  "lexical-core",
  "memchr",
- "version_check 0.9.2",
+ "version_check",
 ]
 
 [[package]]
@@ -3427,7 +3422,7 @@ checksum = "76971977e6121664ec1b960d1313aacfa75642adc93b9d4d53b247bd4cb1747e"
 dependencies = [
  "dirs 2.0.2",
  "fnv",
- "nom 5.1.2",
+ "nom",
  "phf",
  "phf_codegen",
 ]
@@ -3754,12 +3749,6 @@ name = "vec_map"
 version = "0.8.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f1bddf1187be692e79c5ffeab891132dfb0f236ed36a43c7ed39f1165ee20191"
-
-[[package]]
-name = "version_check"
-version = "0.1.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "914b1a6776c4c929a602fafd8bc742e06365d4bcbe48c30f9cca5824f70dc9dd"
 
 [[package]]
 name = "version_check"

--- a/impls/src/test_framework/testclient.rs
+++ b/impls/src/test_framework/testclient.rs
@@ -19,7 +19,6 @@
 use crate::api::{self, LocatedTxKernel};
 use crate::chain::types::NoopAdapter;
 use crate::chain::Chain;
-use crate::core::core::verifier_cache::LruVerifierCache;
 use crate::core::core::{Transaction, TxKernel};
 use crate::core::global::{set_local_chain_type, ChainTypes};
 use crate::core::pow;
@@ -32,7 +31,7 @@ use crate::util;
 use crate::util::secp::key::SecretKey;
 use crate::util::secp::pedersen;
 use crate::util::secp::pedersen::Commitment;
-use crate::util::{Mutex, RwLock, ToHex};
+use crate::util::{Mutex, ToHex};
 use failure::ResultExt;
 use serde_json;
 use std::collections::HashMap;
@@ -95,14 +94,12 @@ where
 	pub fn new(chain_dir: &str) -> Self {
 		set_local_chain_type(ChainTypes::AutomatedTesting);
 		let genesis_block = pow::mine_genesis_block().unwrap();
-		let verifier_cache = Arc::new(RwLock::new(LruVerifierCache::new()));
 		let dir_name = format!("{}/.grin", chain_dir);
 		let c = Chain::init(
 			dir_name,
 			Arc::new(NoopAdapter {}),
 			genesis_block,
 			pow::verify_size,
-			verifier_cache,
 			false,
 		)
 		.unwrap();

--- a/libwallet/src/slate.rs
+++ b/libwallet/src/slate.rs
@@ -22,20 +22,18 @@ use crate::grin_core::core::transaction::{
 	FeeFields, Input, Inputs, KernelFeatures, NRDRelativeHeight, Output, OutputFeatures,
 	Transaction, TxKernel, Weighting,
 };
-use crate::grin_core::core::verifier_cache::LruVerifierCache;
 use crate::grin_core::libtx::{aggsig, build, proof::ProofBuild, tx_fee};
 use crate::grin_core::map_vec;
 use crate::grin_keychain::{BlindSum, BlindingFactor, Keychain, SwitchCommitmentType};
 use crate::grin_util::secp::key::{PublicKey, SecretKey};
 use crate::grin_util::secp::pedersen::Commitment;
 use crate::grin_util::secp::Signature;
-use crate::grin_util::{secp, static_secp_instance, RwLock};
+use crate::grin_util::{secp, static_secp_instance};
 use ed25519_dalek::PublicKey as DalekPublicKey;
 use ed25519_dalek::Signature as DalekSignature;
 use serde::ser::{Serialize, Serializer};
 use serde_json;
 use std::fmt;
-use std::sync::Arc;
 use uuid::Uuid;
 
 use crate::slate_versions::v4::{
@@ -677,8 +675,7 @@ impl Slate {
 
 		// confirm the overall transaction is valid (including the updated kernel)
 		// accounting for tx weight limits
-		let verifier_cache = Arc::new(RwLock::new(LruVerifierCache::new()));
-		if let Err(e) = final_tx.validate(Weighting::AsTransaction, verifier_cache, 0) {
+		if let Err(e) = final_tx.validate(Weighting::AsTransaction, 0) {
 			error!("Error with final tx validation: {}", e);
 			Err(e.into())
 		} else {


### PR DESCRIPTION
As reported by @tromp in keybase://chat/grincoin.teams.wallet_dev#general/8552 :

>it looks like grin-wallet is out of sync with grin ?!
>grin master removed verifier cache from calls like Chain::init
>but it's still passed in e.g. https://github.com/mimblewimble/grin-wallet/blob/master/impls/src/test_framework/testclient.rs#L105
>shldn't there be a grin-wallet complement to your commit https://github.com/mimblewimble/grin/commit/f6ec77a592de04fcc4a78127822932ec7e18525c  ?

Bumps `Cargo.lock` `mimblewimble/grin` git dependencies to latest commit https://github.com/mimblewimble/grin/commit/f6ec77a592de04fcc4a78127822932ec7e18525c and fixes the disappearance of the verifier cache.

`cargo test --all` passes locally.

Unblocks #479.