### PR TITLE
Contracts - Test fixes + warning cleanups

### DIFF
--- a/api/src/foreign.rs
+++ b/api/src/foreign.rs
@@ -483,13 +483,12 @@ where
 	/// TODO
 	pub fn verify_payment_proof_invoice(
 		&self,
-		keychain_mask: Option<&SecretKey>,
 		recipient_address: &DalekPublicKey,
 		proof: &InvoiceProof,
 	) -> Result<(), Error> {
 		let mut w_lock = self.wallet_inst.lock();
 		let w = w_lock.lc_provider()?.wallet_inst()?;
-		foreign::verify_payment_proof_invoice(&mut **w, keychain_mask, recipient_address, proof)
+		foreign::verify_payment_proof_invoice(&mut **w, recipient_address, proof)
 	}
 }
 

--- a/api/src/owner_rpc.rs
+++ b/api/src/owner_rpc.rs
@@ -513,21 +513,43 @@ pub trait OwnerRpc {
 	```
 	*/
 
+	/**
+	   TODO: Full docs once API has stabilised
+	*/
 	fn init_send_tx(&self, token: Token, args: InitTxArgs) -> Result<VersionedSlate, Error>;
-	fn contract_new(&self, token: Token, args: ContractNewArgsAPI)
-		-> Result<VersionedSlate, Error>;
+
+	/**
+	   TODO: Implement
+	*/
 	// fn contract_setup(
 	// 	&self,
 	// 	token: Token,
 	// 	slate: VersionedSlate,
 	// 	args: ContractSetupArgsAPI,
 	// ) -> Result<VersionedSlate, Error>;
+
+	/**
+	   TODO: Full docs once API has stabilised
+	*/
+
+	fn contract_new(&self, token: Token, args: ContractNewArgsAPI)
+		-> Result<VersionedSlate, Error>;
+
+	/**
+	   TODO: Full docs once API has stabilised
+	*/
+
 	fn contract_sign(
 		&self,
 		token: Token,
 		slate: VersionedSlate,
 		args: ContractSetupArgsAPI,
 	) -> Result<VersionedSlate, Error>;
+
+	/**
+	   TODO: Full docs once API has stabilised
+	*/
+
 	fn contract_revoke(
 		&self,
 		token: Token,

--- a/controller/tests/common/mod.rs
+++ b/controller/tests/common/mod.rs
@@ -184,6 +184,7 @@ pub fn open_local_wallet(
 }
 
 // Creates the given number of wallets and spawns a thread that runs the wallet proxy
+#[allow(dead_code)]
 pub fn create_wallets(
 	wallets_def: Vec<Vec<(&'static str, u64)>>, // a vector of boolean that represent whether we mine into a wallet
 	test_dir: &'static str,

--- a/controller/tests/contract_accounts.rs
+++ b/controller/tests/contract_accounts.rs
@@ -24,9 +24,8 @@ use self::core::global;
 use self::keychain::{ExtKeychain, Keychain};
 use grin_wallet_libwallet as libwallet;
 use impls::test_framework::{self};
-use libwallet::contract::my_fee_contribution;
 use libwallet::contract::types::{ContractNewArgsAPI, ContractSetupArgsAPI};
-use libwallet::{Slate, SlateState, TxLogEntryType};
+use libwallet::{Slate, SlateState};
 use std::sync::atomic::Ordering;
 use std::thread;
 use std::time::Duration;
@@ -38,7 +37,7 @@ use common::{clean_output_dir, create_wallets, setup};
 /// contract accounts testing (mostly the same as accounts.rs)
 fn contract_accounts_impl(test_dir: &'static str) -> Result<(), libwallet::Error> {
 	// create two wallets with some extra accounts and don't mine anything in them
-	let (wallets, chain, stopper, mut bh) = create_wallets(
+	let (wallets, chain, stopper, _bh) = create_wallets(
 		vec![
 			vec![
 				("default", 0),
@@ -184,7 +183,6 @@ fn contract_accounts_impl(test_dir: &'static str) -> Result<(), libwallet::Error
 		api.post_tx(m, &slate, false)?;
 		Ok(())
 	})?;
-	bh += 1;
 
 	wallet::controller::owner_single_use(Some(wallet1.clone()), mask1, None, |api, m| {
 		let (wallet1_refreshed, wallet1_info) = api.retrieve_summary_info(m, true, 1)?;

--- a/controller/tests/contract_accounts_switch.rs
+++ b/controller/tests/contract_accounts_switch.rs
@@ -18,15 +18,10 @@ extern crate grin_wallet_impls as impls;
 extern crate log;
 
 use grin_core as core;
-use grin_keychain as keychain;
-
-use self::core::global;
-use self::keychain::{ExtKeychain, Keychain};
 use grin_wallet_libwallet as libwallet;
-use impls::test_framework::{self};
 use libwallet::contract::my_fee_contribution;
 use libwallet::contract::types::{ContractNewArgsAPI, ContractSetupArgsAPI};
-use libwallet::{Slate, SlateState, TxLogEntryType};
+use libwallet::{Slate, SlateState};
 use std::sync::atomic::Ordering;
 use std::thread;
 use std::time::Duration;
@@ -38,7 +33,7 @@ use common::{clean_output_dir, create_wallets, setup};
 /// contract accounts testing when switching between accounts during transaction building
 fn contract_accounts_switch_impl(test_dir: &'static str) -> Result<(), libwallet::Error> {
 	// create two wallets with some extra accounts and don't mine anything in them
-	let (wallets, chain, stopper, mut bh) = create_wallets(
+	let (wallets, _chain, stopper, _bh) = create_wallets(
 		vec![
 			vec![("default", 0), ("account1", 1), ("account2", 2)],
 			vec![("default", 0), ("account1", 3), ("account2", 4)],

--- a/controller/tests/contract_accounts_switch.rs
+++ b/controller/tests/contract_accounts_switch.rs
@@ -113,10 +113,11 @@ fn contract_accounts_switch_impl(test_dir: &'static str) -> Result<(), libwallet
 	}
 	wallet::controller::owner_single_use(Some(wallet2.clone()), mask2, None, |api, m| {
 		// Receive wallet calls --receive=5
-		let args = &ContractSetupArgsAPI {
+		let args = &mut ContractSetupArgsAPI {
 			net_change: Some(5_000_000_000),
 			..Default::default()
 		};
+		args.proof_args.suppress_proof = true;
 		slate = api.contract_sign(m, &slate, args)?;
 		Ok(())
 	})?;

--- a/controller/tests/contract_early_lock.rs
+++ b/controller/tests/contract_early_lock.rs
@@ -20,10 +20,9 @@ extern crate log;
 use grin_wallet_libwallet as libwallet;
 
 use grin_core::consensus;
-use impls::test_framework::{self};
 use libwallet::contract::my_fee_contribution;
-use libwallet::contract::types::{ContractNewArgsAPI, ContractSetupArgsAPI, OutputSelectionArgs};
-use libwallet::{OutputCommitMapping, OutputStatus, Slate, SlateState, TxLogEntryType};
+use libwallet::contract::types::{ContractNewArgsAPI, ContractSetupArgsAPI};
+use libwallet::{OutputStatus, Slate, SlateState};
 use std::sync::atomic::Ordering;
 use std::thread;
 use std::time::Duration;
@@ -35,7 +34,7 @@ use common::{clean_output_dir, create_wallets, setup};
 /// contract new with --add-outputs
 fn contract_early_lock_tx_impl(test_dir: &'static str) -> Result<(), libwallet::Error> {
 	// create a single wallet and mine 5 blocks
-	let (wallets, chain, stopper, mut bh) =
+	let (wallets, _chain, stopper, _bh) =
 		create_wallets(vec![vec![("default", 5)]], test_dir).unwrap();
 	let send_wallet = wallets[0].0.clone();
 	let send_mask = wallets[0].1.as_ref();

--- a/controller/tests/contract_rsr.rs
+++ b/controller/tests/contract_rsr.rs
@@ -45,13 +45,14 @@ fn contract_rsr_tx_impl(test_dir: &'static str) -> Result<(), libwallet::Error> 
 
 	wallet::controller::owner_single_use(Some(recv_wallet.clone()), recv_mask, None, |api, m| {
 		// Receive wallet inititates an invoice transaction with --receive=5
-		let args = &ContractNewArgsAPI {
+		let args = &mut ContractNewArgsAPI {
 			setup_args: ContractSetupArgsAPI {
 				net_change: Some(5_000_000_000),
 				..Default::default()
 			},
 			..Default::default()
 		};
+		args.setup_args.proof_args.suppress_proof = true;
 		slate = api.contract_new(m, args)?;
 		Ok(())
 	})?;
@@ -70,9 +71,11 @@ fn contract_rsr_tx_impl(test_dir: &'static str) -> Result<(), libwallet::Error> 
 
 	// Receive wallet finalizes and posts
 	wallet::controller::owner_single_use(Some(recv_wallet.clone()), recv_mask, None, |api, m| {
-		let args = &ContractSetupArgsAPI {
+		let args = &mut ContractSetupArgsAPI {
 			..Default::default()
 		};
+		// TODO: This possibly shouldn't be needed here if no proof?
+		args.proof_args.suppress_proof = true;
 		slate = api.contract_sign(m, &slate, args)?;
 		Ok(())
 	})?;

--- a/controller/tests/contract_srs.rs
+++ b/controller/tests/contract_srs.rs
@@ -45,7 +45,7 @@ fn contract_srs_tx_impl(test_dir: &'static str) -> Result<(), libwallet::Error> 
 
 	wallet::controller::owner_single_use(Some(send_wallet.clone()), send_mask, None, |api, m| {
 		// Send wallet inititates a standard transaction with --send=5
-		let args = &ContractNewArgsAPI {
+		let args = &mut ContractNewArgsAPI {
 			setup_args: ContractSetupArgsAPI {
 				net_change: Some(-5_000_000_000),
 				..Default::default()
@@ -59,10 +59,11 @@ fn contract_srs_tx_impl(test_dir: &'static str) -> Result<(), libwallet::Error> 
 
 	wallet::controller::owner_single_use(Some(recv_wallet.clone()), recv_mask, None, |api, m| {
 		// Receive wallet calls --receive=5
-		let args = &ContractSetupArgsAPI {
+		let args = &mut ContractSetupArgsAPI {
 			net_change: Some(5_000_000_000),
 			..Default::default()
 		};
+		args.proof_args.suppress_proof = true;
 		slate = api.contract_sign(m, &slate, args)?;
 		Ok(())
 	})?;
@@ -70,9 +71,10 @@ fn contract_srs_tx_impl(test_dir: &'static str) -> Result<(), libwallet::Error> 
 
 	// Send wallet finalizes and posts
 	wallet::controller::owner_single_use(Some(send_wallet.clone()), send_mask, None, |api, m| {
-		let args = &ContractSetupArgsAPI {
+		let args = &mut ContractSetupArgsAPI {
 			..Default::default()
 		};
+		args.proof_args.suppress_proof = true;
 		slate = api.contract_sign(m, &slate, args)?;
 		Ok(())
 	})?;

--- a/impls/src/backends/lmdb.rs
+++ b/impls/src/backends/lmdb.rs
@@ -21,8 +21,6 @@ use std::io::{Read, Write};
 use std::marker::PhantomData;
 use std::path::Path;
 
-use uuid::Uuid;
-
 use crate::blake2::blake2b::{Blake2b, Blake2bResult};
 
 use crate::keychain::{ChildNumber, ExtKeychain, Identifier, Keychain, SwitchCommitmentType};

--- a/libwallet/src/api_impl/owner.rs
+++ b/libwallet/src/api_impl/owner.rs
@@ -45,7 +45,6 @@ use ed25519_dalek::SecretKey as DalekSecretKey;
 use ed25519_dalek::Verifier;
 
 use std::convert::{TryFrom, TryInto};
-use std::ops::Index;
 use std::sync::mpsc::Sender;
 use std::sync::Arc;
 
@@ -713,7 +712,10 @@ where
 			sender_address: Some(sender_address.to_ed25519()?),
 			receiver_address: a.pub_key,
 			promise_signature: None,
-			timestamp: DateTime::<Utc>::from_utc(NaiveDateTime::from_timestamp(0, 0), Utc),
+			timestamp: DateTime::<Utc>::from_utc(
+				NaiveDateTime::from_timestamp_opt(0, 0).unwrap(),
+				Utc,
+			),
 			memo: None,
 		});
 

--- a/libwallet/src/contract/actions/revoke.rs
+++ b/libwallet/src/contract/actions/revoke.rs
@@ -13,9 +13,6 @@
 // limitations under the License.
 
 //! Implementation of contract revoke
-
-use std::default;
-
 use crate::contract::types::{ContractRevokeArgsAPI, ContractSetupArgsAPI, OutputSelectionArgs};
 use crate::contract::{new, sign};
 use crate::error::Error;

--- a/libwallet/src/contract/actions/view.rs
+++ b/libwallet/src/contract/actions/view.rs
@@ -23,10 +23,10 @@ use crate::types::{NodeClient, WalletBackend};
 
 /// View contract
 pub fn view<'a, T: ?Sized, C, K>(
-	w: &mut T,
-	keychain_mask: Option<&SecretKey>,
+	_w: &mut T,
+	_keychain_mask: Option<&SecretKey>,
 	slate: &mut Slate,
-	encrypted_for: &str,
+	_encrypted_for: &str,
 ) -> Result<ContractView, Error>
 where
 	T: WalletBackend<'a, C, K>,

--- a/libwallet/src/contract/slate.rs
+++ b/libwallet/src/contract/slate.rs
@@ -47,7 +47,7 @@ where
 {
 	// TODO: Implement. Consider adding this function to the Slate itself so they can easily be versioned
 	// e.g. slate.add_payment_proof_data()
-	trace!("contract::slate::add_payment_proof => called");
+	debug!("contract::slate::add_payment_proof => called");
 	// If we're a recipient, generate proof unless explicity told not to
 	if let Some(ref c) = net_change {
 		if *c > 0 && !proof_args.suppress_proof && slate.payment_proof.is_none() {

--- a/libwallet/src/contract/slate.rs
+++ b/libwallet/src/contract/slate.rs
@@ -26,9 +26,10 @@ use super::types::ProofArgs;
 use crate::contract::proofs::InvoiceProof;
 use ed25519_dalek::PublicKey as DalekPublicKey;
 
+/// TODO: Removed for now, consider secp error in sign function
 /// The secret key we replace the actual key with after we have signed with the Context keys. This is
 /// to prevent possibility of signing with the same key twice.
-pub const SEC_KEY_FAKE: [u8; 32] = [0; 32];
+/// pub const SEC_KEY_FAKE: [u8; 32] = [0; 32];
 
 /// Add payment proof data to slate, noop for sender
 pub fn add_payment_proof<'a, T: ?Sized, C, K>(

--- a/libwallet/src/contract/types.rs
+++ b/libwallet/src/contract/types.rs
@@ -219,6 +219,8 @@ impl Default for ContractView {
 		}
 	}
 }
+
+/// Arguments for contract revoke function
 #[derive(Clone, Serialize, Deserialize)]
 pub struct ContractRevokeArgsAPI {
 	/// Tx id to cancel

--- a/libwallet/src/contract/utils.rs
+++ b/libwallet/src/contract/utils.rs
@@ -26,8 +26,6 @@ use crate::{address, Error, OutputData, OutputStatus, TxLogEntry};
 use grin_core::core::FeeFields;
 use uuid::Uuid;
 
-use super::proofs::InvoiceProof;
-
 /// Creates an initial TxLogEntry without input/output or kernel information
 pub fn create_tx_log_entry(
 	slate: &Slate,

--- a/libwallet/src/error.rs
+++ b/libwallet/src/error.rs
@@ -257,7 +257,7 @@ pub enum Error {
 	#[error("Proof Address decoding: {0}")]
 	AddressDecoding(String),
 
-	// Payment proof - no sender address provided or found in slate
+	/// Payment proof - no sender address provided or found in slate
 	#[error("Sender address has not been provided")]
 	NoSenderAddressProvided,
 

--- a/libwallet/src/slate.rs
+++ b/libwallet/src/slate.rs
@@ -1600,7 +1600,10 @@ impl From<&PaymentInfoV4> for PaymentInfo {
 			sender_address: Some(sender_address),
 			receiver_address,
 			promise_signature: receiver_signature,
-			timestamp: DateTime::<Utc>::from_utc(NaiveDateTime::from_timestamp(0, 0), Utc),
+			timestamp: DateTime::<Utc>::from_utc(
+				NaiveDateTime::from_timestamp_opt(0, 0).unwrap(),
+				Utc,
+			),
 			memo: None,
 		}
 	}

--- a/libwallet/src/slate_versions/mod.rs
+++ b/libwallet/src/slate_versions/mod.rs
@@ -142,7 +142,7 @@ impl VersionedCoinbase {
 }
 #[cfg(test)]
 pub mod tests {
-	use crate::grin_core::core::transaction::{FeeFields, OutputFeatures};
+	use crate::grin_core::core::transaction::OutputFeatures;
 	use crate::grin_util::from_hex;
 	use crate::grin_util::secp::key::PublicKey;
 	use crate::grin_util::secp::pedersen::{Commitment, RangeProof};
@@ -155,7 +155,6 @@ pub mod tests {
 	use ed25519_dalek::Signature as DalekSignature;
 	use grin_core::global::{set_local_chain_type, ChainTypes};
 	use grin_keychain::{ExtKeychain, Keychain, SwitchCommitmentType};
-	use grin_wallet_util::byte_ser::from_bytes;
 	use std::convert::TryInto;
 
 	// Populate a test internal slate with all fields to test conversions
@@ -224,7 +223,7 @@ pub mod tests {
 		let b = from_hex(raw_pubkey_str).unwrap();
 		let d_pkey = DalekPublicKey::from_bytes(&b).unwrap();
 		// Need to remove milliseconds component for comparison. Won't be serialized
-		let ts = NaiveDateTime::from_timestamp(Utc::now().timestamp(), 0);
+		let ts = NaiveDateTime::from_timestamp_opt(Utc::now().timestamp(), 0).unwrap();
 		let ts = DateTime::<Utc>::from_utc(ts, Utc);
 		let pm = PaymentMemo {
 			memo_type: 1,


### PR DESCRIPTION
* Cleanup of warnings throughout
* Modify existing contract tests to take early payment proofs into account - either proofs need to be explicitly turned off in code or you need to supply a receiver address, mix of both sprinkled throughout (need to think about this).
* General cleanup in preparation for some more contracts/payment proof testing, to be integrated into the gui wallet in turn