### PR TITLE
[WIP] Updates for rust 1.80

### DIFF
--- a/.cargo/config
+++ b/.cargo/config
@@ -1,4 +1,0 @@
-[target.x86_64-pc-windows-msvc]
-rustflags = ["-Ctarget-feature=+crt-static"]
-[target.i686-pc-windows-msvc]
-rustflags = ["-Ctarget-feature=+crt-static"]

--- a/.cargo/config.toml
+++ b/.cargo/config.toml
@@ -1,0 +1,4 @@
+[target.x86_64-pc-windows-msvc]
+rustflags = ["-Ctarget-feature=+crt-static"]
+[target.i686-pc-windows-msvc]
+rustflags = ["-Ctarget-feature=+crt-static"]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -330,11 +330,10 @@ checksum = "476e9cd489f9e121e02ffa6014a8ef220ecb15c05ed23fc34cca13925dc283fb"
 
 [[package]]
 name = "built"
-version = "0.4.4"
+version = "0.7.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c8f1b029cb3929cb0c99780b0c10fe512f60be5438adf5f757e4afa1bc75a984"
+checksum = "236e6289eda5a812bc6b53c3b024039382a2895fbbeef2d748b2931546d392c4"
 dependencies = [
- "cargo-lock",
  "git2",
 ]
 
@@ -377,18 +376,6 @@ name = "bytes"
 version = "1.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "514de17de45fdb8dc022b1a7975556c53c86f9f0aa5f534b98977b171857c2c9"
-
-[[package]]
-name = "cargo-lock"
-version = "4.0.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8504b63dd1249fd1745b7b4ef9b6f7b107ddeb3c95370043c7dbcc38653a2679"
-dependencies = [
- "semver 0.9.0",
- "serde",
- "toml 0.5.11",
- "url",
-]
 
 [[package]]
 name = "cc"
@@ -1190,11 +1177,11 @@ checksum = "4271d37baee1b8c7e4b708028c57d816cf9d2434acb33a549475f78c181f6253"
 
 [[package]]
 name = "git2"
-version = "0.13.25"
+version = "0.19.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f29229cc1b24c0e6062f6e742aa3e256492a5323365e5ed3413599f8a5eff7d6"
+checksum = "b903b73e45dc0c6c596f2d37eccece7c1c8bb6e4407b001096387c63d0d93724"
 dependencies = [
- "bitflags 1.3.2",
+ "bitflags 2.5.0",
  "libc",
  "libgit2-sys",
  "log",
@@ -1422,7 +1409,7 @@ dependencies = [
  "remove_dir_all",
  "rpassword",
  "rustyline",
- "semver 0.10.0",
+ "semver",
  "serde",
  "serde_derive",
  "serde_json",
@@ -2049,9 +2036,9 @@ checksum = "97b3888a4aecf77e811145cadf6eef5901f4782c53886191b2f693f24761847c"
 
 [[package]]
 name = "libgit2-sys"
-version = "0.12.26+1.3.0"
+version = "0.17.0+1.8.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "19e1c899248e606fbfe68dcb31d8b0176ebab833b103824af31bddf4b7457494"
+checksum = "10472326a8a6477c3c20a64547b0059e4b0d086869eee31e6d7da728a8eb7224"
 dependencies = [
  "cc",
  "libc",
@@ -3517,16 +3504,6 @@ name = "self_cell"
 version = "1.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d369a96f978623eb3dc28807c4852d6cc617fed53da5d3c400feff1ef34a714a"
-
-[[package]]
-name = "semver"
-version = "0.9.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1d7eb9ef2c18661902cc47e535f9bc51b78acd254da71d375c2f6720d9a40403"
-dependencies = [
- "semver-parser",
- "serde",
-]
 
 [[package]]
 name = "semver"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -68,7 +68,7 @@ grin_api = { git = "https://github.com/mimblewimble/grin", branch = "master" }
 ###### 
 
 [build-dependencies]
-built = { version = "0.4", features = ["git2"]}
+built = { version = "0.7", features = ["git2"]}
 
 [dev-dependencies]
 url = "2.1"

--- a/impls/src/adapters/mod.rs
+++ b/impls/src/adapters/mod.rs
@@ -17,7 +17,7 @@ pub mod http;
 mod slatepack;
 
 pub use self::file::PathToSlate;
-pub use self::http::{HttpSlateSender, SchemeNotHttp};
+pub use self::http::HttpSlateSender;
 pub use self::slatepack::PathToSlatepack;
 
 use crate::config::WalletConfig;

--- a/impls/src/node_clients/resp_types.rs
+++ b/impls/src/node_clients/resp_types.rs
@@ -14,7 +14,7 @@
 // Derived from https://github.com/apoelstra/rust-jsonrpc
 
 //! JSON RPC Types for V2 node client
-
+#[allow(dead_code)]
 #[derive(Debug, Deserialize)]
 pub struct GetTipResp {
 	pub height: u64,

--- a/src/build/build.rs
+++ b/src/build/build.rs
@@ -39,13 +39,10 @@ fn main() {
 	}
 
 	// build and versioning information
-	let mut opts = built::Options::default();
-	opts.set_dependencies(true);
 	let out_dir_path = format!("{}{}", env::var("OUT_DIR").unwrap(), "/built.rs");
 	// don't fail the build if something's missing, may just be cargo release
 	let _ = built::write_built_file_with_opts(
-		&opts,
-		Path::new(env!("CARGO_MANIFEST_DIR")),
+		Some(Path::new(env!("CARGO_MANIFEST_DIR"))),
 		Path::new(&out_dir_path),
 	);
 }


### PR DESCRIPTION
* Update `built` crate to 0.7
* Remove warnings, allow `dead_code` when necessary
* Rename `.cargo/build` to `.cargo/build.toml`

Note that grin dependencies will be updated once https://github.com/mimblewimble/grin/pull/3796  is reviewed and merged.