### PR TITLE
[Contracts] Experimental Slate v5

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -733,6 +733,41 @@ dependencies = [
 ]
 
 [[package]]
+name = "darling"
+version = "0.13.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a01d95850c592940db9b8194bc39f4bc0e89dee5c4265e4b1807c34a9aba453c"
+dependencies = [
+ "darling_core",
+ "darling_macro",
+]
+
+[[package]]
+name = "darling_core"
+version = "0.13.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "859d65a907b6852c9361e3185c862aae7fafd2887876799fa55f5f99dc40d610"
+dependencies = [
+ "fnv",
+ "ident_case",
+ "proc-macro2 1.0.42",
+ "quote 1.0.20",
+ "strsim 0.10.0",
+ "syn 1.0.98",
+]
+
+[[package]]
+name = "darling_macro"
+version = "0.13.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9c972679f83bdf9c42bd905396b6c3588a843a17f0f16dfcfa3e2c5d57441835"
+dependencies = [
+ "darling_core",
+ "quote 1.0.20",
+ "syn 1.0.98",
+]
+
+[[package]]
 name = "dashmap"
 version = "5.3.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1637,6 +1672,7 @@ dependencies = [
  "serde",
  "serde_derive",
  "serde_json",
+ "serde_with",
  "sha2 0.8.2",
  "strum",
  "strum_macros",
@@ -1937,6 +1973,12 @@ dependencies = [
  "quote 1.0.20",
  "syn 1.0.98",
 ]
+
+[[package]]
+name = "ident_case"
+version = "1.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b9e0384b61958566e926dc50660321d12159025e767c18e043daf26b70104c39"
 
 [[package]]
 name = "idna"
@@ -3707,6 +3749,29 @@ dependencies = [
  "itoa 1.0.2",
  "ryu",
  "serde",
+]
+
+[[package]]
+name = "serde_with"
+version = "1.14.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "678b5a069e50bf00ecd22d0cd8ddf7c236f68581b03db652061ed5eb13a312ff"
+dependencies = [
+ "chrono",
+ "serde",
+ "serde_with_macros",
+]
+
+[[package]]
+name = "serde_with_macros"
+version = "1.5.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e182d6ec6f05393cc0e5ed1bf81ad6db3a8feedf8ee515ecdd369809bcce8082"
+dependencies = [
+ "darling",
+ "proc-macro2 1.0.42",
+ "quote 1.0.20",
+ "syn 1.0.98",
 ]
 
 [[package]]

--- a/api/src/foreign_rpc.rs
+++ b/api/src/foreign_rpc.rs
@@ -52,6 +52,7 @@ pub trait ForeignRpc {
 			"Ok": {
 				"foreign_api_version": 2,
 				"supported_slate_versions": [
+					"V5",
 					"V4"
 				]
 			}

--- a/api/src/foreign_rpc.rs
+++ b/api/src/foreign_rpc.rs
@@ -142,7 +142,7 @@ pub trait ForeignRpc {
 					}
 				],
 				"sta": "S1",
-				"ver": "4:2"
+				"ver": "5:2"
 			},
 			null,
 			null
@@ -177,7 +177,7 @@ pub trait ForeignRpc {
 					}
 				],
 				"sta": "S2",
-				"ver": "4:2"
+				"ver": "5:2"
 			}
 		}
 	}
@@ -206,7 +206,7 @@ pub trait ForeignRpc {
 		"method": "finalize_tx",
 		"id": 1,
 		"params": [{
-			"ver": "4:2",
+			"ver": "5:2",
 			"id": "0436430c-2b02-624c-2032-570501212b00",
 			"sta": "I2",
 			"off": "383bc9df0dd332629520a0a72f8dd7f0e97d579dccb4dbdc8592aa3d424c846c",
@@ -276,7 +276,7 @@ pub trait ForeignRpc {
 					}
 				],
 				"sta": "I3",
-				"ver": "4:2"
+				"ver": "5:2"
 			}
 		}
 	}

--- a/api/src/owner_rpc.rs
+++ b/api/src/owner_rpc.rs
@@ -504,7 +504,7 @@ pub trait OwnerRpc {
 						}
 					],
 					"sta": "S1",
-					"ver": "4:2"
+					"ver": "5:2"
 				}
 			}
 		}
@@ -570,7 +570,7 @@ pub trait OwnerRpc {
 						}
 					],
 					"sta": "I1",
-					"ver": "4:2"
+					"ver": "5:2"
 				}
 			}
 		}
@@ -941,7 +941,7 @@ pub trait OwnerRpc {
 				"id": "0436430c-2b02-624c-2032-570501212b00",
 				"sigs": [],
 				"sta": "S3",
-				"ver": "4:3"
+				"ver": "5:3"
 			}
 		}
 	}

--- a/impls/src/adapters/http.rs
+++ b/impls/src/adapters/http.rs
@@ -179,6 +179,10 @@ impl HttpSlateSender {
 			return Err(Error::ClientCallback(report));
 		}
 
+		if supported_slate_versions.contains(&"V5".to_owned()) {
+			return Ok(SlateVersion::V5);
+		}
+
 		if supported_slate_versions.contains(&"V4".to_owned()) {
 			return Ok(SlateVersion::V4);
 		}
@@ -223,6 +227,7 @@ impl SlateSender for HttpSlateSender {
 		self.launch_tor()?;
 
 		let slate_send = match self.check_other_version(&url_str)? {
+			SlateVersion::V5 => VersionedSlate::into_version(slate.clone(), SlateVersion::V5)?,
 			SlateVersion::V4 => VersionedSlate::into_version(slate.clone(), SlateVersion::V4)?,
 		};
 		// Note: not using easy-jsonrpc as don't want the dependencies in this crate

--- a/libwallet/Cargo.toml
+++ b/libwallet/Cargo.toml
@@ -16,6 +16,7 @@ rand = "0.6"
 serde = "1"
 serde_derive = "1"
 serde_json = "1"
+serde_with = { version = "1", features = ["chrono"] }
 log = "0.4"
 uuid = { version = "0.8", features = ["serde", "v4"] }
 chrono = { version = "0.4.11", features = ["serde"] }

--- a/libwallet/src/api_impl/foreign.rs
+++ b/libwallet/src/api_impl/foreign.rs
@@ -116,14 +116,16 @@ where
 	let excess = ret_slate.calc_excess(keychain.secp())?;
 
 	if let Some(ref mut p) = ret_slate.payment_proof {
-		let sig = tx::create_payment_proof_signature(
-			ret_slate.amount,
-			&excess,
-			p.sender_address,
-			address::address_from_derivation_path(&keychain, &parent_key_id, 0)?,
-		)?;
+		if let Some(saddr) = p.sender_address {
+			let sig = tx::create_payment_proof_signature(
+				ret_slate.amount,
+				&excess,
+				saddr,
+				address::address_from_derivation_path(&keychain, &parent_key_id, 0)?,
+			)?;
 
-		p.receiver_signature = Some(sig);
+			p.promise_signature = Some(sig);
+		}
 	}
 
 	ret_slate.amount = 0;

--- a/libwallet/src/api_impl/owner.rs
+++ b/libwallet/src/api_impl/owner.rs
@@ -568,9 +568,9 @@ where
 		let sender_address = OnionV3Address::from_private(&sec_addr_key.0)?;
 
 		slate.payment_proof = Some(PaymentInfo {
-			sender_address: sender_address.to_ed25519()?,
+			sender_address: Some(sender_address.to_ed25519()?),
 			receiver_address: a.pub_key,
-			receiver_signature: None,
+			promise_signature: None,
 		});
 
 		context.payment_proof_derivation_index = Some(deriv_path);

--- a/libwallet/src/api_impl/owner.rs
+++ b/libwallet/src/api_impl/owner.rs
@@ -38,6 +38,7 @@ use crate::{
 	SlatepackAddress, Slatepacker, SlatepackerArgs, TxLogEntryType, ViewWallet, WalletInitStatus,
 	WalletInst, WalletLCProvider,
 };
+use chrono::prelude::{DateTime, NaiveDateTime, Utc};
 use ed25519_dalek::PublicKey as DalekPublicKey;
 use ed25519_dalek::SecretKey as DalekSecretKey;
 use ed25519_dalek::Verifier;
@@ -571,6 +572,8 @@ where
 			sender_address: Some(sender_address.to_ed25519()?),
 			receiver_address: a.pub_key,
 			promise_signature: None,
+			timestamp: DateTime::<Utc>::from_utc(NaiveDateTime::from_timestamp(0, 0), Utc),
+			memo: None,
 		});
 
 		context.payment_proof_derivation_index = Some(deriv_path);

--- a/libwallet/src/internal/selection.rs
+++ b/libwallet/src/internal/selection.rs
@@ -205,7 +205,7 @@ where
 			let sender_address = OnionV3Address::from_private(&sender_key.0)?;
 			t.payment_proof = Some(StoredProofInfo {
 				receiver_address: p.receiver_address,
-				receiver_signature: p.receiver_signature,
+				receiver_signature: p.promise_signature,
 				sender_address: sender_address.to_ed25519()?,
 				sender_address_path,
 				sender_signature: None,

--- a/libwallet/src/internal/tx.rs
+++ b/libwallet/src/internal/tx.rs
@@ -421,25 +421,27 @@ where
 	}
 
 	if let Some(ref p) = slate.clone().payment_proof {
-		let derivation_index = match context.payment_proof_derivation_index {
-			Some(i) => i,
-			None => 0,
-		};
-		let keychain = wallet.keychain(keychain_mask)?;
-		let parent_key_id = wallet.parent_key_id();
-		let excess = slate.calc_excess(keychain.secp())?;
-		let sender_key =
-			address::address_from_derivation_path(&keychain, &parent_key_id, derivation_index)?;
-		let sender_address = OnionV3Address::from_private(&sender_key.0)?;
-		let sig =
-			create_payment_proof_signature(slate.amount, &excess, p.sender_address, sender_key)?;
-		tx.payment_proof = Some(StoredProofInfo {
-			receiver_address: p.receiver_address,
-			receiver_signature: p.receiver_signature,
-			sender_address_path: derivation_index,
-			sender_address: sender_address.to_ed25519()?,
-			sender_signature: Some(sig),
-		})
+		if let Some(saddr) = p.sender_address {
+			let derivation_index = match context.payment_proof_derivation_index {
+				Some(i) => i,
+				None => 0,
+			};
+			let keychain = wallet.keychain(keychain_mask)?;
+			let parent_key_id = wallet.parent_key_id();
+			let excess = slate.calc_excess(keychain.secp())?;
+			let sender_key =
+				address::address_from_derivation_path(&keychain, &parent_key_id, derivation_index)?;
+			let sender_address = OnionV3Address::from_private(&sender_key.0)?;
+			let sig = create_payment_proof_signature(slate.amount, &excess, saddr, sender_key)?;
+			tx.payment_proof = Some(StoredProofInfo {
+				receiver_address: p.receiver_address,
+				receiver_signature: p.promise_signature,
+				sender_address_path: derivation_index,
+				sender_address: sender_address.to_ed25519()?,
+				sender_signature: Some(sig),
+			})
+		} else {
+		}
 	}
 
 	wallet.store_tx(&format!("{}", tx.tx_slate_id.unwrap()), slate.tx_or_err()?)?;
@@ -561,9 +563,15 @@ where
 		let orig_sender_sk =
 			address::address_from_derivation_path(&keychain, parent_key_id, index)?;
 		let orig_sender_address = OnionV3Address::from_private(&orig_sender_sk.0)?;
-		if p.sender_address != orig_sender_address.to_ed25519()? {
+		if let Some(saddr) = p.sender_address {
+			if saddr != orig_sender_address.to_ed25519()? {
+				return Err(Error::PaymentProof(
+					"Sender address on slate does not match original sender address".to_owned(),
+				));
+			}
+		} else {
 			return Err(Error::PaymentProof(
-				"Sender address on slate does not match original sender address".to_owned(),
+				"Sender address on slate is not provided".to_owned(),
 			));
 		}
 
@@ -577,7 +585,7 @@ where
 			&slate.calc_excess(&keychain.secp())?,
 			orig_sender_address.to_ed25519()?,
 		)?;
-		let sig = match p.receiver_signature {
+		let sig = match p.promise_signature {
 			Some(s) => s,
 			None => {
 				return Err(Error::PaymentProof(

--- a/libwallet/src/lib.rs
+++ b/libwallet/src/lib.rs
@@ -33,7 +33,7 @@ use grin_wallet_util as util;
 use blake2_rfc as blake2;
 
 #[macro_use]
-extern crate serde_derive;
+extern crate serde_with;
 #[macro_use]
 extern crate log;
 #[macro_use]

--- a/libwallet/src/slate.rs
+++ b/libwallet/src/slate.rs
@@ -28,6 +28,7 @@ use crate::grin_util::secp::key::{PublicKey, SecretKey};
 use crate::grin_util::secp::pedersen::Commitment;
 use crate::grin_util::secp::Signature;
 use crate::grin_util::{secp, static_secp_instance};
+use chrono::prelude::{DateTime, NaiveDateTime, Utc};
 use ed25519_dalek::PublicKey as DalekPublicKey;
 use ed25519_dalek::Signature as DalekSignature;
 use serde::ser::{Serialize, Serializer};
@@ -55,6 +56,10 @@ pub struct PaymentInfo {
 	pub receiver_address: DalekPublicKey,
 	/// Promise signature
 	pub promise_signature: Option<DalekSignature>,
+	/// Timestamp
+	pub timestamp: DateTime<Utc>,
+	/// Memo
+	pub memo: Option<[u8; 32]>,
 }
 
 /// Public data for each participant in the slate
@@ -893,6 +898,8 @@ impl From<&PaymentInfo> for PaymentInfoV4 {
 			sender_address,
 			receiver_address,
 			promise_signature: receiver_signature,
+			timestamp,
+			memo,
 		} = data;
 		let sender_address = *sender_address;
 		// TODO: If not provided and we need to downgrade to V4,
@@ -1124,6 +1131,8 @@ impl From<&PaymentInfoV4> for PaymentInfo {
 			sender_address: Some(sender_address),
 			receiver_address,
 			promise_signature: receiver_signature,
+			timestamp: DateTime::<Utc>::from_utc(NaiveDateTime::from_timestamp(0, 0), Utc),
+			memo: None,
 		}
 	}
 }

--- a/libwallet/src/slate.rs
+++ b/libwallet/src/slate.rs
@@ -895,10 +895,20 @@ impl From<&PaymentInfo> for PaymentInfoV4 {
 			promise_signature: receiver_signature,
 		} = data;
 		let sender_address = *sender_address;
+		// TODO: If not provided and we need to downgrade to V4,
+		// Provide a blank key insted. Consider whether this should fail
+		// instead, noting that `try_from`isn't currently used in any versioning
+		// logic
+		// Also note the zeroized ed25519 public key has a known private key, check if
+		// this could ever possibly become an issue
+		let saddr = match sender_address {
+			Some(a) => a,
+			None => DalekPublicKey::from_bytes(&[0u8; 32]).unwrap(),
+		};
 		let receiver_address = *receiver_address;
 		let receiver_signature = *receiver_signature;
 		PaymentInfoV4 {
-			saddr: sender_address,
+			saddr,
 			raddr: receiver_address,
 			rsig: receiver_signature,
 		}
@@ -1111,7 +1121,7 @@ impl From<&PaymentInfoV4> for PaymentInfo {
 		let receiver_address = *receiver_address;
 		let receiver_signature = *receiver_signature;
 		PaymentInfo {
-			sender_address,
+			sender_address: Some(sender_address),
 			receiver_address,
 			promise_signature: receiver_signature,
 		}

--- a/libwallet/src/slate.rs
+++ b/libwallet/src/slate.rs
@@ -66,7 +66,7 @@ pub struct PaymentInfo {
 	pub receiver_address: DalekPublicKey,
 	/// Promise signature
 	pub promise_signature: Option<DalekSignature>,
-	/// Timestamp
+	/// Timestamp (seconds)
 	pub timestamp: DateTime<Utc>,
 	/// Memo
 	pub memo: Option<PaymentMemo>,

--- a/libwallet/src/slate.rs
+++ b/libwallet/src/slate.rs
@@ -39,6 +39,10 @@ use crate::slate_versions::v4::{
 	CommitsV4, KernelFeaturesArgsV4, OutputFeaturesV4, ParticipantDataV4, PaymentInfoV4,
 	SlateStateV4, SlateV4, VersionCompatInfoV4,
 };
+use crate::slate_versions::v5::{
+	CommitsV5, KernelFeaturesArgsV5, OutputFeaturesV5, ParticipantDataV5, PaymentInfoV5,
+	SlateStateV5, SlateV5, VersionCompatInfoV5,
+};
 use crate::slate_versions::VersionedSlate;
 use crate::slate_versions::{CURRENT_SLATE_VERSION, GRIN_BLOCK_HEADER_VERSION};
 use crate::Context;
@@ -46,11 +50,11 @@ use crate::Context;
 #[derive(Debug, Clone)]
 pub struct PaymentInfo {
 	/// Sender address
-	pub sender_address: DalekPublicKey,
+	pub sender_address: Option<DalekPublicKey>,
 	/// Receiver address
 	pub receiver_address: DalekPublicKey,
-	/// Receiver signature
-	pub receiver_signature: Option<DalekSignature>,
+	/// Promise signature
+	pub promise_signature: Option<DalekSignature>,
 }
 
 /// Public data for each participant in the slate
@@ -888,7 +892,7 @@ impl From<&PaymentInfo> for PaymentInfoV4 {
 		let PaymentInfo {
 			sender_address,
 			receiver_address,
-			receiver_signature,
+			promise_signature: receiver_signature,
 		} = data;
 		let sender_address = *sender_address;
 		let receiver_address = *receiver_address;
@@ -908,6 +912,16 @@ impl From<OutputFeatures> for OutputFeaturesV4 {
 			OutputFeatures::Coinbase => 1,
 		};
 		OutputFeaturesV4(index)
+	}
+}
+
+impl From<OutputFeatures> for OutputFeaturesV5 {
+	fn from(of: OutputFeatures) -> OutputFeaturesV5 {
+		let index = match of {
+			OutputFeatures::Plain => 0,
+			OutputFeatures::Coinbase => 1,
+		};
+		OutputFeaturesV5(index)
 	}
 }
 
@@ -1099,7 +1113,7 @@ impl From<&PaymentInfoV4> for PaymentInfo {
 		PaymentInfo {
 			sender_address,
 			receiver_address,
-			receiver_signature,
+			promise_signature: receiver_signature,
 		}
 	}
 }

--- a/libwallet/src/slate_versions/mod.rs
+++ b/libwallet/src/slate_versions/mod.rs
@@ -21,6 +21,7 @@ use crate::slate::Slate;
 use crate::slate_versions::v4::{CoinbaseV4, SlateV4};
 use crate::slate_versions::v4_bin::SlateV4Bin;
 use crate::slate_versions::v5::{CoinbaseV5, SlateV5};
+use crate::slate_versions::v5_bin::SlateV5Bin;
 use crate::types::CbData;
 use crate::Error;
 use std::convert::TryFrom;
@@ -33,6 +34,8 @@ pub mod v4;
 pub mod v4_bin;
 #[allow(missing_docs)]
 pub mod v5;
+#[allow(missing_docs)]
+pub mod v5_bin;
 
 /// The most recent version of the slate
 pub const CURRENT_SLATE_VERSION: u16 = 5;
@@ -94,6 +97,8 @@ impl From<VersionedSlate> for Slate {
 pub enum VersionedBinSlate {
 	/// Version 4, binary
 	V4(SlateV4Bin),
+	/// Version 5, binary
+	V5(SlateV5Bin),
 }
 
 impl TryFrom<VersionedSlate> for VersionedBinSlate {
@@ -109,6 +114,7 @@ impl TryFrom<VersionedSlate> for VersionedBinSlate {
 impl From<VersionedBinSlate> for VersionedSlate {
 	fn from(slate: VersionedBinSlate) -> VersionedSlate {
 		match slate {
+			VersionedBinSlate::V5(s) => VersionedSlate::V5(s.0),
 			VersionedBinSlate::V4(s) => VersionedSlate::V4(s.0),
 		}
 	}

--- a/libwallet/src/slate_versions/mod.rs
+++ b/libwallet/src/slate_versions/mod.rs
@@ -30,6 +30,8 @@ pub mod ser;
 pub mod v4;
 #[allow(missing_docs)]
 pub mod v4_bin;
+#[allow(missing_docs)]
+pub mod v5;
 
 /// The most recent version of the slate
 pub const CURRENT_SLATE_VERSION: u16 = 4;

--- a/libwallet/src/slate_versions/ser.rs
+++ b/libwallet/src/slate_versions/ser.rs
@@ -472,7 +472,7 @@ pub mod option_dalek_sig_base64 {
 	}
 }
 
-/// Serializes slates 'version_info' field
+/// Serializes slates 'version_info' field - V4
 pub mod version_info_v4 {
 	use serde::de::Error;
 	use serde::{Deserialize, Deserializer, Serializer};
@@ -514,7 +514,49 @@ pub mod version_info_v4 {
 	}
 }
 
-/// Serializes slates 'state' field
+/// Serializes slates 'version_info' field - V5
+pub mod version_info_v5 {
+	use serde::de::Error;
+	use serde::{Deserialize, Deserializer, Serializer};
+
+	use crate::slate_versions::v5::VersionCompatInfoV5;
+
+	///
+	pub fn serialize<S>(v: &VersionCompatInfoV5, serializer: S) -> Result<S::Ok, S::Error>
+	where
+		S: Serializer,
+	{
+		serializer.serialize_str(&format!("{}:{}", v.version, v.block_header_version))
+	}
+
+	///
+	pub fn deserialize<'de, D>(deserializer: D) -> Result<VersionCompatInfoV5, D::Error>
+	where
+		D: Deserializer<'de>,
+	{
+		String::deserialize(deserializer).and_then(|s| {
+			let mut retval = VersionCompatInfoV5 {
+				version: 0,
+				block_header_version: 0,
+			};
+			let v: Vec<&str> = s.split(':').collect();
+			if v.len() != 2 {
+				return Err(Error::custom("Cannot parse version"));
+			}
+			match u16::from_str_radix(v[0], 10) {
+				Ok(u) => retval.version = u,
+				Err(e) => return Err(Error::custom(format!("Cannot parse version: {}", e))),
+			}
+			match u16::from_str_radix(v[1], 10) {
+				Ok(u) => retval.block_header_version = u,
+				Err(e) => return Err(Error::custom(format!("Cannot parse version: {}", e))),
+			}
+			Ok(retval)
+		})
+	}
+}
+
+/// Serializes slates 'state' field - V4
 pub mod slate_state_v4 {
 	use serde::de::Error;
 	use serde::{Deserialize, Deserializer, Serializer};
@@ -552,6 +594,51 @@ pub mod slate_state_v4 {
 				"I1" => SlateStateV4::Invoice1,
 				"I2" => SlateStateV4::Invoice2,
 				"I3" => SlateStateV4::Invoice3,
+				_ => return Err(Error::custom("Invalid Slate state")),
+			};
+			Ok(retval)
+		})
+	}
+}
+
+/// Serializes slates 'state' field - V5
+pub mod slate_state_v5 {
+	use serde::de::Error;
+	use serde::{Deserialize, Deserializer, Serializer};
+
+	use crate::slate_versions::v5::SlateStateV5;
+
+	///
+	pub fn serialize<S>(st: &SlateStateV5, serializer: S) -> Result<S::Ok, S::Error>
+	where
+		S: Serializer,
+	{
+		let label = match st {
+			SlateStateV5::Unknown => "NA",
+			SlateStateV5::Standard1 => "S1",
+			SlateStateV5::Standard2 => "S2",
+			SlateStateV5::Standard3 => "S3",
+			SlateStateV5::Invoice1 => "I1",
+			SlateStateV5::Invoice2 => "I2",
+			SlateStateV5::Invoice3 => "I3",
+		};
+		serializer.serialize_str(label)
+	}
+
+	///
+	pub fn deserialize<'de, D>(deserializer: D) -> Result<SlateStateV5, D::Error>
+	where
+		D: Deserializer<'de>,
+	{
+		String::deserialize(deserializer).and_then(|s| {
+			let retval = match s.as_str() {
+				"NA" => SlateStateV5::Unknown,
+				"S1" => SlateStateV5::Standard1,
+				"S2" => SlateStateV5::Standard2,
+				"S3" => SlateStateV5::Standard3,
+				"I1" => SlateStateV5::Invoice1,
+				"I2" => SlateStateV5::Invoice2,
+				"I3" => SlateStateV5::Invoice3,
 				_ => return Err(Error::custom("Invalid Slate state")),
 			};
 			Ok(retval)

--- a/libwallet/src/slate_versions/v5.rs
+++ b/libwallet/src/slate_versions/v5.rs
@@ -1,0 +1,359 @@
+// Copyright 2023 The Grin Developers
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+//! Contains V5 of the slate (version as yet undetermined)
+//!
+//! TODO: Should be considered experimental and remain in an experimental branch
+//! until such time as the relevant RFCs are accepted
+//!
+//! Changes from V4:
+//! #### Top-Level Slate Struct
+//! *
+//! #### PaymentInfoV5
+//! * `saddr`, i.e. `sender_address` in main Slate becomes optional
+//! * `rsig` is renamed to `psig`, corresponding to rename of `receiver_signature` to `promise_signature` in main Slate
+//!
+
+use crate::grin_core::core::FeeFields;
+use crate::grin_core::core::{Input, Output, TxKernel};
+use crate::grin_core::libtx::secp_ser;
+use crate::grin_keychain::{BlindingFactor, Identifier};
+use crate::grin_util::secp;
+use crate::grin_util::secp::key::PublicKey;
+use crate::grin_util::secp::pedersen::{Commitment, RangeProof};
+use crate::grin_util::secp::Signature;
+use crate::{slate_versions::ser, CbData};
+use ed25519_dalek::PublicKey as DalekPublicKey;
+use ed25519_dalek::Signature as DalekSignature;
+use uuid::Uuid;
+
+#[derive(Serialize, Deserialize, Debug, Clone)]
+pub struct SlateV5 {
+	// Required Fields
+	/// Versioning info
+	#[serde(with = "ser::version_info_v5")]
+	pub ver: VersionCompatInfoV5,
+	/// Unique transaction ID, selected by sender
+	pub id: Uuid,
+	/// Slate state
+	#[serde(with = "ser::slate_state_v5")]
+	pub sta: SlateStateV5,
+	/// Offset, modified by each participant inserting inputs
+	/// as the transaction progresses
+	#[serde(
+		serialize_with = "secp_ser::as_hex",
+		deserialize_with = "secp_ser::blind_from_hex"
+	)]
+	#[serde(default = "default_offset_zero")]
+	#[serde(skip_serializing_if = "offset_is_zero")]
+	pub off: BlindingFactor,
+	// Optional fields depending on state
+	/// The number of participants intended to take part in this transaction
+	#[serde(default = "default_num_participants_2")]
+	#[serde(skip_serializing_if = "num_parts_is_2")]
+	pub num_parts: u8,
+	/// base amount (excluding fee)
+	#[serde(with = "secp_ser::string_or_u64")]
+	#[serde(skip_serializing_if = "u64_is_blank")]
+	#[serde(default = "default_u64_0")]
+	pub amt: u64,
+	/// fee
+	#[serde(skip_serializing_if = "fee_is_zero")]
+	#[serde(default = "default_fee")]
+	pub fee: FeeFields,
+	/// kernel features, if any
+	#[serde(skip_serializing_if = "u8_is_blank")]
+	#[serde(default = "default_u8_0")]
+	pub feat: u8,
+	/// TTL, the block height at which wallets
+	/// should refuse to process the transaction and unlock all
+	#[serde(with = "secp_ser::string_or_u64")]
+	#[serde(skip_serializing_if = "u64_is_blank")]
+	#[serde(default = "default_u64_0")]
+	pub ttl: u64,
+	// Structs always required
+	/// Participant data, each participant in the transaction will
+	/// insert their public data here. For now, 0 is sender and 1
+	/// is receiver, though this will change for multi-party
+	pub sigs: Vec<ParticipantDataV5>,
+	// Situational, but required at some point in the tx
+	/// Inputs/Output commits added to slate
+	#[serde(default = "default_coms_none")]
+	#[serde(skip_serializing_if = "Option::is_none")]
+	pub coms: Option<Vec<CommitsV5>>,
+	// Optional Structs
+	/// Payment Proof
+	#[serde(default = "default_payment_none")]
+	#[serde(skip_serializing_if = "Option::is_none")]
+	pub proof: Option<PaymentInfoV5>,
+	/// Kernel features arguments
+	#[serde(default = "default_kernel_features_none")]
+	#[serde(skip_serializing_if = "Option::is_none")]
+	pub feat_args: Option<KernelFeaturesArgsV5>,
+}
+
+fn default_payment_none() -> Option<PaymentInfoV5> {
+	None
+}
+
+fn default_offset_zero() -> BlindingFactor {
+	BlindingFactor::zero()
+}
+
+fn offset_is_zero(o: &BlindingFactor) -> bool {
+	*o == BlindingFactor::zero()
+}
+
+fn default_coms_none() -> Option<Vec<CommitsV5>> {
+	None
+}
+
+fn default_u64_0() -> u64 {
+	0
+}
+
+fn num_parts_is_2(n: &u8) -> bool {
+	*n == 2
+}
+
+fn default_num_participants_2() -> u8 {
+	2
+}
+
+fn default_kernel_features_none() -> Option<KernelFeaturesArgsV5> {
+	None
+}
+
+/// Slate state definition
+#[derive(Serialize, Deserialize, Debug, Clone)]
+pub enum SlateStateV5 {
+	/// Unknown, coming from earlier versions of the slate
+	Unknown,
+	/// Standard flow, freshly init
+	Standard1,
+	/// Standard flow, return journey
+	Standard2,
+	/// Standard flow, ready for transaction posting
+	Standard3,
+	/// Invoice flow, freshly init
+	Invoice1,
+	///Invoice flow, return journey
+	Invoice2,
+	/// Invoice flow, ready for tranasction posting
+	Invoice3,
+}
+
+#[derive(Serialize, Deserialize, Debug, Clone, PartialEq, Eq)]
+/// Kernel features arguments definition
+pub struct KernelFeaturesArgsV5 {
+	/// Lock height, for HeightLocked
+	pub lock_hgt: u64,
+}
+
+#[derive(Serialize, Deserialize, Debug, Clone, PartialEq, Eq)]
+pub struct VersionCompatInfoV5 {
+	/// The current version of the slate format
+	pub version: u16,
+	/// Version of grin block header this slate is compatible with
+	pub block_header_version: u16,
+}
+
+#[derive(Serialize, Deserialize, Debug, Clone, PartialEq, Eq)]
+pub struct ParticipantDataV5 {
+	/// Public key corresponding to private blinding factor
+	#[serde(with = "secp_ser::pubkey_serde")]
+	pub xs: PublicKey,
+	/// Public key corresponding to private nonce
+	#[serde(with = "secp_ser::pubkey_serde")]
+	pub nonce: PublicKey,
+	/// Public partial signature
+	#[serde(default = "default_part_sig_none")]
+	#[serde(skip_serializing_if = "Option::is_none")]
+	#[serde(with = "secp_ser::option_sig_serde")]
+	pub part: Option<Signature>,
+}
+
+fn default_part_sig_none() -> Option<Signature> {
+	None
+}
+
+#[derive(Serialize, Deserialize, Debug, Clone, Eq, PartialEq)]
+pub struct PaymentInfoV5 {
+	#[serde(with = "ser::dalek_pubkey_serde")]
+	pub saddr: DalekPublicKey,
+	#[serde(with = "ser::dalek_pubkey_serde")]
+	pub raddr: DalekPublicKey,
+	#[serde(default = "default_promise_signature_none")]
+	#[serde(with = "ser::option_dalek_sig_serde")]
+	#[serde(skip_serializing_if = "Option::is_none")]
+	pub psig: Option<DalekSignature>,
+}
+
+fn default_promise_signature_none() -> Option<DalekSignature> {
+	None
+}
+
+#[derive(Debug, Copy, Clone, Serialize, Deserialize)]
+pub struct CommitsV5 {
+	/// Options for an output's structure or use
+	#[serde(default = "default_output_feature")]
+	#[serde(skip_serializing_if = "output_feature_is_plain")]
+	pub f: OutputFeaturesV5,
+	/// The homomorphic commitment representing the output amount
+	#[serde(
+		serialize_with = "secp_ser::as_hex",
+		deserialize_with = "secp_ser::commitment_from_hex"
+	)]
+	pub c: Commitment,
+	/// A proof that the commitment is in the right range
+	/// Only applies for transaction outputs
+	#[serde(with = "ser::option_rangeproof_hex")]
+	#[serde(default = "default_range_proof")]
+	#[serde(skip_serializing_if = "Option::is_none")]
+	pub p: Option<RangeProof>,
+}
+
+impl From<&Output> for CommitsV5 {
+	fn from(out: &Output) -> CommitsV5 {
+		CommitsV5 {
+			f: out.features().into(),
+			c: out.commitment(),
+			p: Some(out.proof()),
+		}
+	}
+}
+
+// This will need to be reworked once we no longer support input features with "commit only" inputs.
+impl From<&Input> for CommitsV5 {
+	fn from(input: &Input) -> CommitsV5 {
+		CommitsV5 {
+			f: input.features.into(),
+			c: input.commitment(),
+			p: None,
+		}
+	}
+}
+
+fn default_output_feature() -> OutputFeaturesV5 {
+	OutputFeaturesV5(0)
+}
+
+fn output_feature_is_plain(o: &OutputFeaturesV5) -> bool {
+	o.0 == 0
+}
+
+#[derive(Serialize, Deserialize, Copy, Debug, Clone, PartialEq, Eq)]
+pub struct OutputFeaturesV5(pub u8);
+
+pub fn sig_is_blank(s: &secp::Signature) -> bool {
+	for b in s.to_raw_data().iter() {
+		if *b != 0 {
+			return false;
+		}
+	}
+	true
+}
+
+fn default_range_proof() -> Option<RangeProof> {
+	None
+}
+
+fn u64_is_blank(u: &u64) -> bool {
+	*u == 0
+}
+
+fn default_u8_0() -> u8 {
+	0
+}
+
+fn u8_is_blank(u: &u8) -> bool {
+	*u == 0
+}
+
+fn fee_is_zero(f: &FeeFields) -> bool {
+	f.is_zero()
+}
+
+fn default_fee() -> FeeFields {
+	FeeFields::zero()
+}
+
+/// A mining node requests new coinbase via the foreign api every time a new candidate block is built.
+#[derive(Serialize, Deserialize, Debug, Clone)]
+pub struct CoinbaseV5 {
+	/// Output
+	output: CbOutputV5,
+	/// Kernel
+	kernel: CbKernelV5,
+	/// Key Id
+	key_id: Option<Identifier>,
+}
+
+impl From<CbData> for CoinbaseV5 {
+	fn from(cb: CbData) -> CoinbaseV5 {
+		CoinbaseV5 {
+			output: CbOutputV5::from(&cb.output),
+			kernel: CbKernelV5::from(&cb.kernel),
+			key_id: cb.key_id,
+		}
+	}
+}
+
+impl From<&Output> for CbOutputV5 {
+	fn from(output: &Output) -> CbOutputV5 {
+		CbOutputV5 {
+			features: CbOutputFeatures::Coinbase,
+			commit: output.commitment(),
+			proof: output.proof(),
+		}
+	}
+}
+
+impl From<&TxKernel> for CbKernelV5 {
+	fn from(kernel: &TxKernel) -> CbKernelV5 {
+		CbKernelV5 {
+			features: CbKernelFeatures::Coinbase,
+			excess: kernel.excess,
+			excess_sig: kernel.excess_sig,
+		}
+	}
+}
+
+#[derive(Debug, Copy, Clone, Serialize, Deserialize)]
+enum CbOutputFeatures {
+	Coinbase,
+}
+
+#[derive(Debug, Copy, Clone, Serialize, Deserialize)]
+enum CbKernelFeatures {
+	Coinbase,
+}
+
+#[derive(Debug, Copy, Clone, Serialize, Deserialize)]
+struct CbOutputV5 {
+	features: CbOutputFeatures,
+	#[serde(serialize_with = "secp_ser::as_hex")]
+	commit: Commitment,
+	#[serde(serialize_with = "secp_ser::as_hex")]
+	proof: RangeProof,
+}
+
+#[derive(Serialize, Deserialize, Debug, Clone)]
+struct CbKernelV5 {
+	features: CbKernelFeatures,
+	#[serde(serialize_with = "secp_ser::as_hex")]
+	excess: Commitment,
+	#[serde(with = "secp_ser::sig_serde")]
+	excess_sig: secp::Signature,
+}

--- a/libwallet/src/slate_versions/v5.rs
+++ b/libwallet/src/slate_versions/v5.rs
@@ -38,6 +38,7 @@ use crate::{slate_versions::ser, CbData};
 use chrono::prelude::{DateTime, Utc};
 use ed25519_dalek::PublicKey as DalekPublicKey;
 use ed25519_dalek::Signature as DalekSignature;
+use serde_with::TimestampSeconds;
 use uuid::Uuid;
 
 #[derive(Serialize, Deserialize, Debug, Clone)]
@@ -200,12 +201,14 @@ pub struct PaymentMemoV5 {
 	pub memo: [u8; 32],
 }
 
+#[serde_as]
 #[derive(Serialize, Deserialize, Debug, Clone, Eq, PartialEq)]
 pub struct PaymentInfoV5 {
 	#[serde(with = "ser::dalek_pubkey_serde")]
 	pub saddr: DalekPublicKey,
 	#[serde(with = "ser::dalek_pubkey_serde")]
 	pub raddr: DalekPublicKey,
+	#[serde_as(as = "TimestampSeconds<i64>")]
 	pub ts: DateTime<Utc>,
 	#[serde(default = "default_promise_signature_none")]
 	#[serde(with = "ser::option_dalek_sig_serde")]

--- a/libwallet/src/slate_versions/v5.rs
+++ b/libwallet/src/slate_versions/v5.rs
@@ -23,8 +23,13 @@
 //! #### PaymentInfoV5
 //! * `saddr`, i.e. `sender_address` in main Slate becomes optional
 //! * `rsig` is renamed to `psig`, corresponding to rename of `receiver_signature` to `promise_signature` in main Slate
-//! * `ts` added (`timestamp` in main Slate) (Epoch Time)
-//! * `memo` added as optional [u8;32]
+//!
+//! * `ts` added (`timestamp` in main slate). Serialized as i64 representing epoch time in seconds
+//! * `memo` added as optional MemoV5 Struct, which contains:
+//!   * `memo_type`: u8
+//!      * 0x00 = payment details directly embedded
+//!      * 0x01 = Blake2b hash of an arbitrary invoice document
+//!   * `memo`: [u8;32] the memo data itself
 
 use crate::grin_core::core::FeeFields;
 use crate::grin_core::core::{Input, Output, TxKernel};

--- a/libwallet/src/slate_versions/v5.rs
+++ b/libwallet/src/slate_versions/v5.rs
@@ -190,19 +190,29 @@ fn default_part_sig_none() -> Option<Signature> {
 	None
 }
 
+#[derive(Serialize, Deserialize, Debug, Clone, PartialEq, Eq)]
+pub struct PaymentMemoV5 {
+	// The type of memo
+	// 0x00 is directly embedded additional payment details
+	// 0x01 represents the blake2b hash of an arbitrary invoice document
+	pub memo_type: u8,
+	// memo data itself
+	pub memo: [u8; 32],
+}
+
 #[derive(Serialize, Deserialize, Debug, Clone, Eq, PartialEq)]
 pub struct PaymentInfoV5 {
 	#[serde(with = "ser::dalek_pubkey_serde")]
 	pub saddr: DalekPublicKey,
 	#[serde(with = "ser::dalek_pubkey_serde")]
 	pub raddr: DalekPublicKey,
+	pub ts: DateTime<Utc>,
 	#[serde(default = "default_promise_signature_none")]
 	#[serde(with = "ser::option_dalek_sig_serde")]
 	#[serde(skip_serializing_if = "Option::is_none")]
 	pub psig: Option<DalekSignature>,
-	pub ts: DateTime<Utc>,
 	#[serde(skip_serializing_if = "Option::is_none")]
-	pub memo: Option<String>,
+	pub memo: Option<PaymentMemoV5>,
 }
 
 fn default_promise_signature_none() -> Option<DalekSignature> {

--- a/libwallet/src/slate_versions/v5.rs
+++ b/libwallet/src/slate_versions/v5.rs
@@ -35,7 +35,7 @@ use crate::grin_util::secp::key::PublicKey;
 use crate::grin_util::secp::pedersen::{Commitment, RangeProof};
 use crate::grin_util::secp::Signature;
 use crate::{slate_versions::ser, CbData};
-use chrono::prelude::{DateTime, NaiveDateTime, Utc};
+use chrono::prelude::{DateTime, Utc};
 use ed25519_dalek::PublicKey as DalekPublicKey;
 use ed25519_dalek::Signature as DalekSignature;
 use uuid::Uuid;

--- a/libwallet/src/slate_versions/v5.rs
+++ b/libwallet/src/slate_versions/v5.rs
@@ -23,7 +23,8 @@
 //! #### PaymentInfoV5
 //! * `saddr`, i.e. `sender_address` in main Slate becomes optional
 //! * `rsig` is renamed to `psig`, corresponding to rename of `receiver_signature` to `promise_signature` in main Slate
-//!
+//! * `ts` added (`timestamp` in main Slate) (Epoch Time)
+//! * `memo` added as optional [u8;32]
 
 use crate::grin_core::core::FeeFields;
 use crate::grin_core::core::{Input, Output, TxKernel};
@@ -34,6 +35,7 @@ use crate::grin_util::secp::key::PublicKey;
 use crate::grin_util::secp::pedersen::{Commitment, RangeProof};
 use crate::grin_util::secp::Signature;
 use crate::{slate_versions::ser, CbData};
+use chrono::prelude::{DateTime, NaiveDateTime, Utc};
 use ed25519_dalek::PublicKey as DalekPublicKey;
 use ed25519_dalek::Signature as DalekSignature;
 use uuid::Uuid;
@@ -198,6 +200,9 @@ pub struct PaymentInfoV5 {
 	#[serde(with = "ser::option_dalek_sig_serde")]
 	#[serde(skip_serializing_if = "Option::is_none")]
 	pub psig: Option<DalekSignature>,
+	pub ts: DateTime<Utc>,
+	#[serde(skip_serializing_if = "Option::is_none")]
+	pub memo: Option<String>,
 }
 
 fn default_promise_signature_none() -> Option<DalekSignature> {

--- a/libwallet/src/slate_versions/v5_bin.rs
+++ b/libwallet/src/slate_versions/v5_bin.rs
@@ -234,6 +234,7 @@ impl<'a> Writeable for ProofWrapRef<'a> {
 		}
 		match &self.0.memo {
 			Some(s) => {
+				writer.write_u8(1)?;
 				writer.write_u8(s.memo_type)?;
 				writer.write_fixed_bytes(&s.memo)?;
 			}
@@ -487,13 +488,16 @@ fn slate_v5_serialize_deserialize() {
 	let b = from_hex(raw_pubkey_str).unwrap();
 	let d_pkey = DalekPublicKey::from_bytes(&b).unwrap();
 	let ts = Utc::now();
+	let pm = PaymentMemoV5 {
+		memo_type: 0,
+		memo: [9; 32],
+	};
 	v5.proof = Some(PaymentInfoV5 {
 		raddr: d_pkey.clone(),
 		saddr: d_pkey.clone(),
 		ts: ts.clone(),
 		psig: None,
-		// TODO: Just getting things to compile, need to focus on testing this part
-		memo: None,
+		memo: Some(pm),
 	});
 	v5.coms = None;
 	let v5_1 = v5.clone();

--- a/libwallet/src/slate_versions/v5_bin.rs
+++ b/libwallet/src/slate_versions/v5_bin.rs
@@ -487,7 +487,9 @@ fn slate_v5_serialize_deserialize() {
 	let raw_pubkey_str = "d03c09e9c19bb74aa9ea44e0fe5ae237a9bf40bddf0941064a80913a4459c8bb";
 	let b = from_hex(raw_pubkey_str).unwrap();
 	let d_pkey = DalekPublicKey::from_bytes(&b).unwrap();
-	let ts = Utc::now();
+	// Need to remove milliseconds component for comparison. Won't be serialized
+	let ts = NaiveDateTime::from_timestamp(Utc::now().timestamp(), 0);
+	let ts = DateTime::<Utc>::from_utc(ts, Utc);
 	let pm = PaymentMemoV5 {
 		memo_type: 0,
 		memo: [9; 32],


### PR DESCRIPTION
Slate V5 changes in order to provide experimental support to [Early Payment Proofs](https://github.com/mimblewimble/grin-rfcs/pull/70#pullrequestreview-1352319887) for use with contract transaction workflows. This aims to provide the new slate fields in a V5 Slate as well as provide all needed v4 conversions and tests. 

Specific slate changes are [WIP]:

PaymentInfoV5 Struct
* `saddr`, i.e. `sender_address` in main Slate becomes optional
* `rsig` is renamed to `psig`, corresponding to rename of `receiver_signature` to `promise_signature` in main Slate
* `ts` added (`timestamp` in main slate). Serialized as i64 representing epoch time in seconds
* `memo` added as optional MemoV5 Struct, which contains:
   * `memo_type`: u8
      * 0x00 = payment details directly embedded
      * 0x01 = Blake2b hash of an arbitrary invoice document
   * `memo`: [u8;32] the memo data itself

* [WIP] Outstanding task remains to implement additional tests that convert back and forth between slate versions.



