### PR TITLE
[Contracts] Slatepack v5 Deserialization fix

### DIFF
--- a/libwallet/src/slate.rs
+++ b/libwallet/src/slate.rs
@@ -59,7 +59,7 @@ pub struct PaymentMemo {
 	pub memo: [u8; 32],
 }
 
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, Eq, PartialEq)]
 pub struct PaymentInfo {
 	/// Sender address
 	pub sender_address: Option<DalekPublicKey>,

--- a/libwallet/src/slate_versions/mod.rs
+++ b/libwallet/src/slate_versions/mod.rs
@@ -94,11 +94,12 @@ impl From<VersionedSlate> for Slate {
 #[serde(untagged)]
 /// Binary versions, can only be parsed 1:1 into the appropriate
 /// version, and VersionedSlate can up/downgrade from there
+/// NB (IMPORTANT): Ensure the latest version of the slate is the first enum element
 pub enum VersionedBinSlate {
-	/// Version 4, binary
-	V4(SlateV4Bin),
 	/// Version 5, binary
 	V5(SlateV5Bin),
+	/// Version 4, binary
+	V4(SlateV4Bin),
 }
 
 impl TryFrom<VersionedSlate> for VersionedBinSlate {
@@ -149,7 +150,9 @@ pub mod tests {
 	use crate::grin_util::secp::Signature;
 	use crate::slate::{KernelFeaturesArgs, ParticipantData, PaymentInfo, PaymentMemo};
 	use crate::slate_versions::v5::{CommitsV5, SlateV5};
-	use crate::{slate, Error, Slate, VersionedBinSlate, VersionedSlate};
+	use crate::{
+		slate, Error, Slate, Slatepacker, SlatepackerArgs, VersionedBinSlate, VersionedSlate,
+	};
 	use chrono::{DateTime, NaiveDateTime, Utc};
 	use ed25519_dalek::PublicKey as DalekPublicKey;
 	use ed25519_dalek::Signature as DalekSignature;
@@ -240,6 +243,27 @@ pub mod tests {
 		});
 
 		Ok(slate_internal)
+	}
+
+	#[test]
+	fn ser_deser_current_slate() -> Result<(), Error> {
+		let slate_internal = populate_test_slate()?;
+		// Serialize slate into slatepack
+		let slatepacker_args = SlatepackerArgs {
+			sender: None,
+			recipients: vec![],
+			dec_key: None,
+		};
+
+		let slate_packer = Slatepacker::new(slatepacker_args);
+		let slate_packed = slate_packer.create_slatepack(&slate_internal).unwrap();
+
+		let slate_unpacked = slate_packer.get_slate(&slate_packed).unwrap();
+
+		// Just verifying payment proof for now, extend later to cover EQ for full slate if needs
+		// be
+		assert_eq!(slate_internal.payment_proof, slate_unpacked.payment_proof);
+		Ok(())
 	}
 
 	#[test]

--- a/libwallet/src/slate_versions/mod.rs
+++ b/libwallet/src/slate_versions/mod.rs
@@ -94,7 +94,8 @@ impl From<VersionedSlate> for Slate {
 #[serde(untagged)]
 /// Binary versions, can only be parsed 1:1 into the appropriate
 /// version, and VersionedSlate can up/downgrade from there
-/// NB (IMPORTANT): Ensure the latest version of the slate is the first enum element
+/// NB (IMPORTANT): Ensure the slates are listed in reverse chronological
+/// order (latest first)
 pub enum VersionedBinSlate {
 	/// Version 5, binary
 	V5(SlateV5Bin),

--- a/libwallet/src/slate_versions/v5_bin.rs
+++ b/libwallet/src/slate_versions/v5_bin.rs
@@ -249,10 +249,13 @@ impl Readable for ProofWrap {
 		let raddr = DalekPublicKey::from_bytes(&reader.read_fixed_bytes(32)?).unwrap();
 		let ts_raw: i64 = match reader.read_i64() {
 			Ok(v) => v,
-			Err(e) => return Err(grin_ser::Error::CorruptedData),
+			Err(_) => return Err(grin_ser::Error::CorruptedData),
 		};
-		let ts =
-			DateTime::<Utc>::from_utc(NaiveDateTime::from_timestamp_opt(ts_raw, 0).unwrap(), Utc);
+		let ts_opt = match NaiveDateTime::from_timestamp_opt(ts_raw, 0) {
+			Some(o) => o,
+			None => return Err(grin_ser::Error::CorruptedData),
+		};
+		let ts = DateTime::<Utc>::from_utc(ts_opt, Utc);
 		let psig = match reader.read_u8()? {
 			0 => None,
 			1 | _ => Some(DalekSignature::try_from(&reader.read_fixed_bytes(64)?[..]).unwrap()),

--- a/libwallet/src/slate_versions/v5_bin.rs
+++ b/libwallet/src/slate_versions/v5_bin.rs
@@ -25,6 +25,7 @@ use chrono::{DateTime, NaiveDateTime, Utc};
 use ed25519_dalek::PublicKey as DalekPublicKey;
 use ed25519_dalek::Signature as DalekSignature;
 use std::convert::{TryFrom, TryInto};
+use std::f64::consts::E;
 
 use crate::slate_versions::v5::{
 	CommitsV5, KernelFeaturesArgsV5, ParticipantDataV5, PaymentInfoV5, PaymentMemoV5, SlateStateV5,
@@ -246,7 +247,10 @@ impl Readable for ProofWrap {
 	fn read<R: Reader>(reader: &mut R) -> Result<ProofWrap, grin_ser::Error> {
 		let saddr = DalekPublicKey::from_bytes(&reader.read_fixed_bytes(32)?).unwrap();
 		let raddr = DalekPublicKey::from_bytes(&reader.read_fixed_bytes(32)?).unwrap();
-		let ts_raw: i64 = reader.read_i64().unwrap();
+		let ts_raw: i64 = match reader.read_i64() {
+			Ok(v) => v,
+			Err(e) => return Err(grin_ser::Error::CorruptedData),
+		};
 		let ts =
 			DateTime::<Utc>::from_utc(NaiveDateTime::from_timestamp_opt(ts_raw, 0).unwrap(), Utc);
 		let psig = match reader.read_u8()? {

--- a/libwallet/src/slatepack/packer.rs
+++ b/libwallet/src/slatepack/packer.rs
@@ -94,7 +94,7 @@ impl<'a> Slatepacker<'a> {
 
 	/// Create slatepack from slate and args
 	pub fn create_slatepack(&self, slate: &Slate) -> Result<Slatepack, Error> {
-		let out_slate = VersionedSlate::into_version(slate.clone(), SlateVersion::V4)?;
+		let out_slate = VersionedSlate::into_version(slate.clone(), SlateVersion::V5)?;
 		let bin_slate = VersionedBinSlate::try_from(out_slate).map_err(|_| Error::SlatepackSer)?;
 		let mut slatepack = Slatepack::default();
 		slatepack.payload = byte_ser::to_bytes(&bin_slate).map_err(|_| Error::SlatepackSer)?;


### PR DESCRIPTION
Fix to subtle bug preventing slatepacked slates deserializing payments proof properly, thus preventing RSR contracts transactions working within the GUI wallet. Basically, an enum's fields were in the wrong order.

Adds tests in a few places to check for this in future.