### PR TITLE
Config file migration fix

### DIFF
--- a/config/src/comments.rs
+++ b/config/src/comments.rs
@@ -223,6 +223,14 @@ fn comments() -> HashMap<String, String> {
 	);
 
 	retval.insert(
+		"skip_send_attempt".to_string(),
+		"
+#Whether to skip send attempts (used for debugging) 
+"
+		.to_string(),
+	);
+
+	retval.insert(
 		"use_tor_listener".to_string(),
 		"
 #Whether to start tor listener on listener startup (default true)


### PR DESCRIPTION
Previous Merged PR #617 contains config file migration functionality, however this was failing on very old wallet files due to a missing comment entry for `skip_send_attempt`. This adds the comment and allows older wallet files to migrate successfully.