### PR TITLE
Show slatepack QR codes

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1544,6 +1544,7 @@ dependencies = [
  "lazy_static",
  "log",
  "prettytable-rs",
+ "qr_code",
  "rand 0.7.3",
  "remove_dir_all 0.7.0",
  "ring",
@@ -2865,6 +2866,12 @@ checksum = "c7342d5883fbccae1cc37a2353b09c87c9b0f3afd73f5fb9bba687a1f733b029"
 dependencies = [
  "unicode-xid 0.2.2",
 ]
+
+[[package]]
+name = "qr_code"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5520fbcd7da152a449261c5a533a1c7fad044e9e8aa9528cfec3f464786c7926"
 
 [[package]]
 name = "quick-error"

--- a/controller/Cargo.toml
+++ b/controller/Cargo.toml
@@ -29,6 +29,7 @@ url = "2.1"
 chrono = { version = "0.4.11", features = ["serde"] }
 easy-jsonrpc-mw = "0.5.4"
 lazy_static = "1"
+qr_code = "1.1.0"
 
 grin_wallet_util = { path = "../util", version = "5.2.0-alpha.1" }
 

--- a/controller/src/command.rs
+++ b/controller/src/command.rs
@@ -30,6 +30,7 @@ use crate::util::secp::key::SecretKey;
 use crate::util::{Mutex, ZeroingString};
 use crate::{controller, display};
 use ::core::time;
+use qr_code::QrCode;
 use serde_json as json;
 use std::convert::TryFrom;
 use std::fs::File;
@@ -527,6 +528,10 @@ where
 	println!();
 	println!("{}", out_file_name);
 	println!();
+	if let Ok(qr_string) = QrCode::new(message) {
+		println!("{}", qr_string.to_string(false, 3));
+		println!();
+	}
 	if address.is_some() {
 		println!("The slatepack data is encrypted for the recipient only");
 	} else {


### PR DESCRIPTION
Resolves https://github.com/stakervali/grin-wishlist/issues/12.
This PR addresses the [slatepack QR wishlist feature](https://grincc.mw/projects).

This PR shows a QR code when slatepacks are generated. The second slatepack (e.g. response when receiving) results in quite a large QR code, so I think someone should approve that from a UX perspective, but below is an example of the QR output when initiating a send.
```
$ .grin-wallet send -m 0.5
Password: 
No recipient Slatepack address or provided address invalid. No payment proof will be requested.
./testdir/slatepack/4d003e43-b377-4880-8bdd-4e70ba4499e7.S1.slatepack

Slatepack data follows. Please provide this output to the other party

--- CUT BELOW THIS LINE ---

BEGINSLATEPACK. YLpmbZFYB5gcEbq W7pdEknbFxART1L nTnvKkES8REBmV1 D6ohYYMVA8HqXnF yTGqKser9Srb6wZ pSYxR497rt4oiok M5h6TyfZijibxZV acQo2VnHBvDE8XY WoLMumptd3PeRgb 3DudXdb9XZBdGX3 XjxUfiKCSsLkabF aubR26yZ7gss2Fh 5tjKDrDVFoUcwnJ R96g6EQb3QkAqjh ydk3ezNypJJ4kaf 6AAfCJXqKvTjroL rYDpti3b84k69UD QCMUgXnRKVY4T2A 7fT2qhReQnFSXD9 sfLEkYcrC31Axmr 3YVNYw. ENDSLATEPACK.

--- CUT ABOVE THIS LINE ---

Slatepack data was also output to

./testdir/slatepack/4d003e43-b377-4880-8bdd-4e70ba4499e7.S1.slatepack

                                                                   
 █▀▀▀▀▀█ ▄▄ █▄▀███▄▀▄▄▄  ▀ ▄▀▀▄█ ▄▀ ▄██ ▀ ▄▀█ █▄▀▄▀ ▄▀▀ ▀▄ █▀▀▀▀▀█ 
 █ ███ █ ▄▀▄█ █▀ █▄ ▄ █▄███ ▀▀▄▄▀▄▄ ███  ▄▀  ▄ ▀▀▀█▀  ██▄▀ █ ███ █ 
 █ ▀▀▀ █ ▄▀▀  ▀▀▀▀▄▀ ▄██ ▄▄   ▄█▀▀▀█▄ ▄ ▀▄▄█▄  ▀▀██  ▄▄▄ ▀ █ ▀▀▀ █ 
 ▀▀▀▀▀▀▀ ▀▄█▄▀▄█▄█ █▄█▄▀ █▄▀ █ █ ▀ █▄█▄▀ ▀▄█▄▀ ▀▄█▄█ ▀ ▀ ▀ ▀▀▀▀▀▀▀ 
 ████▀▄▀▀██▄█▀ █▀  ▄█ ▀  ▀▄▀  █▀█▀████ ▀█▄▀▀ ▀██ ▀▄▀▀ █  ▀█ █▄▀▄▀  
 ▀ ▄▀█▄▀ ▄█▀██▀██▀██▀▄▀▀▀█▄▀▄▀▄▄█ ▄▄█▄█  ▀█▀█▀▄▄▀▄█▄▄ ▀▀▀▀▄███▄ █  
 ▄ ▀▀ █▀   ▀▄█    ██▀ ▀ ▀▄▄ ▄ ██▄█ ▀ ▀▄ ▀█▄▄▄▀ ██▄▀ █▀█▀█▄█▀ ▄█▄ █ 
 ▀▀▄ ▄▀▀ █▀▀ ▀██▀  ▄▀ ▄▀   ▀▀███▄ ▄▄█▄█ █▀▄█ ▄  ▀██ ▀ ███▄ █ ▄▀    
 █▀█▀█ ▀▀▄▄▄█ ▄█▀█▄██▄  ▀▀     ▄  ▄ ▄▀ █▄▀▀▀▀ ▄▀███ ▀▀▄▄█  ▄▀▀▀ ▄  
  ▄▄▀▀▄▀▄▄ ▄ █▄█ ▄▄█▀█▀▀ ▄▀▄█▄▀█▀   ▄█▀█▄  ██  ▄██ ▄▄ █  █  █ █ █▄ 
 ▄▀█▄▀▀▀██ ▀▀▄█▀▄ ▄█▀▄█ ▀▀ █▄ ▄█▀ ▄█ █▀██▀▄█  █ ▄▄█▄█  █▄ █▄█▀▄  ▀ 
  ▄█▄█ ▀█   ▄ ▄ ▄ ▀  █▄█▄▄  ▄  ▀███ ▄▄█ █▀▀▀ ▀  ██▀▄▀▀▀▀  ▀▄▄█▄▄▄█ 
 ▄▀▀█▄█▀▀▀▄█▀█▀█▀ ███▄  ▀▀▀   █▀▄▄  █▀▄▀  ▀ ██▄▄ ▄▀▄▀▀▄   ▀▄█ ▀▄▀▀ 
  ▄▄ ▀▀▀▀▀   █ ▄██▄▄▄▄▀ ▀ ▀▄▀▀ █▄  ▄ █ ▄▀ █▀▄▀▀ ▄▄▀▄ ▀▄▀  ▄ ▄█ ▄█  
 ▄▀▀██▀▀ █ █▄█▄█▀▄▄▄▄▄ ▀█▄▄  ███ ██ ▀▄▄██ ▀▀ ▀   █ █▄▄▄▀ ▄▀▄██▀▄▀█ 
 ▄▄███▀▀▀█  ▀█▄ ▀█▀▄▄██▄▀▄█▀▄  █▀▀▀██▀█ ████ █    ▀ ▄▄██▄█▀▀▀█▄█ █ 
 ▄██▄█ ▀ █▀▀▄▄▄▀▄ ▄▄▀▄ ▀█▀▄▀ ▄██ ▀ █▄▀▀▄▄▄▄█▀███▀▀▀▀  ▀▀▀█ ▀ █  ▄  
 ▀▄ ▄▀▀▀▀█▀▄▀▀█▄ ▄▀ ▄▄█  █▀▄██████▀▀ ██▄  ▄█▀ █▄██ █▄  ▀▀█▀██▀▄▀█▀ 
 ▀ █▀▄▄▀ █▀▀ ▀█▄ ▄▀▄▀ █ ▀██  ▄▄ █▄██ ▀▀▄▄  ▀ █▄ ▄█▄▄█▄█▄█▀▄▀ ██▀▀▀ 
 ▄▀ █▀▄▀ ▀▀▀▄▄▀█▀ ▀█▄▀  ▄▄▀█▀▄▄▀▄▄▄▀▄▄▀▄  ▀█▄ ▄▄▄██ █▀▀▀▀ ▀▀█▀▄▀▀▄ 
  ▄▀▄██▀▀▄▀▄█  █▄▄█▄█▄▀ ▀█▄   ▄▀ ▄▄▄▄▀  ▀  ▄▀ █ ▀▀ ██▄ █ █▄▀▄ ▀ █  
 █▀█▄ ▄▀▀█▄▀▄█ ▀ ▄   ▀▄▄▄▄▄▀▀▀  █  ▀▄█▀ █ ▀▀█ ▄▄ ▄▀ ▀▀█▀▀▄█▀▀▀▀▄██ 
  ▄▄▄▄▀▀▄▄██▀ ▄▄▄ ██  █ ▄ ▄ █ ██  █ ██▄ ▀▄█▀▄█▀▄▀█▄█▀▀▄▀▄▄▄▀ █▄▄▄  
 █▄▀█ ▀▀ ▄▄▄▀█▄▄▄ ▀▀   ▀▀▀  █▀ ▀ ▀▀▀▄▀█ ▀▄ █▄▀  █ █ ▀▄▄█▀██▀ ▀▀▄▄▄ 
 ██ ▄██▀ █▀▄▄▀██▄ ██▀▄▀▀▀▀█ ▄ ▄ █  ▀ █ ▀▀▄▀ ▄ ▄ █▀  █▀▄ ▄▄█ ██▄ ▀  
 ▀  ▀▀█▀▀▀█▄ ▀▀ ▀▄▄█ ██ ▀▀█▄ ▄▄▀▀▄▀ ██▀▀  ███ █▀▄█▀     ▀▀ ▀ ▀█▀▄▀ 
  ▀▄ ██▀▀ █▀▄▀▀█ ▄▄█▀ ▄ ███▄█ █▀  ▄▀  ▄█  ▀█▄█   ▄█ ▀▀ ▀ █ ▀ ▀██ ▀ 
 ▄ ▀█ ▀▀▀▀▄▄▀█ ██ ▀▄ ▄▀ ▄  ▄█▄▄ ▀▄ ▀▄▄█ ▀  █▄▀▄▄█▄▀▄▀ ▀██▀█ ▄█ ▀▄▀ 
  ▀▀ ▀ ▀▀██   ▄▄█▄▄▄█  ▀██▄ ▄  █▀▀▀██ █▄▀▀ ▀▀▀▀   ▄▀  █▄ █▀▀▀█▀▄ ▀ 
 █▀▀▀▀▀█ ▀▀▀▀ ▄▄█▄ ▀▄▄▄▀▄▀ ▀██▄█ ▀ █▄▄█▄ ▀█▀▄▀ ▄▄▄▀  ▀▄▀ █ ▀ █   ▀ 
 █ ███ █ ███  █▀▀▄█▄ ▄▄▀▄█ ▀ ▀ ██▀▀▀▀ ▄ ▄ ▀▀▀█ ▄ ▄▀ ██ ▀█▀▀█▀██▄▄▀ 
 █ ▀▀▀ █ ████▀ ▄▀█▄█ ▀  █▄   ▀ ▀█▄▄▀  █ ▄▀▀█▄▀   ▄▀ ▄▄██ ▀▄▄█▀▄▀█▄ 
 ▀▀▀▀▀▀▀ ▀ ▀ ▀▀    ▀▀ ▀ ▀▀▀ ▀    ▀▀▀ ▀▀▀▀   ▀ ▀▀ ▀ ▀▀ ▀▀▀▀  ▀▀  ▀  



The slatepack data is NOT encrypted

Command 'send' completed successfully
```