### PR TITLE
Implement fee inclusive transactions

### DIFF
--- a/controller/src/command.rs
+++ b/controller/src/command.rs
@@ -322,6 +322,7 @@ where
 #[derive(Clone)]
 pub struct SendArgs {
 	pub amount: u64,
+	pub amount_includes_fee: bool,
 	pub minimum_confirmations: u64,
 	pub selection_strategy: String,
 	pub estimate_selection_strategies: bool,
@@ -361,6 +362,7 @@ where
 					let init_args = InitTxArgs {
 						src_acct_name: None,
 						amount: args.amount,
+						amount_includes_fee: Some(args.amount_includes_fee),
 						minimum_confirmations: args.minimum_confirmations,
 						max_outputs: args.max_outputs as u32,
 						num_change_outputs: args.change_outputs as u32,
@@ -378,6 +380,7 @@ where
 			let init_args = InitTxArgs {
 				src_acct_name: None,
 				amount: args.amount,
+				amount_includes_fee: Some(args.amount_includes_fee),
 				minimum_confirmations: args.minimum_confirmations,
 				max_outputs: args.max_outputs as u32,
 				num_change_outputs: args.change_outputs as u32,

--- a/libwallet/src/api_impl/owner.rs
+++ b/libwallet/src/api_impl/owner.rs
@@ -508,6 +508,7 @@ where
 			&mut *w,
 			keychain_mask,
 			args.amount,
+			args.amount_includes_fee.unwrap_or(false),
 			args.minimum_confirmations,
 			args.max_outputs as usize,
 			args.num_change_outputs as usize,
@@ -543,6 +544,7 @@ where
 			&parent_key_id,
 			true,
 			use_test_rng,
+			args.amount_includes_fee.unwrap_or(false),
 		)?
 	};
 
@@ -696,6 +698,7 @@ where
 		&parent_key_id,
 		false,
 		use_test_rng,
+		false,
 	)?;
 
 	let keychain = w.keychain(keychain_mask)?;
@@ -823,6 +826,7 @@ where
 			parent_key_id.clone(),
 			false,
 			true,
+			false,
 		)?;
 
 		// Add inputs and outputs to original context

--- a/libwallet/src/api_impl/types.rs
+++ b/libwallet/src/api_impl/types.rs
@@ -40,6 +40,8 @@ pub struct InitTxArgs {
 	#[serde(with = "secp_ser::string_or_u64")]
 	/// The amount to send, in nanogrins. (`1 G = 1_000_000_000nG`)
 	pub amount: u64,
+	/// Does the amount include the fee, or will fees be spent in addition to the amount?
+	pub amount_includes_fee: Option<bool>,
 	#[serde(with = "secp_ser::string_or_u64")]
 	/// The minimum number of confirmations an output
 	/// should have in order to be included in the transaction.
@@ -105,6 +107,7 @@ impl Default for InitTxArgs {
 		InitTxArgs {
 			src_acct_name: None,
 			amount: 0,
+			amount_includes_fee: None,
 			minimum_confirmations: 10,
 			max_outputs: 500,
 			num_change_outputs: 1,

--- a/libwallet/src/internal/tx.rs
+++ b/libwallet/src/internal/tx.rs
@@ -96,6 +96,7 @@ pub fn estimate_send_tx<'a, T: ?Sized, C, K>(
 	wallet: &mut T,
 	keychain_mask: Option<&SecretKey>,
 	amount: u64,
+	amount_includes_fee: bool,
 	minimum_confirmations: u64,
 	max_outputs: usize,
 	num_change_outputs: usize,
@@ -128,6 +129,7 @@ where
 	let (_coins, total, _amount, fee) = selection::select_coins_and_fee(
 		wallet,
 		amount,
+		amount_includes_fee,
 		current_height,
 		minimum_confirmations,
 		max_outputs,
@@ -151,6 +153,7 @@ pub fn add_inputs_to_slate<'a, T: ?Sized, C, K>(
 	parent_key_id: &Identifier,
 	is_initiator: bool,
 	use_test_rng: bool,
+	amount_includes_fee: bool,
 ) -> Result<Context, Error>
 where
 	T: WalletBackend<'a, C, K>,
@@ -181,6 +184,7 @@ where
 		parent_key_id.clone(),
 		use_test_rng,
 		is_initiator,
+		amount_includes_fee,
 	)?;
 
 	// Generate a kernel offset and subtract from our context's secret key. Store
@@ -270,6 +274,7 @@ where
 	let (_coins, _total, _amount, fee) = selection::select_coins_and_fee(
 		wallet,
 		init_tx_args.amount,
+		init_tx_args.amount_includes_fee.unwrap_or(false),
 		current_height,
 		init_tx_args.minimum_confirmations,
 		init_tx_args.max_outputs as usize,

--- a/src/bin/grin-wallet.yml
+++ b/src/bin/grin-wallet.yml
@@ -181,6 +181,9 @@ subcommands:
             help: Show slatepack data as QR code
             short: q
             long: slatepack_qr
+        - amount_includes_fee:
+            help: Transaction amount includes transaction fee. Recipient will receive (amount - fee).
+            long: amount_includes_fee
   - unpack:
       about: Unpack and display an armored Slatepack Message, decrypting if possible
       args:

--- a/src/bin/grin-wallet.yml
+++ b/src/bin/grin-wallet.yml
@@ -109,7 +109,7 @@ subcommands:
       about: Builds a transaction to send coins and sends to the recipient via the Slatepack workflow
       args:
         - amount:
-            help: Number of coins to send with optional fraction, e.g. 12.423
+            help: Number of coins to send with optional fraction, e.g. 12.423. Keyword 'max' will send maximum amount.
             index: 1
         - minimum_confirmations:
             help: Minimum number of confirmations required for an output to be spendable

--- a/src/cmd/wallet_args.rs
+++ b/src/cmd/wallet_args.rs
@@ -444,7 +444,11 @@ pub fn parse_account_args(account_args: &ArgMatches) -> Result<command::AccountA
 pub fn parse_send_args(args: &ArgMatches) -> Result<command::SendArgs, ParseError> {
 	// amount
 	let amount = parse_required(args, "amount")?;
-	let amount = core::core::amount_from_hr_string(amount);
+	let (amount, spend_max) = if amount.eq_ignore_ascii_case("max") {
+		(Ok(0), true)
+	} else {
+		(core::core::amount_from_hr_string(amount), false)
+	};
 	let amount = match amount {
 		Ok(a) => a,
 		Err(e) => {
@@ -455,7 +459,7 @@ pub fn parse_send_args(args: &ArgMatches) -> Result<command::SendArgs, ParseErro
 			return Err(ParseError::ArgumentError(msg));
 		}
 	};
-	let amount_includes_fee = args.is_present("amount_includes_fee");
+	let amount_includes_fee = args.is_present("amount_includes_fee") || spend_max;
 
 	// minimum_confirmations
 	let min_c = parse_required(args, "minimum_confirmations")?;
@@ -526,6 +530,7 @@ pub fn parse_send_args(args: &ArgMatches) -> Result<command::SendArgs, ParseErro
 	Ok(command::SendArgs {
 		amount: amount,
 		amount_includes_fee: amount_includes_fee,
+		use_max_amount: spend_max,
 		minimum_confirmations: min_c,
 		selection_strategy: selection_strategy.to_owned(),
 		estimate_selection_strategies,

--- a/src/cmd/wallet_args.rs
+++ b/src/cmd/wallet_args.rs
@@ -455,6 +455,7 @@ pub fn parse_send_args(args: &ArgMatches) -> Result<command::SendArgs, ParseErro
 			return Err(ParseError::ArgumentError(msg));
 		}
 	};
+	let amount_includes_fee = args.is_present("amount_includes_fee");
 
 	// minimum_confirmations
 	let min_c = parse_required(args, "minimum_confirmations")?;
@@ -524,6 +525,7 @@ pub fn parse_send_args(args: &ArgMatches) -> Result<command::SendArgs, ParseErro
 
 	Ok(command::SendArgs {
 		amount: amount,
+		amount_includes_fee: amount_includes_fee,
 		minimum_confirmations: min_c,
 		selection_strategy: selection_strategy.to_owned(),
 		estimate_selection_strategies,

--- a/tests/data/v3_reqs/init_send_tx.req.json
+++ b/tests/data/v3_reqs/init_send_tx.req.json
@@ -6,6 +6,7 @@
 		"args": {
 			"src_acct_name": null,
 			"amount": "600000000000",
+			"amount_includes_fee": false,
 			"minimum_confirmations": 2,
 			"max_outputs": 500,
 			"num_change_outputs": 1,


### PR DESCRIPTION
This feature consists of three commits:
1) Extend API to allow "fee inclusive" transaction amounts
2) Expose this option in the CLI `send` command via new flag: `--amount_includes_fee`
3) Calculate & spend max wallet balance, if 'max' keyword is used as send amount

I've added tests for all three commits as well as functionally tested with real coins in a real wallet.

@yeastplume @phyro as written today, I think this incurs a breaking API change. I tried to come up with an approach that would be backwards compatible, but I kept having to resort to hacks and abuse of other args to make it happen... I decided it would be better to implement this logic "properly" for now, and see how bad the pushback is for making a breaking change to the API :grimacing:. Please let me know your thoughts.

Resolves https://github.com/mimblewimble/grin-wallet/issues/601.