### PR TITLE
Increase network read timeout when sending transactions

### DIFF
--- a/impls/src/adapters/http.rs
+++ b/impls/src/adapters/http.rs
@@ -27,6 +27,7 @@ use crate::tor::config as tor_config;
 use crate::tor::process as tor_process;
 
 const TOR_CONFIG_PATH: &str = "tor/sender";
+const SEND_TX_TIMEOUT_DURATION_SECTIONS: u64 = 5 * 60;
 
 #[derive(Clone)]
 pub struct HttpSlateSender {
@@ -107,7 +108,7 @@ impl HttpSlateSender {
 			"params": []
 		});
 
-		let res: String = self.post(url, None, req).map_err(|e| {
+		let res: String = self.post(url, None, req, None).map_err(|e| {
 			let mut report = format!("Performing version check (is recipient listening?): {}", e);
 			let err_string = format!("{}", e);
 			if err_string.contains("404") {
@@ -159,17 +160,18 @@ impl HttpSlateSender {
 		url: &str,
 		api_secret: Option<String>,
 		input: IN,
+		timeout: Option<u64>,
 	) -> Result<String, ClientError>
 	where
 		IN: Serialize,
 	{
 		let client =
 			if !self.use_socks {
-				Client::new()
+				Client::new(timeout)
 			} else {
 				Client::with_socks_proxy(self.socks_proxy_addr.ok_or_else(|| {
 					ClientErrorKind::Internal("No socks proxy address set".into())
-				})?)
+				})?, timeout)
 			}
 			.map_err(|_| ClientErrorKind::Internal("Unable to create http client".into()))?;
 		let req = client.create_post_request(url, api_secret, &input)?;
@@ -215,7 +217,7 @@ impl SlateSender for HttpSlateSender {
 
 		trace!("Sending receive_tx request: {}", req);
 
-		let res: String = self.post(&url_str, None, req).map_err(|e| {
+		let res: String = self.post(&url_str, None, req, Some(SEND_TX_TIMEOUT_DURATION_SECTIONS)).map_err(|e| {
 			let report = format!(
 				"Sending transaction slate to other wallet (is recipient listening?): {}",
 				e

--- a/impls/src/client_utils/client.rs
+++ b/impls/src/client_utils/client.rs
@@ -105,22 +105,23 @@ pub struct Client {
 
 impl Client {
 	/// New client
-	pub fn new() -> Result<Self, Error> {
-		Self::build(None)
+	pub fn new(read_and_write_timeout: Option<u64>) -> Result<Self, Error> {
+		Self::build(None, read_and_write_timeout)
 	}
 
-	pub fn with_socks_proxy(socks_proxy_addr: SocketAddr) -> Result<Self, Error> {
-		Self::build(Some(socks_proxy_addr))
+	pub fn with_socks_proxy(socks_proxy_addr: SocketAddr, read_and_write_timeout: Option<u64>) -> Result<Self, Error> {
+		Self::build(Some(socks_proxy_addr), read_and_write_timeout)
 	}
 
-	fn build(socks_proxy_addr: Option<SocketAddr>) -> Result<Self, Error> {
+	fn build(socks_proxy_addr: Option<SocketAddr>, read_and_write_timeout: Option<u64>) -> Result<Self, Error> {
 		let mut headers = HeaderMap::new();
 		headers.insert(USER_AGENT, HeaderValue::from_static("grin-client"));
 		headers.insert(ACCEPT, HeaderValue::from_static("application/json"));
 		headers.insert(CONTENT_TYPE, HeaderValue::from_static("application/json"));
 
 		let mut builder = ClientBuilder::new()
-			.timeout(Duration::from_secs(20))
+			.timeout(Duration::from_secs(read_and_write_timeout.unwrap_or(20)))
+			.connect_timeout(Duration::from_secs(20))
 			.use_rustls_tls()
 			.default_headers(headers);
 

--- a/impls/src/node_clients/http.rs
+++ b/impls/src/node_clients/http.rs
@@ -47,7 +47,7 @@ impl HTTPNodeClient {
 		node_api_secret: Option<String>,
 	) -> Result<HTTPNodeClient, libwallet::Error> {
 		Ok(HTTPNodeClient {
-			client: Client::new().map_err(|_| libwallet::ErrorKind::Node)?,
+			client: Client::new(None).map_err(|_| libwallet::ErrorKind::Node)?,
 			node_url: node_url.to_owned(),
 			node_api_secret: node_api_secret,
 			node_version_info: None,


### PR DESCRIPTION
These changes increase the network read timeout from 20 seconds to 5 minutes when sending transactions to avoid timing out too early when exchanging a slate with a device that takes longer than 20 seconds to generate a reply.

This will improve interoperability with wallets that support the [Grin dependent Ledger app](https://github.com/NicolasFlamel1/ledger-mimblewimble-coin) since that app takes approximately 90 seconds to generate a bulletproof on current Ledger hardware wallets.