### PR TITLE
Update to latest master and ser&des fn arguments

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1217,7 +1217,7 @@ checksum = "9b919933a397b79c37e33b77bb2aa3dc8eb6e165ad809e58ff75bc7db2e34574"
 [[package]]
 name = "grin_api"
 version = "5.2.0-alpha.1"
-source = "git+https://github.com/mimblewimble/grin?branch=master#3f4f165e0bda7410ca0c0197da9a44b22070fd66"
+source = "git+https://github.com/mimblewimble/grin?branch=master#382e914c50c46ddd167b47f9f0c2c3d33f273ef4"
 dependencies = [
  "bytes 0.5.6",
  "easy-jsonrpc-mw",
@@ -1250,7 +1250,7 @@ dependencies = [
 [[package]]
 name = "grin_chain"
 version = "5.2.0-alpha.1"
-source = "git+https://github.com/mimblewimble/grin?branch=master#3f4f165e0bda7410ca0c0197da9a44b22070fd66"
+source = "git+https://github.com/mimblewimble/grin?branch=master#382e914c50c46ddd167b47f9f0c2c3d33f273ef4"
 dependencies = [
  "bit-vec",
  "bitflags 1.3.2",
@@ -1274,7 +1274,7 @@ dependencies = [
 [[package]]
 name = "grin_core"
 version = "5.2.0-alpha.1"
-source = "git+https://github.com/mimblewimble/grin?branch=master#3f4f165e0bda7410ca0c0197da9a44b22070fd66"
+source = "git+https://github.com/mimblewimble/grin?branch=master#382e914c50c46ddd167b47f9f0c2c3d33f273ef4"
 dependencies = [
  "blake2-rfc",
  "byteorder",
@@ -1301,7 +1301,7 @@ dependencies = [
 [[package]]
 name = "grin_keychain"
 version = "5.2.0-alpha.1"
-source = "git+https://github.com/mimblewimble/grin?branch=master#3f4f165e0bda7410ca0c0197da9a44b22070fd66"
+source = "git+https://github.com/mimblewimble/grin?branch=master#382e914c50c46ddd167b47f9f0c2c3d33f273ef4"
 dependencies = [
  "blake2-rfc",
  "byteorder",
@@ -1323,7 +1323,7 @@ dependencies = [
 [[package]]
 name = "grin_p2p"
 version = "5.2.0-alpha.1"
-source = "git+https://github.com/mimblewimble/grin?branch=master#3f4f165e0bda7410ca0c0197da9a44b22070fd66"
+source = "git+https://github.com/mimblewimble/grin?branch=master#382e914c50c46ddd167b47f9f0c2c3d33f273ef4"
 dependencies = [
  "bitflags 1.3.2",
  "bytes 0.5.6",
@@ -1345,7 +1345,7 @@ dependencies = [
 [[package]]
 name = "grin_pool"
 version = "5.2.0-alpha.1"
-source = "git+https://github.com/mimblewimble/grin?branch=master#3f4f165e0bda7410ca0c0197da9a44b22070fd66"
+source = "git+https://github.com/mimblewimble/grin?branch=master#382e914c50c46ddd167b47f9f0c2c3d33f273ef4"
 dependencies = [
  "blake2-rfc",
  "chrono",
@@ -1379,7 +1379,7 @@ dependencies = [
 [[package]]
 name = "grin_store"
 version = "5.2.0-alpha.1"
-source = "git+https://github.com/mimblewimble/grin?branch=master#3f4f165e0bda7410ca0c0197da9a44b22070fd66"
+source = "git+https://github.com/mimblewimble/grin?branch=master#382e914c50c46ddd167b47f9f0c2c3d33f273ef4"
 dependencies = [
  "byteorder",
  "croaring",
@@ -1399,7 +1399,7 @@ dependencies = [
 [[package]]
 name = "grin_util"
 version = "5.2.0-alpha.1"
-source = "git+https://github.com/mimblewimble/grin?branch=master#3f4f165e0bda7410ca0c0197da9a44b22070fd66"
+source = "git+https://github.com/mimblewimble/grin?branch=master#382e914c50c46ddd167b47f9f0c2c3d33f273ef4"
 dependencies = [
  "backtrace",
  "base64 0.12.3",

--- a/libwallet/src/slate_versions/v4_bin.rs
+++ b/libwallet/src/slate_versions/v4_bin.rs
@@ -401,8 +401,12 @@ impl<'de> serde::Deserialize<'de> for SlateV4Bin {
 				E: serde::de::Error,
 			{
 				let mut reader = std::io::Cursor::new(value.to_vec());
-				let s = grin_ser::deserialize(&mut reader, grin_ser::ProtocolVersion(4))
-					.map_err(|err| serde::de::Error::custom(err.to_string()))?;
+				let s = grin_ser::deserialize(
+					&mut reader,
+					grin_ser::ProtocolVersion(4),
+					grin_ser::DeserializationMode::default(),
+				)
+				.map_err(|err| serde::de::Error::custom(err.to_string()))?;
 				Ok(s)
 			}
 		}

--- a/libwallet/src/slatepack/types.rs
+++ b/libwallet/src/slatepack/types.rs
@@ -287,8 +287,12 @@ impl<'de> serde::Deserialize<'de> for SlatepackBin {
 				E: serde::de::Error,
 			{
 				let mut reader = std::io::Cursor::new(value.to_vec());
-				let s = ser::deserialize(&mut reader, ser::ProtocolVersion(4))
-					.map_err(|err| serde::de::Error::custom(err.to_string()))?;
+				let s = ser::deserialize(
+					&mut reader,
+					ser::ProtocolVersion(4),
+					ser::DeserializationMode::default(),
+				)
+				.map_err(|err| serde::de::Error::custom(err.to_string()))?;
 				Ok(s)
 			}
 		}
@@ -515,8 +519,12 @@ impl<'de> serde::Deserialize<'de> for SlatepackEncMetadataBin {
 				E: serde::de::Error,
 			{
 				let mut reader = std::io::Cursor::new(value.to_vec());
-				let s = ser::deserialize(&mut reader, ser::ProtocolVersion(4))
-					.map_err(|err| serde::de::Error::custom(err.to_string()))?;
+				let s = ser::deserialize(
+					&mut reader,
+					ser::ProtocolVersion(4),
+					ser::DeserializationMode::default(),
+				)
+				.map_err(|err| serde::de::Error::custom(err.to_string()))?;
 				Ok(s)
 			}
 		}


### PR DESCRIPTION
With the PR #630, I need to fetch actually the lastest master. But the test are failing due to the fact that the des&ser function are taking additional arguments with this new commit https://github.com/mimblewimble/grin/commit/63c65605bbe7a3ee4a8805c7f5aa7e7e153a15d5

