### PR TITLE
[Contracts] Add self spend transaction state

### DIFF
--- a/controller/tests/contract_self_spend.rs
+++ b/controller/tests/contract_self_spend.rs
@@ -85,7 +85,7 @@ fn contract_self_spend_tx_impl(test_dir: &'static str) -> Result<(), libwallet::
 		assert!(refreshed);
 		assert_eq!(txs.len() as u64, bh + 1); // send wallet didn't mine 4 blocks and made 1 tx
 		let tx_log = txs[txs.len() - 5].clone(); // TODO: why -5 and not -4?
-		assert_eq!(tx_log.tx_type, TxLogEntryType::TxSent);
+		assert_eq!(tx_log.tx_type, TxLogEntryType::TxSelfSpend);
 		assert_eq!(tx_log.amount_credited, 0);
 		assert_eq!(tx_log.amount_debited, 0);
 		assert_eq!(tx_log.num_inputs, 1);

--- a/controller/tests/contract_self_spend_custom.rs
+++ b/controller/tests/contract_self_spend_custom.rs
@@ -44,6 +44,7 @@ fn contract_self_spend_custom_tx_impl(test_dir: &'static str) -> Result<(), libw
 
 	wallet::controller::owner_single_use(Some(send_wallet.clone()), send_mask, None, |api, m| {
 		let (_, commits) = api.retrieve_outputs(m, true, false, None)?;
+		println!("OOOT: {:?}", commits[0].output);
 		use_inputs = format!(
 			"{},{}",
 			commits[0].output.commit.as_ref().unwrap(),
@@ -104,7 +105,7 @@ fn contract_self_spend_custom_tx_impl(test_dir: &'static str) -> Result<(), libw
 		assert!(refreshed);
 		assert_eq!(txs.len() as u64, bh + 1); // send wallet didn't mine 4 blocks and made 1 tx
 		let tx_log = txs[txs.len() - 5].clone(); // TODO: why -5 and not -4?
-		assert_eq!(tx_log.tx_type, TxLogEntryType::TxSent);
+		assert_eq!(tx_log.tx_type, TxLogEntryType::TxSelfSpend);
 		assert_eq!(tx_log.amount_credited, 0);
 		assert_eq!(tx_log.amount_debited, 0);
 		assert_eq!(tx_log.num_inputs, 3);

--- a/libwallet/src/api_impl/types.rs
+++ b/libwallet/src/api_impl/types.rs
@@ -200,6 +200,8 @@ pub struct RetrieveTxQueryArgs {
 	pub include_received_only: Option<bool>,
 	/// whether to only consider coinbase transactions
 	pub include_coinbase_only: Option<bool>,
+	/// whether to only consider self spend transactions
+	pub include_self_spend_only: Option<bool>,
 	/// whether to only consider reverted transactions
 	pub include_reverted_only: Option<bool>,
 	/// lower bound on the total amount (amount_credited - amount_debited), inclusive
@@ -237,6 +239,7 @@ impl Default for RetrieveTxQueryArgs {
 			include_sent_only: Some(false),
 			include_received_only: Some(false),
 			include_coinbase_only: Some(false),
+			include_self_spend_only: Some(false),
 			include_reverted_only: Some(false),
 			min_amount: None,
 			max_amount: None,

--- a/libwallet/src/contract/actions/sign.rs
+++ b/libwallet/src/contract/actions/sign.rs
@@ -82,6 +82,7 @@ where
 		contract::slate::verify_payment_proof(&sl, expected_net_change, &p.receiver_address)?;
 		// noop for the receiver
 	}
+
 	contract::slate::sign(w, keychain_mask, &mut sl, &mut context)?;
 	contract::slate::transition_state(&mut sl)?;
 

--- a/libwallet/src/contract/utils.rs
+++ b/libwallet/src/contract/utils.rs
@@ -33,10 +33,14 @@ pub fn create_tx_log_entry(
 	parent_key_id: Identifier,
 	log_id: u32,
 ) -> Result<TxLogEntry, Error> {
-	let log_type = if net_change > 0 {
-		TxLogEntryType::TxReceived
+	let log_type = if slate.num_participants == 1 {
+		TxLogEntryType::TxSelfSpend
 	} else {
-		TxLogEntryType::TxSent
+		if net_change > 0 {
+			TxLogEntryType::TxReceived
+		} else {
+			TxLogEntryType::TxSent
+		}
 	};
 	let mut t = TxLogEntry::new(parent_key_id.clone(), log_type, log_id);
 	// TODO: TxLogEntry has stored_tx field. Check what this needs to be set to and check other fields as well
@@ -209,6 +213,7 @@ where
 				.unwrap()
 		}
 	};
+
 	// Update TxLogEntry if we have signed the contract (we have data about the kernel)
 	if is_signed {
 		update_tx_log_entry(w, keychain_mask, &slate, &context, &mut tx_log_entry)?;

--- a/libwallet/src/internal/updater.rs
+++ b/libwallet/src/internal/updater.rs
@@ -146,6 +146,7 @@ where
 					if v {
 						tx_entry.tx_type == TxLogEntryType::TxSent
 							|| tx_entry.tx_type == TxLogEntryType::TxSentCancelled
+							|| tx_entry.tx_type == TxLogEntryType::TxSelfSpend
 					} else {
 						true
 					}
@@ -158,6 +159,7 @@ where
 					if v {
 						tx_entry.tx_type == TxLogEntryType::TxReceived
 							|| tx_entry.tx_type == TxLogEntryType::TxReceivedCancelled
+							|| tx_entry.tx_type == TxLogEntryType::TxSelfSpend
 					} else {
 						true
 					}
@@ -169,6 +171,17 @@ where
 				if let Some(v) = query_args.include_coinbase_only {
 					if v {
 						tx_entry.tx_type == TxLogEntryType::ConfirmedCoinbase
+					} else {
+						true
+					}
+				} else {
+					true
+				}
+			})
+			.filter(|tx_entry| {
+				if let Some(v) = query_args.include_self_spend_only {
+					if v {
+						tx_entry.tx_type == TxLogEntryType::TxSelfSpend
 					} else {
 						true
 					}
@@ -365,7 +378,8 @@ where
 						!tx_entry.confirmed
 							&& (tx_entry.tx_type == TxLogEntryType::TxReceived
 								|| tx_entry.tx_type == TxLogEntryType::TxSent
-								|| tx_entry.tx_type == TxLogEntryType::TxReverted)
+								|| tx_entry.tx_type == TxLogEntryType::TxReverted
+								|| tx_entry.tx_type == TxLogEntryType::TxSelfSpend)
 					}
 					false => true,
 				};

--- a/libwallet/src/types.rs
+++ b/libwallet/src/types.rs
@@ -791,6 +791,10 @@ pub enum TxLogEntryType {
 	TxReceivedCancelled,
 	/// Sent transaction that was rolled back by user
 	TxSentCancelled,
+	/// Self spend, as per contracts and mwmixnet
+	TxSelfSpend,
+	/// Self Spend Cancelled (has to happen before sent to chain, flag rather than delete)
+	TxSelfSpendCancelled,
 	/// Received transaction that was reverted on-chain
 	TxReverted,
 }
@@ -804,6 +808,8 @@ impl fmt::Display for TxLogEntryType {
 			TxLogEntryType::TxReceivedCancelled => write!(f, "Received Tx\n- Cancelled"),
 			TxLogEntryType::TxSentCancelled => write!(f, "Sent Tx\n- Cancelled"),
 			TxLogEntryType::TxReverted => write!(f, "Received Tx\n- Reverted"),
+			TxLogEntryType::TxSelfSpend => write!(f, "Self Spend"),
+			TxLogEntryType::TxSelfSpendCancelled => write!(f, "Self Spend\n- Cancelled"),
 		}
 	}
 }


### PR DESCRIPTION
* Adds an explicit `SelfSpend` transaction state, at the moment only set during contracts workflow.
* Sets the type on a transaction during contract workflow when the number of participants in the slate is set to 1

Note this would have a lot of extra areas that needs to be addressed were it used in the legacy wallet workflow. This included on the contracts branch only for experimental purposes and reflected only in the gui project for now.