### PR TITLE
Fix macOS CI tests

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -59,9 +59,6 @@ jobs:
         CI_JOB: release
         PLATFORM: macos
   steps:
-    - script: |
-        brew uninstall llvm
-      displayName: macOS Uninstall LLVM
     - template: '.ci/test.yml'
     - template: '.ci/release.yml'
 - job: windows


### PR DESCRIPTION
Looks like the newest version of the runner does not include llvm anymore. This PR fixes the CI and unblocks #650.