### PR TITLE
remove height argument from fee related functions as per fixpastfees RFC

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1180,8 +1180,8 @@ checksum = "9b919933a397b79c37e33b77bb2aa3dc8eb6e165ad809e58ff75bc7db2e34574"
 
 [[package]]
 name = "grin_api"
-version = "5.1.0-alpha.1"
-source = "git+https://github.com/mimblewimble/grin?branch=master#f6ec77a592de04fcc4a78127822932ec7e18525c"
+version = "5.2.0-alpha.1"
+source = "git+https://github.com/mimblewimble/grin?branch=master#f51b6e13761ac4c3c8e57904618ef431c14c6227"
 dependencies = [
  "bytes 0.5.6",
  "easy-jsonrpc-mw",
@@ -1213,8 +1213,8 @@ dependencies = [
 
 [[package]]
 name = "grin_chain"
-version = "5.1.0-alpha.1"
-source = "git+https://github.com/mimblewimble/grin?branch=master#f6ec77a592de04fcc4a78127822932ec7e18525c"
+version = "5.2.0-alpha.1"
+source = "git+https://github.com/mimblewimble/grin?branch=master#f51b6e13761ac4c3c8e57904618ef431c14c6227"
 dependencies = [
  "bit-vec",
  "bitflags 1.2.1",
@@ -1237,8 +1237,8 @@ dependencies = [
 
 [[package]]
 name = "grin_core"
-version = "5.1.0-alpha.1"
-source = "git+https://github.com/mimblewimble/grin?branch=master#f6ec77a592de04fcc4a78127822932ec7e18525c"
+version = "5.2.0-alpha.1"
+source = "git+https://github.com/mimblewimble/grin?branch=master#f51b6e13761ac4c3c8e57904618ef431c14c6227"
 dependencies = [
  "blake2-rfc",
  "byteorder",
@@ -1264,8 +1264,8 @@ dependencies = [
 
 [[package]]
 name = "grin_keychain"
-version = "5.1.0-alpha.1"
-source = "git+https://github.com/mimblewimble/grin?branch=master#f6ec77a592de04fcc4a78127822932ec7e18525c"
+version = "5.2.0-alpha.1"
+source = "git+https://github.com/mimblewimble/grin?branch=master#f51b6e13761ac4c3c8e57904618ef431c14c6227"
 dependencies = [
  "blake2-rfc",
  "byteorder",
@@ -1286,8 +1286,8 @@ dependencies = [
 
 [[package]]
 name = "grin_p2p"
-version = "5.1.0-alpha.1"
-source = "git+https://github.com/mimblewimble/grin?branch=master#f6ec77a592de04fcc4a78127822932ec7e18525c"
+version = "5.2.0-alpha.1"
+source = "git+https://github.com/mimblewimble/grin?branch=master#f51b6e13761ac4c3c8e57904618ef431c14c6227"
 dependencies = [
  "bitflags 1.2.1",
  "bytes 0.5.6",
@@ -1308,8 +1308,8 @@ dependencies = [
 
 [[package]]
 name = "grin_pool"
-version = "5.1.0-alpha.1"
-source = "git+https://github.com/mimblewimble/grin?branch=master#f6ec77a592de04fcc4a78127822932ec7e18525c"
+version = "5.2.0-alpha.1"
+source = "git+https://github.com/mimblewimble/grin?branch=master#f51b6e13761ac4c3c8e57904618ef431c14c6227"
 dependencies = [
  "blake2-rfc",
  "chrono",
@@ -1342,8 +1342,8 @@ dependencies = [
 
 [[package]]
 name = "grin_store"
-version = "5.1.0-alpha.1"
-source = "git+https://github.com/mimblewimble/grin?branch=master#f6ec77a592de04fcc4a78127822932ec7e18525c"
+version = "5.2.0-alpha.1"
+source = "git+https://github.com/mimblewimble/grin?branch=master#f51b6e13761ac4c3c8e57904618ef431c14c6227"
 dependencies = [
  "byteorder",
  "croaring",
@@ -1362,8 +1362,8 @@ dependencies = [
 
 [[package]]
 name = "grin_util"
-version = "5.1.0-alpha.1"
-source = "git+https://github.com/mimblewimble/grin?branch=master#f6ec77a592de04fcc4a78127822932ec7e18525c"
+version = "5.2.0-alpha.1"
+source = "git+https://github.com/mimblewimble/grin?branch=master#f51b6e13761ac4c3c8e57904618ef431c14c6227"
 dependencies = [
  "backtrace",
  "base64 0.12.3",
@@ -4160,9 +4160,9 @@ dependencies = [
 
 [[package]]
 name = "zip"
-version = "0.5.8"
+version = "0.5.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "543adf038106b64cfca4711c82c917d785e3540e04f7996554488f988ec43124"
+checksum = "9c83dc9b784d252127720168abd71ea82bf8c3d96b17dc565b5e2a02854f2b27"
 dependencies = [
  "byteorder",
  "crc32fast",

--- a/controller/src/display.rs
+++ b/controller/src/display.rs
@@ -12,7 +12,6 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-use crate::core::consensus::YEAR_HEIGHT;
 use crate::core::core::FeeFields;
 use crate::core::core::{self, amount_to_hr_string};
 use crate::core::global;
@@ -191,7 +190,7 @@ pub fn txs(
 		let amount_debited_str = core::amount_to_hr_string(t.amount_debited, true);
 		let amount_credited_str = core::amount_to_hr_string(t.amount_credited, true);
 		let fee = match t.fee {
-			Some(f) => format!("{}", core::amount_to_hr_string(f.fee(cur_height), true)),
+			Some(f) => format!("{}", core::amount_to_hr_string(f.fee(), true)),
 			None => "None".to_owned(),
 		};
 		let net_diff = if t.amount_credited >= t.amount_debited {
@@ -418,13 +417,13 @@ pub fn estimate(
 		if dark_background_color_scheme {
 			table.add_row(row![
 				bFC->strategy,
-				FR->amount_to_hr_string(fee_fields.fee(2*YEAR_HEIGHT), false), // apply fee mask past HF4
+				FR->amount_to_hr_string(fee_fields.fee(), false), // apply fee mask past HF4
 				FY->amount_to_hr_string(total, false),
 			]);
 		} else {
 			table.add_row(row![
 				bFD->strategy,
-				FR->amount_to_hr_string(fee_fields.fee(2*YEAR_HEIGHT), false), // apply fee mask past HF4
+				FR->amount_to_hr_string(fee_fields.fee(), false), // apply fee mask past HF4
 				FY->amount_to_hr_string(total, false),
 			]);
 		}
@@ -486,7 +485,7 @@ pub fn payment_proof(tx: &TxLogEntry) -> Result<(), Error> {
 		None => "None".to_owned(),
 	};
 	let fee = match tx.fee {
-		Some(f) => f.fee(2 * YEAR_HEIGHT), // apply fee mask past HF4
+		Some(f) => f.fee(), // apply fee mask past HF4
 		None => 0,
 	};
 	let amount = if tx.amount_credited >= tx.amount_debited {

--- a/controller/tests/transaction.rs
+++ b/controller/tests/transaction.rs
@@ -272,7 +272,7 @@ fn basic_transaction_api(test_dir: &'static str) -> Result<(), libwallet::Error>
 		let est = sender_api.init_send_tx(m, init_args)?;
 		assert_eq!(est.amount, 600_000_000_000);
 		// fees for 5 inputs, 2 outputs, 1 kernel (weight 50)
-		assert_eq!(est.fee_fields.fee(0), 25_000_000);
+		assert_eq!(est.fee_fields.fee(), 25_000_000);
 
 		let init_args = InitTxArgs {
 			src_acct_name: None,
@@ -287,7 +287,7 @@ fn basic_transaction_api(test_dir: &'static str) -> Result<(), libwallet::Error>
 		let est = sender_api.init_send_tx(m, init_args)?;
 		assert_eq!(est.amount, 180_000_000_000);
 		// fees for 3 inputs, 2 outputs, 1 kernel (weight 48)
-		assert_eq!(est.fee_fields.fee(0), 24_000_000);
+		assert_eq!(est.fee_fields.fee(), 24_000_000);
 
 		Ok(())
 	})?;

--- a/impls/src/test_framework/mod.rs
+++ b/impls/src/test_framework/mod.rs
@@ -156,7 +156,7 @@ where
 	K: keychain::Keychain + 'a,
 {
 	// build block fees
-	let fee_amt = txs.iter().map(|tx| tx.fee(prev.height + 1)).sum();
+	let fee_amt = txs.iter().map(|tx| tx.fee()).sum();
 	let block_fees = BlockFees {
 		fees: fee_amt,
 		key_id: None,

--- a/libwallet/src/api_impl/owner.rs
+++ b/libwallet/src/api_impl/owner.rs
@@ -16,7 +16,6 @@
 
 use uuid::Uuid;
 
-use crate::grin_core::consensus::YEAR_HEIGHT;
 use crate::grin_core::core::hash::Hashed;
 use crate::grin_core::core::Transaction;
 use crate::grin_util::secp::key::SecretKey;
@@ -404,7 +403,7 @@ where
 		tx.amount_credited - tx.amount_debited
 	} else {
 		let fee = match tx.fee {
-			Some(f) => f.fee(2 * YEAR_HEIGHT), // apply fee mask past HF4
+			Some(f) => f.fee(), // apply fee mask past HF4
 			None => 0,
 		};
 		tx.amount_debited - tx.amount_credited - fee
@@ -800,7 +799,7 @@ where
 			args.max_outputs as usize,
 			args.num_change_outputs as usize,
 			args.selection_strategy_is_use_all,
-			Some(context.fee.map(|f| f.fee(current_height)).unwrap_or(0)),
+			Some(context.fee.map(|f| f.fee()).unwrap_or(0)),
 			parent_key_id.clone(),
 			false,
 			true,
@@ -907,7 +906,7 @@ where
 		Some(tx) => {
 			let mut slate = Slate::blank(2, false);
 			slate.tx = Some(tx.clone());
-			slate.fee_fields = tx.aggregate_fee_fields(2 * YEAR_HEIGHT).unwrap(); // apply fee mask past HF4
+			slate.fee_fields = tx.aggregate_fee_fields().unwrap(); // apply fee mask past HF4
 			slate.id = id;
 			slate.offset = tx.offset;
 			slate.state = SlateState::Standard3;

--- a/libwallet/src/slate_versions/v4_bin.rs
+++ b/libwallet/src/slate_versions/v4_bin.rs
@@ -14,7 +14,6 @@
 
 //! Wraps a V4 Slate into a V4 Binary slate
 
-use crate::grin_core::consensus::YEAR_HEIGHT;
 use crate::grin_core::core::transaction::{FeeFields, OutputFeatures};
 use crate::grin_core::ser as grin_ser;
 use crate::grin_core::ser::{Readable, Reader, Writeable, Writer};
@@ -108,7 +107,7 @@ impl Writeable for SlateOptFields {
 		if self.amt > 0 {
 			status |= 0x02;
 		}
-		if self.fee.fee(2 * YEAR_HEIGHT) > 0 {
+		if self.fee.fee() > 0 {
 			// apply fee mask past HF4
 			status |= 0x04;
 		}


### PR DESCRIPTION
name: fixpastfees
about: remove dependence of fee() and fee_shift() functions on height
title: 'fix past fees'

Companion PR for

https://github.com/mimblewimble/grin/pull/3629

both implementing RFC https://github.com/mimblewimble/grin-rfcs/blob/master/text/0021-fix-prior-fees.md
to extend the 40 bit fee restriction and use of fee shifts back beyond HF4 to all history.
Technically a Hard Fork, but if we have a many month reorg introducing a > 40 bit fee prior to HF4, we have bigger problems to deal with than a chain split.

This simplifies all fee related functions as they no longer need a height argument to distinguish preHF4 from postHF4 behaviour.