### PR TITLE
Fix Windows CI `cargo test` silently passing

### DIFF
--- a/.ci/test.yml
+++ b/.ci/test.yml
@@ -1,10 +1,9 @@
 steps:
-  - script: |
-      refreshenv
-      LIBCLANG_PATH=C:\Program Files\LLVM\lib
-      LLVM_CONFIG_PATH=C:\Program Files\LLVM\bin\llvm-config
-      ROARING_ARCH=x86-64-v2
-      cargo test --all
+  - script: 'refreshenv && cargo test --all'
+    env:
+      LIBCLANG_PATH: C:\Program Files\LLVM\lib
+      LLVM_CONFIG_PATH: C:\Program Files\LLVM\bin\llvm-config
+      ROARING_ARCH: x86-64-v2
     displayName: Windows Cargo Test
     condition: and(eq( variables['Agent.OS'], 'Windows_NT' ), eq( variables['CI_JOB'], 'test-all' ))
   - script: 'ROARING_ARCH=x86-64-v2 cargo test --all'

--- a/.ci/windows-release.yml
+++ b/.ci/windows-release.yml
@@ -6,10 +6,7 @@ steps:
       ROARING_ARCH: x86-64-v2
     displayName: Cargo Test All
     condition:  and(succeeded(), contains(variables['Build.SourceBranch'], 'refs/tags/'), eq(variables['CI_JOB'], 'release' ))
-  - script: 'cargo clean'
-    displayName: Cargo Clean
-    condition:  and(succeeded(), contains(variables['Build.SourceBranch'], 'refs/tags/'), eq(variables['CI_JOB'], 'release' ))
-  - script: 'refreshenv && cargo build --release'
+  - script: 'refreshenv && cargo clean && cargo build --release'
     env:
       LIBCLANG_PATH: C:\Program Files\LLVM\lib
       LLVM_CONFIG_PATH: C:\Program Files\LLVM\bin\llvm-config

--- a/.ci/windows-release.yml
+++ b/.ci/windows-release.yml
@@ -1,22 +1,19 @@
 steps:
-  - script: |
-      refreshenv
-      LIBCLANG_PATH=C:\Program Files\LLVM\lib
-      LLVM_CONFIG_PATH=C:\Program Files\LLVM\bin\llvm-config
-      ROARING_ARCH=x86-64-v2
-      cargo test --all
+  - script: 'refreshenv && cargo test --all'
+    env:
+      LIBCLANG_PATH: C:\Program Files\LLVM\lib
+      LLVM_CONFIG_PATH: C:\Program Files\LLVM\bin\llvm-config
+      ROARING_ARCH: x86-64-v2
     displayName: Cargo Test All
     condition:  and(succeeded(), contains(variables['Build.SourceBranch'], 'refs/tags/'), eq(variables['CI_JOB'], 'release' ))
   - script: 'cargo clean'
     displayName: Cargo Clean
     condition:  and(succeeded(), contains(variables['Build.SourceBranch'], 'refs/tags/'), eq(variables['CI_JOB'], 'release' ))
-  - script: |
-      cargo clean
-      refreshenv
-      LIBCLANG_PATH=C:\Program Files\LLVM\lib
-      LLVM_CONFIG_PATH=C:\Program Files\LLVM\bin\llvm-config
-      ROARING_ARCH=x86-64-v2
-      cargo build --release
+  - script: 'refreshenv && cargo build --release'
+    env:
+      LIBCLANG_PATH: C:\Program Files\LLVM\lib
+      LLVM_CONFIG_PATH: C:\Program Files\LLVM\bin\llvm-config
+      ROARING_ARCH: x86-64-v2
     displayName: Build Release
     condition:  and(succeeded(), contains(variables['Build.SourceBranch'], 'refs/tags/'), eq(variables['CI_JOB'], 'release' ))
   - script: |


### PR DESCRIPTION
Counterpart to https://github.com/mimblewimble/grin/pull/3632, fixes Windows `cargo test` to actually test instead of silently passing.

