### PR TITLE
Store retrieved kernel height at TxLogEntry structure

### DIFF
--- a/libwallet/src/api_impl/owner.rs
+++ b/libwallet/src/api_impl/owner.rs
@@ -1320,6 +1320,7 @@ where
 				wallet_lock!(wallet_inst, w);
 				let mut batch = w.batch(keychain_mask)?;
 				tx.confirmed = true;
+				tx.kernel_height = Some(k.1);
 				tx.update_confirmation_ts();
 				batch.save_tx_log_entry(tx.clone(), &parent_key_id)?;
 				batch.commit()?;

--- a/libwallet/src/types.rs
+++ b/libwallet/src/types.rs
@@ -839,6 +839,8 @@ pub struct TxLogEntry {
 	/// Track the time it took for a transaction to get reverted
 	#[serde(with = "option_duration_as_secs", default)]
 	pub reverted_after: Option<Duration>,
+	/// Height of the block kernel included in
+	pub kernel_height: Option<u64>,
 }
 
 impl ser::Writeable for TxLogEntry {
@@ -876,6 +878,7 @@ impl TxLogEntry {
 			kernel_lookup_min_height: None,
 			payment_proof: None,
 			reverted_after: None,
+			kernel_height: None,
 		}
 	}
 

--- a/libwallet/src/types.rs
+++ b/libwallet/src/types.rs
@@ -840,6 +840,7 @@ pub struct TxLogEntry {
 	#[serde(with = "option_duration_as_secs", default)]
 	pub reverted_after: Option<Duration>,
 	/// Height of the block kernel included in
+	#[serde(default)]
 	pub kernel_height: Option<u64>,
 }
 


### PR DESCRIPTION
Useful to store transaction kernel block height at `grin_wallet_libwallet::TxLogEntry` to calculate left confirmations amount and to know when transaction was exactly included into block without extra API calls from outside, now we are just marking tx as confirmed with current time at `update_txs_via_kernel` from `grin_wallet_libwallet::owner::update_wallet_state`.