### PR TITLE
Implement 'max' value send

### DIFF
--- a/src/bin/grin-wallet.yml
+++ b/src/bin/grin-wallet.yml
@@ -109,7 +109,7 @@ subcommands:
       about: Builds a transaction to send coins and sends to the recipient via the Slatepack workflow
       args:
         - amount:
-            help: Number of coins to send with optional fraction, e.g. 12.423
+            help: Number of coins to send with optional fraction, e.g. 12.423. Keyword 'max' will send maximum amount.
             index: 1
         - minimum_confirmations:
             help: Minimum number of confirmations required for an output to be spendable

--- a/src/cmd/wallet_args.rs
+++ b/src/cmd/wallet_args.rs
@@ -444,7 +444,11 @@ pub fn parse_account_args(account_args: &ArgMatches) -> Result<command::AccountA
 pub fn parse_send_args(args: &ArgMatches) -> Result<command::SendArgs, ParseError> {
 	// amount
 	let amount = parse_required(args, "amount")?;
-	let amount = core::core::amount_from_hr_string(amount);
+	let (amount, max) = if amount.eq_ignore_ascii_case("max") {
+		(Ok(0), true)
+	} else {
+		(core::core::amount_from_hr_string(amount), false)
+	};
 	let amount = match amount {
 		Ok(a) => a,
 		Err(e) => {
@@ -522,6 +526,7 @@ pub fn parse_send_args(args: &ArgMatches) -> Result<command::SendArgs, ParseErro
 
 	Ok(command::SendArgs {
 		amount: amount,
+		max: max,
 		minimum_confirmations: min_c,
 		selection_strategy: selection_strategy.to_owned(),
 		estimate_selection_strategies,


### PR DESCRIPTION
This PR adds a special value 'max', which can be accepted as a spend amount. If this amount is specified, the wallet will calculate the maximum spendable amount (less fees) and send that amount. This is effectively a sweep.

PR is currently in draft state, as I need to test and think through edge cases some more.

Resolves https://github.com/mimblewimble/grin-wallet/issues/601