### PR TITLE
Send API tokio worker panic fix

### DIFF
--- a/impls/src/client_utils/client.rs
+++ b/impls/src/client_utils/client.rs
@@ -319,9 +319,13 @@ impl Client {
 		if Handle::try_current().is_ok() {
 			let rt = RUNTIME.clone();
 			let client = self.clone();
-			std::thread::spawn(move || rt.lock().unwrap().block_on(client.send_request_async(req)))
-				.join()
-				.unwrap()
+			std::thread::spawn(move || {
+				rt.lock()
+					.unwrap()
+					.block_on(async { client.send_request_async(req).await })
+			})
+			.join()
+			.unwrap()
 		} else {
 			RUNTIME
 				.lock()


### PR DESCRIPTION
Attempt to fix #639. 

Basically, I believe that recent changes to tokio are forcing panic when a worker thread attempts to block, causing a panic on futures that block while calling out to the node. The fix here is to ensure another thread is spawned to handle blocking requests, and ensuring they're properly `awaiting` the result.