### PR TITLE
Add option to limit number of TXs shown

### DIFF
--- a/controller/src/command.rs
+++ b/controller/src/command.rs
@@ -1093,6 +1093,7 @@ where
 pub struct TxsArgs {
 	pub id: Option<u32>,
 	pub tx_slate_id: Option<Uuid>,
+	pub count: Option<u32>,
 }
 
 pub fn txs<L, C, K>(
@@ -1112,11 +1113,15 @@ where
 		let res = api.node_height(m)?;
 		let (validated, txs) = api.retrieve_txs(m, true, args.id, args.tx_slate_id)?;
 		let include_status = !args.id.is_some() && !args.tx_slate_id.is_some();
+		// If view count is specified, restrict the TX list to `txs.len() - count`
+		let first_tx = args
+			.count
+			.map_or(0, |c| txs.len().saturating_sub(c as usize));
 		display::txs(
 			&g_args.account,
 			res.height,
 			validated || updater_running,
-			&txs,
+			&txs[first_tx..],
 			include_status,
 			dark_scheme,
 		)?;

--- a/src/bin/grin-wallet.yml
+++ b/src/bin/grin-wallet.yml
@@ -330,6 +330,11 @@ subcommands:
             short: t
             long: txid
             takes_value: true
+        - count:
+            help: Maximum number of transactions to show
+            short: c
+            long: count
+            takes_value: true
   - post:
       about: Posts a finalized transaction to the chain
       args:

--- a/src/cmd/wallet_args.rs
+++ b/src/cmd/wallet_args.rs
@@ -833,9 +833,14 @@ pub fn parse_txs_args(args: &ArgMatches) -> Result<command::TxsArgs, ParseError>
 		let msg = format!("At most one of 'id' (-i) or 'txid' (-t) may be provided.");
 		return Err(ParseError::ArgumentError(msg));
 	}
+	let count = match args.value_of("count") {
+		None => None,
+		Some(c) => Some(parse_u64(c, "count")? as u32),
+	};
 	Ok(command::TxsArgs {
 		id: tx_id,
 		tx_slate_id: tx_slate_id,
+		count: count,
 	})
 }
 


### PR DESCRIPTION
This PR adds a `--count` option to the `txs` wallet command, to restrict the number of TXs shown. I find this very helpful when working in wallets with many transactions. Example usage:

```
# Display last 10 transactions
$ grin-wallet txs --count 10
```

This is a CLI change only, which I think is useful today. As I outline in https://github.com/mimblewimble/grin-wallet/issues/659, it might also be worth modifying the API to allow constrained queries to the wallet.