### PR TITLE
View Wallet - fn rewind_hash & scan_rewind_hash

### DIFF
--- a/api/src/owner_rpc.rs
+++ b/api/src/owner_rpc.rs
@@ -21,7 +21,7 @@ use crate::keychain::{Identifier, Keychain};
 use crate::libwallet::{
 	AcctPathMapping, ErrorKind, InitTxArgs, IssueInvoiceTxArgs, NodeClient, NodeHeightResult,
 	OutputCommitMapping, PaymentProof, Slate, SlateVersion, Slatepack, SlatepackAddress,
-	StatusMessage, TxLogEntry, VersionedSlate, WalletInfo, WalletLCProvider,
+	StatusMessage, TxLogEntry, VersionedSlate, ViewWallet, WalletInfo, WalletLCProvider,
 };
 use crate::util::logger::LoggingConfig;
 use crate::util::secp::key::{PublicKey, SecretKey};
@@ -839,6 +839,115 @@ pub trait OwnerRpc {
 		id: Option<u32>,
 		slate_id: Option<Uuid>,
 	) -> Result<Option<VersionedSlate>, ErrorKind>;
+
+	/**
+	Networked version of [Owner::get_rewind_hash](struct.Owner.html#method.get_rewind_hash).
+	```
+	# grin_wallet_api::doctest_helper_json_rpc_owner_assert_response!(
+	# r#"
+	{
+		"jsonrpc": "2.0",
+		"method": "get_rewind_hash",
+		"params": {
+			"token": "d202964900000000d302964900000000d402964900000000d502964900000000"
+		},
+		"id": 1
+	}
+	# "#
+	# ,
+	# r#"
+	{
+		"id":1,
+		"jsonrpc":"2.0",
+		"result":{
+			"Ok":"c820c52a492b7db511c752035483d0e50e8fd3ec62544f1b99638e220a4682de"
+		}
+	}
+	# "#
+	# , 0, false, false, false, false);
+	```
+	 */
+	fn get_rewind_hash(&self, token: Token) -> Result<String, ErrorKind>;
+
+	/**
+	Networked version of [Owner::view_wallet_scan](struct.Owner.html#method.view_wallet_scan).
+	```
+	# grin_wallet_api::doctest_helper_json_rpc_owner_assert_response!(
+	# r#"
+	{
+		"jsonrpc": "2.0",
+		"method": "scan_rewind_hash",
+		"params": {
+			"rewind_hash": "c820c52a492b7db511c752035483d0e50e8fd3ec62544f1b99638e220a4682de",
+			"start_height": 1
+		},
+		"id": 1
+	}
+	# "#
+	# ,
+	# r#"
+	{
+		"id":1,
+		"jsonrpc":"2.0",
+		"result":{
+			"Ok":{
+				"last_pmmr_index":8,
+				"output_result":[
+					   {
+						   "commit":"08e1da9e6dc4d6e808a718b2f110a991dd775d65ce5ae408a4e1f002a4961aa9e7",
+						   "height":1,
+						   "is_coinbase":true,
+						   "lock_height":4,
+						   "mmr_index":1,
+						   "value":60000000000
+					   },
+					   {
+						   "commit":"087df32304c5d4ae8b2af0bc31e700019d722910ef87dd4eec3197b80b207e3045",
+						   "height":2,
+						   "is_coinbase":true,
+						   "lock_height":5,
+						   "mmr_index":2,
+						   "value":60000000000
+					   },
+					   {
+						   "commit":"084219d64014223a205431acfa8f8cc3e8cb8c6d04df80b26713314becf83861c7",
+						   "height":3,
+						   "is_coinbase":true,
+						   "lock_height":6,
+						   "mmr_index":4,
+						   "value":60000000000
+					   },
+					   {
+						   "commit":"09c5efc4dab05d7d16fc90168c484c13f15a142ea4e1bf93c3fad12f5e8a402598",
+						   "height":4,
+						   "is_coinbase":true,
+						   "lock_height":7,
+						   "mmr_index":5,
+						   "value":60000000000
+					   },
+					   {
+						   "commit":"08fe198e525a5937d0c5d01fa354394d2679be6df5d42064a0f7550c332fce3d9d",
+						   "height":5,
+						   "is_coinbase":true,
+						   "lock_height":8,
+						   "mmr_index":8,
+						   "value":60000000000
+					   }
+				],
+				"rewind_hash":"c820c52a492b7db511c752035483d0e50e8fd3ec62544f1b99638e220a4682de",
+				"total_balance":300000000000
+			}
+		}
+	 }
+	# "#
+	# , 5, false, false, false, false);
+	```
+	 */
+	fn scan_rewind_hash(
+		&self,
+		rewind_hash: String,
+		start_height: Option<u64>,
+	) -> Result<ViewWallet, ErrorKind>;
 
 	/**
 	Networked version of [Owner::scan](struct.Owner.html#method.scan).
@@ -1894,6 +2003,18 @@ where
 			fluff,
 		)
 		.map_err(|e| e.kind())
+	}
+
+	fn get_rewind_hash(&self, token: Token) -> Result<String, ErrorKind> {
+		Owner::get_rewind_hash(self, (&token.keychain_mask).as_ref()).map_err(|e| e.kind())
+	}
+
+	fn scan_rewind_hash(
+		&self,
+		rewind_hash: String,
+		start_height: Option<u64>,
+	) -> Result<ViewWallet, ErrorKind> {
+		Owner::scan_rewind_hash(self, rewind_hash, start_height).map_err(|e| e.kind())
 	}
 
 	fn scan(

--- a/api/src/owner_rpc.rs
+++ b/api/src/owner_rpc.rs
@@ -870,7 +870,7 @@ pub trait OwnerRpc {
 	fn get_rewind_hash(&self, token: Token) -> Result<String, ErrorKind>;
 
 	/**
-	Networked version of [Owner::view_wallet_scan](struct.Owner.html#method.view_wallet_scan).
+	Networked version of [Owner::scan_rewind_hash](struct.Owner.html#method.scan_rewind_hash).
 	```
 	# grin_wallet_api::doctest_helper_json_rpc_owner_assert_response!(
 	# r#"

--- a/libwallet/src/api_impl/owner.rs
+++ b/libwallet/src/api_impl/owner.rs
@@ -18,8 +18,10 @@ use uuid::Uuid;
 
 use crate::grin_core::core::hash::Hashed;
 use crate::grin_core::core::Transaction;
+use crate::grin_keychain::ViewKey;
 use crate::grin_util::secp::key::SecretKey;
 use crate::grin_util::Mutex;
+use crate::grin_util::ToHex;
 use crate::util::{OnionV3Address, OnionV3AddressError};
 
 use crate::api_impl::owner_updater::StatusMessage;
@@ -30,7 +32,7 @@ use crate::types::{AcctPathMapping, NodeClient, TxLogEntry, WalletBackend, Walle
 use crate::{
 	address, wallet_lock, InitTxArgs, IssueInvoiceTxArgs, NodeHeightResult, OutputCommitMapping,
 	PaymentProof, ScannedBlockInfo, Slatepack, SlatepackAddress, Slatepacker, SlatepackerArgs,
-	TxLogEntryType, WalletInitStatus, WalletInst, WalletLCProvider,
+	TxLogEntryType, ViewWallet, WalletInitStatus, WalletInst, WalletLCProvider,
 };
 use crate::{Error, ErrorKind};
 use ed25519_dalek::PublicKey as DalekPublicKey;
@@ -73,6 +75,23 @@ where
 	K: Keychain + 'a,
 {
 	w.set_parent_key_id_by_name(label)
+}
+
+/// Hash of the wallet root public key
+pub fn get_rewind_hash<'a, L, C, K>(
+	wallet_inst: Arc<Mutex<Box<dyn WalletInst<'a, L, C, K>>>>,
+	keychain_mask: Option<&SecretKey>,
+) -> Result<String, Error>
+where
+	L: WalletLCProvider<'a, C, K>,
+	C: NodeClient + 'a,
+	K: Keychain + 'a,
+{
+	wallet_lock!(wallet_inst, w);
+	let keychain = w.keychain(keychain_mask)?;
+	let root_public_key = keychain.public_root_key();
+	let rewind_hash = ViewKey::rewind_hash(keychain.secp(), root_public_key).to_hex();
+	Ok(rewind_hash)
 }
 
 /// Retrieve the slatepack address for the current parent key at
@@ -934,6 +953,46 @@ where
 		);
 		Ok(())
 	}
+}
+
+/// Scan outputs with the rewind hash of a third-party wallet.
+/// Help to retrieve outputs information that belongs it
+pub fn scan_rewind_hash<'a, L, C, K>(
+	wallet_inst: Arc<Mutex<Box<dyn WalletInst<'a, L, C, K>>>>,
+	rewind_hash: String,
+	start_height: Option<u64>,
+	status_send_channel: &Option<Sender<StatusMessage>>,
+) -> Result<ViewWallet, Error>
+where
+	L: WalletLCProvider<'a, C, K>,
+	C: NodeClient + 'a,
+	K: Keychain + 'a,
+{
+	let is_hex = rewind_hash.chars().all(|c| c.is_ascii_hexdigit());
+	let rewind_hash = rewind_hash.to_lowercase();
+	if !(is_hex && rewind_hash.len() == 64) {
+		let msg = format!("Invalid Rewind Hash");
+		return Err(ErrorKind::RewindHash(msg).into());
+	}
+
+	let tip = {
+		wallet_lock!(wallet_inst, w);
+		w.w2n_client().get_chain_tip()?
+	};
+
+	let start_height = match start_height {
+		Some(h) => h,
+		None => 1,
+	};
+
+	let info = scan::scan_rewind_hash(
+		wallet_inst,
+		rewind_hash,
+		start_height,
+		tip.0,
+		status_send_channel,
+	)?;
+	Ok(info)
 }
 
 /// check repair

--- a/libwallet/src/error.rs
+++ b/libwallet/src/error.rs
@@ -298,6 +298,14 @@ pub enum ErrorKind {
 	#[fail(display = "Age error: {}", _0)]
 	Age(String),
 
+	/// Rewind Hash parsing error
+	#[fail(display = "Rewind Hash error: {}", _0)]
+	RewindHash(String),
+
+	/// Nonce creation error
+	#[fail(display = "Nonce error: {}", _0)]
+	Nonce(String),
+
 	/// Slatepack address parsing error
 	#[fail(display = "SlatepackAddress error: {}", _0)]
 	SlatepackAddress(String),

--- a/libwallet/src/internal/scan.rs
+++ b/libwallet/src/internal/scan.rs
@@ -404,8 +404,8 @@ where
 	Ok(())
 }
 
-/// Scan outputs with the rewind hash of a given rewind hash view wallet.
-/// Retrieve outputs information that belongs to it.
+/// Scan outputs with a given rewind hash view wallet.
+/// Retrieve all outputs information that belongs to it.
 pub fn scan_rewind_hash<'a, L, C, K>(
 	wallet_inst: Arc<Mutex<Box<dyn WalletInst<'a, L, C, K>>>>,
 	rewind_hash: String,
@@ -418,7 +418,6 @@ where
 	C: NodeClient + 'a,
 	K: Keychain + 'a,
 {
-	// First, get a definitive list of outputs we own from the chain
 	if let Some(ref s) = status_send_channel {
 		let _ = s.send(StatusMessage::Scanning("Starting UTXO scan".to_owned(), 0));
 	}

--- a/libwallet/src/lib.rs
+++ b/libwallet/src/lib.rs
@@ -75,7 +75,8 @@ pub use slate_versions::ser as dalek_ser;
 pub use types::{
 	AcctPathMapping, BlockIdentifier, CbData, Context, NodeClient, NodeVersionInfo, OutputData,
 	OutputStatus, ScannedBlockInfo, StoredProofInfo, TxLogEntry, TxLogEntryType, TxWrapper,
-	WalletBackend, WalletInfo, WalletInitStatus, WalletInst, WalletLCProvider, WalletOutputBatch,
+	ViewWallet, WalletBackend, WalletInfo, WalletInitStatus, WalletInst, WalletLCProvider,
+	WalletOutputBatch,
 };
 
 /// Helper for taking a lock on the wallet instance

--- a/libwallet/src/types.rs
+++ b/libwallet/src/types.rs
@@ -1019,6 +1019,45 @@ impl ser::Readable for WalletInitStatus {
 	}
 }
 
+/// Utility struct for return values from below
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct ViewWallet {
+	/// Rewind Hash used to retrieve the outputs
+	pub rewind_hash: String,
+	/// All outputs information that belongs to the rewind hash
+	pub output_result: Vec<ViewWalletOutputResult>,
+	/// total balance
+	pub total_balance: u64,
+	/// last pmmr index
+	pub last_pmmr_index: u64,
+}
+/// Utility struct for return values from below
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct ViewWalletOutputResult {
+	///
+	pub commit: String,
+	///
+	pub value: u64,
+	///
+	pub height: u64,
+	///
+	pub mmr_index: u64,
+	///
+	pub is_coinbase: bool,
+	///
+	pub lock_height: u64,
+}
+
+impl ViewWalletOutputResult {
+	pub fn num_confirmations(&self, tip_height: u64) -> u64 {
+		if self.height > tip_height {
+			return 0;
+		} else {
+			1 + (tip_height - self.height)
+		}
+	}
+}
+
 /// Serializes an Option<Duration> to and from a string
 pub mod option_duration_as_secs {
 	use serde::de::Error;

--- a/src/bin/grin-wallet.yml
+++ b/src/bin/grin-wallet.yml
@@ -48,6 +48,24 @@ subcommands:
             short: c
             long: create
             takes_value: true
+  - rewind_hash:
+      about: Return the hash of the root_public_key of the wallet.
+  - scan_rewind_hash:
+      about: Scan the UTXO set and return the outputs and the total of grin owned by a view wallet rewind hash.
+      args:
+        - rewind_hash:
+              help: rewind_hash of the wallet to be scanned in order to retrieve all the outputs and balance.
+              index: 1
+        - start_height:
+            help: If given, the first block from which to start the scan (default 1)
+            short: h
+            long: start_height
+            takes_value: true
+        - backwards_from_tip:
+            help: If given, start scan b blocks back from the tip
+            short: b
+            long: backwards_from_tip,
+            takes_value: true
   - listen:
       about: Runs the wallet in listening mode waiting for transactions
       args:

--- a/src/bin/grin-wallet.yml
+++ b/src/bin/grin-wallet.yml
@@ -49,12 +49,12 @@ subcommands:
             long: create
             takes_value: true
   - rewind_hash:
-      about: Return the hash of the root_public_key of the wallet.
+      about: Return the hash of the wallet root public key.
   - scan_rewind_hash:
       about: Scan the UTXO set and return the outputs and the total of grin owned by a view wallet rewind hash.
       args:
         - rewind_hash:
-              help: rewind_hash of the wallet to be scanned in order to retrieve all the outputs and balance.
+              help: Rewind hash of the wallet to be scanned in order to retrieve all the outputs and balance.
               index: 1
         - start_height:
             help: If given, the first block from which to start the scan (default 1)


### PR DESCRIPTION
Re-opening the PR here. (old #630)

Features (api&cmdline):
- get the rewind_hash of the wallet
- scan of the rewind_hash of a third-party wallet

Goal:
Ensure the transparency (spending, receiving, balance etc) of a wallet that receive grin as donations.
Allow everyone to scan the rewind_hash of the wallet shared publicly.

Cmd usage:
get_rewind_hash: `grin-wallet rewind_hash`
scan_rewind_hash: `grin-wallet scan_rewind_hash 2c95b24de492395934a8a345440ed0ebbe67ee0025b348712a927a91c7fe58e9`


@yeastplume --> Just a note for anyone watching, this PR just provides an API for the post 2.0.0 BP rewind scheme outlined and decided upon prior to the 2.0.0 hardfork here: #105. This just covers public view keys and obviously won't work with any outputs created prior to 2.0.0.