### PR TITLE
Update CI Badge on README.MD

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-[![Build Status](https://dev.azure.com/mimblewimble/grin-wallet/_apis/build/status/mimblewimble.grin-wallet?branchName=master)](https://dev.azure.com/mimblewimble/grin-wallet/_build/latest?definitionId=3&branchName=master)
+[![Continuous Integration](https://github.com/mimblewimble/grin-wallet/actions/workflows/ci.yaml/badge.svg)](https://github.com/mimblewimble/grin-wallet/actions/workflows/ci.yaml)
 [![Coverage Status](https://img.shields.io/codecov/c/github/mimblewimble/grin-wallet/master.svg)](https://codecov.io/gh/mimblewimble/grin-wallet)
 [![Chat](https://img.shields.io/gitter/room/grin_community/Lobby.svg)](https://gitter.im/grin_community/Lobby)
 [![Support](https://img.shields.io/badge/support-on%20gitter-brightgreen.svg)](https://gitter.im/grin_community/support)


### PR DESCRIPTION
As titled. Replace Azure Pipelines by Github Actions Badge.