### PR TITLE
CI update - Ubuntu Image

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -30,7 +30,7 @@ variables:
 jobs:
 - job: linux
   pool:
-    vmImage: ubuntu-18.04
+    vmImage: ubuntu-22.04
   strategy:
     matrix:
       config/libwallet/api:


### PR DESCRIPTION
Ubuntu image 18.04 has been deprecated by azure pipelines. This updates the CI build to use latest ubuntu image 22.04.