### PR TITLE
Do not prompt for password to start owner API

### DIFF
--- a/src/cmd/wallet_args.rs
+++ b/src/cmd/wallet_args.rs
@@ -1018,7 +1018,7 @@ where
 		("init", Some(_)) => open_wallet = false,
 		("recover", _) => open_wallet = false,
 		("cli", _) => open_wallet = false,
-		("owner_api", _) => open_wallet = false
+		("owner_api", _) => open_wallet = false,
 		_ => {}
 	}
 

--- a/src/cmd/wallet_args.rs
+++ b/src/cmd/wallet_args.rs
@@ -1019,7 +1019,7 @@ where
 		("recover", _) => open_wallet = false,
 		("cli", _) => open_wallet = false,
 		("owner_api", _) => {
-			// If wallet exists and password argument is present, open it. Otherwise, that's fine too.
+			// If wallet exists and password is present then open it. Otherwise, that's fine too.
 			let mut wallet_lock = wallet.lock();
 			let lc = wallet_lock.lc_provider().unwrap();
 			open_wallet = wallet_args.is_present("pass") && lc.wallet_exists(None)?;

--- a/src/cmd/wallet_args.rs
+++ b/src/cmd/wallet_args.rs
@@ -1018,12 +1018,7 @@ where
 		("init", Some(_)) => open_wallet = false,
 		("recover", _) => open_wallet = false,
 		("cli", _) => open_wallet = false,
-		("owner_api", _) => {
-			// If wallet exists, open it. Otherwise, that's fine too.
-			let mut wallet_lock = wallet.lock();
-			let lc = wallet_lock.lc_provider().unwrap();
-			open_wallet = lc.wallet_exists(None)?;
-		}
+		("owner_api", _) => open_wallet = false
 		_ => {}
 	}
 

--- a/src/cmd/wallet_args.rs
+++ b/src/cmd/wallet_args.rs
@@ -1018,7 +1018,12 @@ where
 		("init", Some(_)) => open_wallet = false,
 		("recover", _) => open_wallet = false,
 		("cli", _) => open_wallet = false,
-		("owner_api", _) => open_wallet = false,
+		("owner_api", _) => {
+			// If wallet exists and password argument is present, open it. Otherwise, that's fine too.
+			let mut wallet_lock = wallet.lock();
+			let lc = wallet_lock.lc_provider().unwrap();
+			open_wallet = wallet_args.is_present("pass") && lc.wallet_exists(None)?;
+		}
 		_ => {}
 	}
 


### PR DESCRIPTION
It makes no sense to ask for the password if one only wants to initialize the APIs. Asking for the password makes things unnecessarily difficult and insecure in case I, as a system administrator, want to have the APIs running as a system service.