### PR TITLE
Prevent wallet attempting to re-pay a cancelled invoice transaction

### DIFF
--- a/libwallet/src/api_impl/owner.rs
+++ b/libwallet/src/api_impl/owner.rs
@@ -680,6 +680,9 @@ where
 		if t.tx_type == TxLogEntryType::TxSent {
 			return Err(Error::TransactionAlreadyReceived(ret_slate.id.to_string()));
 		}
+		if t.tx_type == TxLogEntryType::TxSentCancelled {
+			return Err(Error::TransactionWasCancelled(ret_slate.id.to_string()));
+		}
 	}
 
 	let height = w.w2n_client().get_chain_tip()?.0;

--- a/libwallet/src/error.rs
+++ b/libwallet/src/error.rs
@@ -153,6 +153,10 @@ pub enum Error {
 	#[error("Transaction {0} has already been received")]
 	TransactionAlreadyReceived(String),
 
+	/// Transaction has been cancelled
+	#[error("Transaction {0} has been cancelled")]
+	TransactionWasCancelled(String),
+
 	/// Attempt to repost a transaction that's not completed and stored
 	#[error("Transaction building not completed: {0}")]
 	TransactionBuildingNotCompleted(u32),


### PR DESCRIPTION
Prevents #706, more correct behavior is to not attempt to re-pay a transaction that's been cancelled. Payee should request a new invoice in this case.