### PR TITLE
Show QR code for listener address

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1544,6 +1544,7 @@ dependencies = [
  "lazy_static",
  "log",
  "prettytable-rs",
+ "qr_code",
  "rand 0.7.3",
  "remove_dir_all 0.7.0",
  "ring",
@@ -2865,6 +2866,12 @@ checksum = "c7342d5883fbccae1cc37a2353b09c87c9b0f3afd73f5fb9bba687a1f733b029"
 dependencies = [
  "unicode-xid 0.2.2",
 ]
+
+[[package]]
+name = "qr_code"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5520fbcd7da152a449261c5a533a1c7fad044e9e8aa9528cfec3f464786c7926"
 
 [[package]]
 name = "quick-error"

--- a/controller/Cargo.toml
+++ b/controller/Cargo.toml
@@ -29,6 +29,7 @@ url = "2.1"
 chrono = { version = "0.4.11", features = ["serde"] }
 easy-jsonrpc-mw = "0.5.4"
 lazy_static = "1"
+qr_code = "1.1.0"
 
 grin_wallet_util = { path = "../util", version = "5.2.0-alpha.1" }
 

--- a/controller/src/controller.rs
+++ b/controller/src/controller.rs
@@ -31,6 +31,7 @@ use grin_wallet_util::OnionV3Address;
 use hyper::body;
 use hyper::header::HeaderValue;
 use hyper::{Body, Request, Response, StatusCode};
+use qr_code::QrCode;
 use serde::{Deserialize, Serialize};
 use serde_json;
 use std::collections::HashMap;
@@ -351,7 +352,11 @@ where
 
 	warn!("HTTP Foreign listener started.");
 	if let Some(a) = address {
-		warn!("Slatepack Address is: {}", a);
+		let qr_string = match QrCode::new(a.to_string()) {
+			Ok(qr) => qr.to_string(false, 3),
+			Err(_) => "Failed to generate QR code!".to_string(),
+		};
+		warn!("Slatepack Address is: {}\n{}", a, qr_string);
 	}
 
 	api_thread


### PR DESCRIPTION
Resolves https://github.com/mimblewimble/grin-wallet/issues/649.

To see it in action, compile and run `grin-wallet listen`. You will see your Slatepack address as usual, but now also with a scanable QR code:
```bash
$ grin-wallet listen
Password:
20220626 22:39:35.332 WARN grin_wallet_controller::controller - Starting Tor Hidden Service for API listener at address x5fnata4ge6fbj35hwojo2eynhxq5lgzr6e3q4lbd4unoxfmekbzw7qd, binding to 127.0.0.1:3415
20220626 22:39:37.720 WARN grin_wallet_controller::controller - Starting HTTP Foreign listener API server at 127.0.0.1:3415.
20220626 22:39:37.721 WARN grin_wallet_controller::controller - HTTP Foreign listener started.
20220626 22:39:37.722 WARN grin_wallet_controller::controller - Slatepack Address is: grin1ha9dqnquxy79pfma8kwfw6ycd8hsatxe37ymsutpru5dwh9vy2ps7xl420


   █▀▀▀▀▀█  █▄▄ ▀ █▄ █▄▀▀█ ▀▄█▄█ █▀▀▀▀▀█
   █ ███ █ █▀█▄██▄ █▄ █▀▀▄ █▄▀▄█ █ ███ █
   █ ▀▀▀ █ █ ▄ ▀▄▄ █ ▄▀█ █▀ ▀▀▄▄ █ ▀▀▀ █
   ▀▀▀▀▀▀▀ █ █▄█ ▀ █ ▀▄▀ ▀▄▀ ▀▄▀ ▀▀▀▀▀▀▀
   █▄█▀█▀▀▄ ▄█▀ ▀ █▄ ▀ ▀█▀ ▀█▀ ▀▄▀▀▀█▀
    ▀▄▄█▀▀▀▀▀▄▄▀   ▄ ▄ ▀▄██▀ ▄▀▀▀█ ▄▀ ▀▀
   ▀▄▀▄█▀▀ █▄▄█ ▄█ ██ ▄█▄▄█ ██▀██▀▄▀▄█▄▀
   █   ▀█▀▀█ ▀▀ ▀▄███▄  █▄▄▄ ▀█ ▄▄▀▄  ▀█
   ▄▀▀▄ █▀▀▄ ▄██ █▄▀▄▄▀▄█▄▀▄▀▄ ██▀▄▀█▀█▀
    ▀▄█  ▀▄   ▀▀ ██▀ ██▄▄▀ ▄  █ ▄██▀▀▀█▀
   ▀▀ ▀ █▀  ██▄▀▄ ▀▄▀▄█▄ █▄▀▀▀▀█▀▀▀▀ ██▀
    ▄▀▀▄ ▀█  ▄▄▄█ █▀ ▀   ▀ █ ▀██▀▀▀ █▀██
   █ ▀▄█▄▀▄▀▀ ▀▄█▀▄▄ ▀▀▀▀▀▀▀▀▄▀██▀█▀ ▀▀▀
   █  ▀█▀▀ █▄█ ▄   ▄   ▀█▄█▀▀▀▀ ▀ ▄ ▄ █▀
   ▀ ▀▀  ▀ █▄▀█ ▀  ██▀▄▀▄▀█▄▀▀▀█▀▀▀█▄▀█
   █▀▀▀▀▀█ ▄▀ █▀█▀▀██▄ ▄█▄ ▄▀  █ ▀ █  █▀
   █ ███ █ ██▀ ▄▀▀█▀ ▄ ▄█▄ ██▄▀▀██▀█▀▀▄▀
   █ ▀▀▀ █ ▀▄ ▄▀▄ █▀▀▀█▄▄▄ █ █▀▄▀ ▀    █
   ▀▀▀▀▀▀▀ ▀▀  ▀▀▀▀▀▀▀▀  ▀ ▀▀▀▀ ▀▀ ▀▀▀▀▀





```