### PR TITLE
[CONTRACTS] Add `owner_api_listen_interface` as hidden configuration field

### DIFF
--- a/config/src/types.rs
+++ b/config/src/types.rs
@@ -28,6 +28,9 @@ pub struct WalletConfig {
 	pub chain_type: Option<ChainTypes>,
 	/// The port this wallet will run on
 	pub api_listen_port: u16,
+	/// Listen interface for the owner API, should be hidden from config by default
+	#[serde(skip_serializing)]
+	pub owner_api_listen_interface: Option<String>,
 	/// The port this wallet's owner API will run on
 	pub owner_api_listen_port: Option<u16>,
 	/// Location of the secret for basic auth on the Owner API
@@ -61,6 +64,7 @@ impl Default for WalletConfig {
 		WalletConfig {
 			chain_type: Some(ChainTypes::Mainnet),
 			api_listen_port: 3415,
+			owner_api_listen_interface: Some(WalletConfig::default_owner_api_listen_interface()),
 			owner_api_listen_port: Some(WalletConfig::default_owner_api_listen_port()),
 			api_secret_path: Some(".owner_api_secret".to_string()),
 			node_api_secret_path: Some(".foreign_api_secret".to_string()),
@@ -83,6 +87,11 @@ impl WalletConfig {
 	}
 
 	/// Default listener port
+	pub fn default_owner_api_listen_interface() -> String {
+		"127.0.0.1".to_string()
+	}
+
+	/// Default listener port
 	pub fn default_owner_api_listen_port() -> u16 {
 		3420
 	}
@@ -93,6 +102,13 @@ impl WalletConfig {
 	}
 
 	/// Use value from config file, defaulting to sensible value if missing.
+	pub fn owner_api_listen_interface(&self) -> String {
+		self.owner_api_listen_interface
+			.clone()
+			.unwrap_or_else(|| WalletConfig::default_owner_api_listen_interface())
+	}
+
+	/// Use value from config file, defaulting to sensible value if missing.
 	pub fn owner_api_listen_port(&self) -> u16 {
 		self.owner_api_listen_port
 			.unwrap_or_else(WalletConfig::default_owner_api_listen_port)
@@ -100,7 +116,11 @@ impl WalletConfig {
 
 	/// Owner API listen address
 	pub fn owner_api_listen_addr(&self) -> String {
-		format!("127.0.0.1:{}", self.owner_api_listen_port())
+		format!(
+			"{}:{}",
+			self.owner_api_listen_interface(),
+			self.owner_api_listen_port()
+		)
 	}
 
 	/// Accept fee base


### PR DESCRIPTION
* The listen interface for the owner API is currently hardcoded to `127.0.0.1`. We'd previously resisted allowing this to be opened up (by, say changing the interface to `0.0.0.0`), as a security measure to ensure clients to the owner interface are limited to being on the same machine.

This is probably far too limiting, and in particular makes docker deployments difficult as there's no way to access the wallet APIs at all from outside the deployed container, (which is necessarily set up to run the owner API as a service and nothing else). 

This PR adds `owner_api_listen_interface` as a configuration field, but doesn't output the field into the configuration file by default, i.e. a user will really need to know what they're doing in order to enable this field. This should provide a good compromise.

Note this is for the experimental contracts branch only, but some discussion merited as to whether to merge into master just yet. 