### PR TITLE
Node submodules

### DIFF
--- a/.github/workflows/cd.yaml
+++ b/.github/workflows/cd.yaml
@@ -10,7 +10,10 @@ jobs:
         name: Linux Release
         runs-on: ubuntu-latest
         steps:
-          - uses: actions/checkout@v3
+          - name: Checkout
+            uses: actions/checkout@v6
+            with:
+              submodules: recursive
           - name: Build
             run: cargo build --release
           - name: Archive
@@ -32,7 +35,9 @@ jobs:
         runs-on: macos-latest
         steps:
           - name: Checkout
-            uses: actions/checkout@v3
+            uses: actions/checkout@v6
+            with:
+              submodules: recursive
           - name: Build
             run: cargo build --release
           - name: Archive
@@ -53,7 +58,9 @@ jobs:
         runs-on: windows-latest
         steps:
           - name: Checkout
-            uses: actions/checkout@v3
+            uses: actions/checkout@v6
+            with:
+              submodules: recursive
           - name: Build
             run: cargo build --release
           - name: Archive

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -9,7 +9,9 @@ jobs:
       matrix:
         job_args: [api, config, controller, impls, libwallet, .]
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v6
+        with:
+          submodules: recursive
       - name: Test ${{ matrix.job_args }}
         working-directory: ${{ matrix.job_args }}
         run: cargo test --release
@@ -19,7 +21,9 @@ jobs:
     runs-on: macos-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@v6
+        with:
+          submodules: recursive
       - name: Tests
         run: cargo test --release --all
 
@@ -28,6 +32,8 @@ jobs:
     runs-on: windows-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@v6
+        with:
+          submodules: recursive
       - name: Tests
         run: cargo test --release --all

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,0 +1,4 @@
+[submodule "grin"]
+	path = grin
+	url = https://github.com/ardocrat/grin
+	branch = workspace_fix

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,0 +1,4 @@
+[submodule "grin"]
+	path = grin
+	branch = staging
+	url = https://github.com/mimblewimble/grin

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,4 +1,0 @@
-[submodule "grin"]
-	path = grin
-	url = https://github.com/ardocrat/grin
-	branch = workspace_fix

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -950,6 +950,19 @@ dependencies = [
 ]
 
 [[package]]
+name = "env_logger"
+version = "0.7.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "44533bbbb3bb3c1fa17d9f2e4e38bbbaf8396ba82193c4cb1b6445d711445d36"
+dependencies = [
+ "atty",
+ "humantime 1.3.0",
+ "log",
+ "regex",
+ "termcolor",
+]
+
+[[package]]
 name = "equivalent"
 version = "1.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -970,6 +983,16 @@ name = "fastrand"
 version = "2.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9f1f227452a390804cdb637b74a86990f2a7d7ba4b7d5693aac9b4dd6defd8d6"
+
+[[package]]
+name = "filetime"
+version = "0.2.29"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5c287a33c7f0a620c38e641e7f60827713987b3c0f26e8ddc9462cc69cf75759"
+dependencies = [
+ "cfg-if 1.0.4",
+ "libc",
+]
 
 [[package]]
 name = "find-crate"
@@ -1279,7 +1302,6 @@ dependencies = [
 [[package]]
 name = "grin_api"
 version = "5.4.0"
-source = "git+https://github.com/mimblewimble/grin?rev=cf2ed3f3becd62b5e754ec964fd90e332b9a021f#cf2ed3f3becd62b5e754ec964fd90e332b9a021f"
 dependencies = [
  "async-stream",
  "bytes 1.11.1",
@@ -1313,7 +1335,6 @@ dependencies = [
 [[package]]
 name = "grin_chain"
 version = "5.4.0"
-source = "git+https://github.com/mimblewimble/grin?rev=cf2ed3f3becd62b5e754ec964fd90e332b9a021f#cf2ed3f3becd62b5e754ec964fd90e332b9a021f"
 dependencies = [
  "bit-vec",
  "bitflags 1.3.2",
@@ -1321,6 +1342,7 @@ dependencies = [
  "chrono",
  "croaring",
  "enum_primitive",
+ "env_logger",
  "grin_core",
  "grin_keychain",
  "grin_store",
@@ -1328,6 +1350,7 @@ dependencies = [
  "lazy_static",
  "log",
  "lru-cache",
+ "rand 0.6.5",
  "serde",
  "serde_derive",
  "thiserror 1.0.69",
@@ -1336,7 +1359,6 @@ dependencies = [
 [[package]]
 name = "grin_core"
 version = "5.4.0"
-source = "git+https://github.com/mimblewimble/grin?rev=cf2ed3f3becd62b5e754ec964fd90e332b9a021f#cf2ed3f3becd62b5e754ec964fd90e332b9a021f"
 dependencies = [
  "blake2-rfc",
  "byteorder",
@@ -1354,6 +1376,7 @@ dependencies = [
  "rand 0.6.5",
  "serde",
  "serde_derive",
+ "serde_json",
  "siphasher 0.3.11",
  "thiserror 1.0.69",
  "zeroize",
@@ -1362,7 +1385,6 @@ dependencies = [
 [[package]]
 name = "grin_keychain"
 version = "5.4.0"
-source = "git+https://github.com/mimblewimble/grin?rev=cf2ed3f3becd62b5e754ec964fd90e332b9a021f#cf2ed3f3becd62b5e754ec964fd90e332b9a021f"
 dependencies = [
  "blake2-rfc",
  "byteorder",
@@ -1384,7 +1406,6 @@ dependencies = [
 [[package]]
 name = "grin_p2p"
 version = "5.4.0"
-source = "git+https://github.com/mimblewimble/grin?rev=cf2ed3f3becd62b5e754ec964fd90e332b9a021f#cf2ed3f3becd62b5e754ec964fd90e332b9a021f"
 dependencies = [
  "bitflags 1.3.2",
  "built",
@@ -1393,6 +1414,7 @@ dependencies = [
  "enum_primitive",
  "grin_chain",
  "grin_core",
+ "grin_pool",
  "grin_store",
  "grin_util",
  "log",
@@ -1407,10 +1429,10 @@ dependencies = [
 [[package]]
 name = "grin_pool"
 version = "5.4.0"
-source = "git+https://github.com/mimblewimble/grin?rev=cf2ed3f3becd62b5e754ec964fd90e332b9a021f#cf2ed3f3becd62b5e754ec964fd90e332b9a021f"
 dependencies = [
  "blake2-rfc",
  "chrono",
+ "grin_chain",
  "grin_core",
  "grin_keychain",
  "grin_util",
@@ -1439,16 +1461,19 @@ dependencies = [
 [[package]]
 name = "grin_store"
 version = "5.4.0"
-source = "git+https://github.com/mimblewimble/grin?rev=cf2ed3f3becd62b5e754ec964fd90e332b9a021f#cf2ed3f3becd62b5e754ec964fd90e332b9a021f"
 dependencies = [
  "byteorder",
+ "chrono",
  "croaring",
+ "env_logger",
+ "filetime",
  "grin_core",
  "grin_util",
  "heed",
  "libc",
  "log",
  "memmap",
+ "rand 0.6.5",
  "serde",
  "serde_derive",
  "tempfile",
@@ -1458,7 +1483,6 @@ dependencies = [
 [[package]]
 name = "grin_util"
 version = "5.4.0"
-source = "git+https://github.com/mimblewimble/grin?rev=cf2ed3f3becd62b5e754ec964fd90e332b9a021f#cf2ed3f3becd62b5e754ec964fd90e332b9a021f"
 dependencies = [
  "anyhow",
  "backtrace",
@@ -1889,6 +1913,15 @@ name = "httpdate"
 version = "1.0.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "df3b46402a9d5adb4c86a0cf463f42e19994e3ee891101b1841f30a545cb49a9"
+
+[[package]]
+name = "humantime"
+version = "1.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "df004cfca50ef23c36850aaaa59ad52cc70d0e90243c3c7737a4dd32dc7a3c4f"
+dependencies = [
+ "quick-error",
+]
 
 [[package]]
 name = "humantime"
@@ -2471,7 +2504,7 @@ dependencies = [
  "derive_more",
  "flate2",
  "fnv",
- "humantime",
+ "humantime 2.3.0",
  "libc",
  "log",
  "log-mdc",
@@ -3205,6 +3238,12 @@ name = "qr_code"
 version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5520fbcd7da152a449261c5a533a1c7fad044e9e8aa9528cfec3f464786c7926"
+
+[[package]]
+name = "quick-error"
+version = "1.2.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a1d01941d82fa2ab50be1e79e6714289dd7cde78eba4c074bc5a4374f650dfe0"
 
 [[package]]
 name = "quote"
@@ -4332,6 +4371,15 @@ dependencies = [
  "dirs-next 2.0.0",
  "rustversion",
  "winapi 0.3.9",
+]
+
+[[package]]
+name = "termcolor"
+version = "1.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "06794f8f6c5c898b3275aebefa6b8a1cb24cd2c6c79397ab15774837a0bc5755"
+dependencies = [
+ "winapi-util",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -40,30 +40,10 @@ grin_wallet_util = { path = "./util", version = "5.4.0-alpha.1" }
 
 ##### Grin Imports
 
-# For Release
-#grin_core = "5.4.0"
-#grin_keychain = "5.4.0"
-#grin_util = "5.4.0"
-#grin_api = "5.4.0"
-
-# For beta release
-
-# grin_core = { git = "https://github.com/mimblewimble/grin", tag = "v5.2.0-beta.3"}
-# grin_keychain = { git = "https://github.com/mimblewimble/grin", tag = "v5.2.0-beta.3" }
-# grin_util = { git = "https://github.com/mimblewimble/grin", tag = "v5.2.0-beta.3" }
-# grin_api = { git = "https://github.com/mimblewimble/grin", tag = "v5.2.0-beta.3" }
-
-# For bleeding edge
-grin_core = { git = "https://github.com/mimblewimble/grin", rev = "cf2ed3f3becd62b5e754ec964fd90e332b9a021f" }
-grin_keychain = { git = "https://github.com/mimblewimble/grin", rev = "cf2ed3f3becd62b5e754ec964fd90e332b9a021f" }
-grin_util = { git = "https://github.com/mimblewimble/grin", rev = "cf2ed3f3becd62b5e754ec964fd90e332b9a021f" }
-grin_api = { git = "https://github.com/mimblewimble/grin", rev = "cf2ed3f3becd62b5e754ec964fd90e332b9a021f" }
-
-# For local testing
-# grin_core = { path = "../grin/core"}
-# grin_keychain = { path = "../grin/keychain"}
-# grin_util = { path = "../grin/util"}
-# grin_api = { path = "../grin/api"}
+grin_core = { path = "grin/core"}
+grin_keychain = { path = "grin/keychain"}
+grin_util = { path = "grin/util"}
+grin_api = { path = "grin/api"}
 
 ###### 
 

--- a/README.md
+++ b/README.md
@@ -14,12 +14,28 @@ This is the reference implementation of [Grin's](https://github.com/mimblewimble
 
 * A reference command-line wallet, which provides a baseline wallet for Grin and demonstrates how the wallet APIs should be called.
 
-# Usage
+## Contributing
+
+To get involved, read our [contributing docs](https://github.com/mimblewimble/grin/blob/master/CONTRIBUTING.md).
+
+Find us:
+
+* Telegram: [Grin Development](https://t.me/grindevelopment)
+* Chat: [Keybase](https://keybase.io/team/grincoin), more instructions on how to join [here](https://grin.mw/community).
+
+## Usage
 
 To use the command-line wallet, we recommend using the latest release from the [Releases page](https://github.com/mimblewimble/grin-wallet/releases). There are distributions for Linux, MacOS and Windows.
 
 Full documentation outlining how to use the command line wallet can be found on [Grin's Wiki](https://github.com/mimblewimble/docs/wiki/Wallet-User-Guide)
 
-# License
+To build locally install Rust and execute in the project directory:
+```
+git submodule update --init --recursive
+cargo build --release
+./target/release/grin-wallet
+```
+
+## License
 
 Apache License v2.0

--- a/api/Cargo.toml
+++ b/api/Cargo.toml
@@ -29,26 +29,9 @@ grin_wallet_util = { path = "../util", version = "5.4.0-alpha.1" }
 
 ##### Grin Imports
 
-# For Release
-#grin_core = "5.4.0"
-#grin_keychain = "5.4.0"
-#grin_util = "5.4.0"
-
-# For beta release
-
-# grin_core = { git = "https://github.com/mimblewimble/grin", tag = "v5.2.0-beta.3"}
-# grin_keychain = { git = "https://github.com/mimblewimble/grin", tag = "v5.2.0-beta.3" }
-# grin_util = { git = "https://github.com/mimblewimble/grin", tag = "v5.2.0-beta.3" }
-
-# For bleeding edge
-grin_core = { git = "https://github.com/mimblewimble/grin", rev = "cf2ed3f3becd62b5e754ec964fd90e332b9a021f" }
-grin_keychain = { git = "https://github.com/mimblewimble/grin", rev = "cf2ed3f3becd62b5e754ec964fd90e332b9a021f" }
-grin_util = { git = "https://github.com/mimblewimble/grin", rev = "cf2ed3f3becd62b5e754ec964fd90e332b9a021f" }
-
-# For local testing
-# grin_core = { path = "../../grin/core"}
-# grin_keychain = { path = "../../grin/keychain"}
-# grin_util = { path = "../../grin/util"}
+grin_core = { path = "../grin/core"}
+grin_keychain = { path = "../grin/keychain"}
+grin_util = { path = "../grin/util"}
 
 #####
 

--- a/config/Cargo.toml
+++ b/config/Cargo.toml
@@ -20,22 +20,8 @@ grin_wallet_util = { path = "../util", version = "5.4.0-alpha.1" }
 
 ##### Grin Imports
 
-# For Release
-#grin_core = "5.4.0"
-#grin_util = "5.4.0"
-
-# For beta release
-
-#grin_core = { git = "https://github.com/mimblewimble/grin", tag = "v5.2.0-beta.3"}
-#grin_util = { git = "https://github.com/mimblewimble/grin", tag = "v5.2.0-beta.3" }
-
-# For bleeding edge
-grin_core = { git = "https://github.com/mimblewimble/grin", rev = "cf2ed3f3becd62b5e754ec964fd90e332b9a021f" }
-grin_util = { git = "https://github.com/mimblewimble/grin", rev = "cf2ed3f3becd62b5e754ec964fd90e332b9a021f" }
-
-# For local testing
-# grin_core = { path = "../../grin/core"}
-# grin_util = { path = "../../grin/util"}
+grin_core = { path = "../grin/core"}
+grin_util = { path = "../grin/util"}
 
 #####
 

--- a/controller/Cargo.toml
+++ b/controller/Cargo.toml
@@ -38,34 +38,11 @@ grin_wallet_config = { path = "../config", version = "5.4.0-alpha.1" }
 
 ##### Grin Imports
 
-# For Release
-#grin_core = "5.4.0"
-#grin_keychain = "5.4.0"
-#grin_util = "5.4.0"
-#grin_api = "5.4.0"
-#grin_chain = "5.4.0"
-
-# For beta release
-
-# grin_core = { git = "https://github.com/mimblewimble/grin", tag = "v5.2.0-beta.3"}
-# grin_keychain = { git = "https://github.com/mimblewimble/grin", tag = "v5.2.0-beta.3" }
-# grin_util = { git = "https://github.com/mimblewimble/grin", tag = "v5.2.0-beta.3" }
-# grin_api = { git = "https://github.com/mimblewimble/grin", tag = "v5.2.0-beta.3" }
-# grin_chain = { git = "https://github.com/mimblewimble/grin", tag = "v5.2.0-beta.3" }
-
-# For bleeding edge
-grin_core = { git = "https://github.com/mimblewimble/grin", rev = "cf2ed3f3becd62b5e754ec964fd90e332b9a021f" }
-grin_keychain = { git = "https://github.com/mimblewimble/grin", rev = "cf2ed3f3becd62b5e754ec964fd90e332b9a021f" }
-grin_util = { git = "https://github.com/mimblewimble/grin", rev = "cf2ed3f3becd62b5e754ec964fd90e332b9a021f" }
-grin_api = { git = "https://github.com/mimblewimble/grin", rev = "cf2ed3f3becd62b5e754ec964fd90e332b9a021f" }
-grin_chain = { git = "https://github.com/mimblewimble/grin", rev = "cf2ed3f3becd62b5e754ec964fd90e332b9a021f" }
-
-# For local testing
-# grin_core = { path = "../../grin/core"}
-# grin_keychain = { path = "../../grin/keychain"}
-# grin_util = { path = "../../grin/util"}
-# grin_api = { path = "../../grin/api"}
-# grin_chain = { path = "../../grin/chain"}
+grin_core = { path = "../grin/core"}
+grin_keychain = { path = "../grin/keychain"}
+grin_util = { path = "../grin/util"}
+grin_api = { path = "../grin/api"}
+grin_chain = { path = "../grin/chain"}
 
 #####
 

--- a/impls/Cargo.toml
+++ b/impls/Cargo.toml
@@ -42,38 +42,12 @@ grin_wallet_libwallet = { path = "../libwallet", version = "5.4.0-alpha.1" }
 
 ##### Grin Imports
 
-# For Release
-#grin_core = "5.4.0"
-#grin_keychain = "5.4.0"
-#grin_chain = "5.4.0"
-#grin_util = "5.4.0"
-#grin_api = "5.4.0"
-#grin_store = "5.4.0"
-
-# For beta release
-
-# grin_core = { git = "https://github.com/mimblewimble/grin", tag = "v5.2.0-beta.3"}
-# grin_keychain = { git = "https://github.com/mimblewimble/grin", tag = "v5.2.0-beta.3" }
-# grin_chain = { git = "https://github.com/mimblewimble/grin", tag = "v5.2.0-beta.3" }
-# grin_util = { git = "https://github.com/mimblewimble/grin", tag = "v5.2.0-beta.3" }
-# grin_api = { git = "https://github.com/mimblewimble/grin", tag = "v5.2.0-beta.3" }
-# grin_store = { git = "https://github.com/mimblewimble/grin", tag = "v5.2.0-beta.3" }
-
-# For bleeding edge
-grin_core = { git = "https://github.com/mimblewimble/grin", rev = "cf2ed3f3becd62b5e754ec964fd90e332b9a021f" }
-grin_keychain = { git = "https://github.com/mimblewimble/grin", rev = "cf2ed3f3becd62b5e754ec964fd90e332b9a021f" }
-grin_chain = { git = "https://github.com/mimblewimble/grin", rev = "cf2ed3f3becd62b5e754ec964fd90e332b9a021f" }
-grin_util = { git = "https://github.com/mimblewimble/grin", rev = "cf2ed3f3becd62b5e754ec964fd90e332b9a021f" }
-grin_api = { git = "https://github.com/mimblewimble/grin", rev = "cf2ed3f3becd62b5e754ec964fd90e332b9a021f" }
-grin_store = { git = "https://github.com/mimblewimble/grin", rev = "cf2ed3f3becd62b5e754ec964fd90e332b9a021f" }
-
-# For local testing
-# grin_core = { path = "../../grin/core"}
-# grin_keychain = { path = "../../grin/keychain"}
-# grin_chain = { path = "../../grin/chain"}
-# grin_util = { path = "../../grin/util"}
-# grin_api = { path = "../../grin/api"}
-# grin_store = { path = "../../grin/store"}
+grin_core = { path = "../grin/core"}
+grin_keychain = { path = "../grin/keychain"}
+grin_chain = { path = "../grin/chain"}
+grin_util = { path = "../grin/util"}
+grin_api = { path = "../grin/api"}
+grin_store = { path = "../grin/store"}
 
 #####
 

--- a/libwallet/Cargo.toml
+++ b/libwallet/Cargo.toml
@@ -45,29 +45,9 @@ grin_wallet_config = { path = "../config", version = "5.4.0-alpha.1" }
 
 ##### Grin Imports
 
-# For Release
-#grin_core = "5.4.0"
-#grin_keychain = "5.4.0"
-#grin_util = "5.4.0"
-#grin_store = "5.4.0"
-
-# For beta release
-
-# grin_core = { git = "https://github.com/mimblewimble/grin", tag = "v5.2.0-beta.3"}
-# grin_keychain = { git = "https://github.com/mimblewimble/grin", tag = "v5.2.0-beta.3" }
-# grin_util = { git = "https://github.com/mimblewimble/grin", tag = "v5.2.0-beta.3" }
-# grin_store = { git = "https://github.com/mimblewimble/grin", tag = "v5.2.0-beta.3" }
-
-# For bleeding edge
-grin_core = { git = "https://github.com/mimblewimble/grin", rev = "cf2ed3f3becd62b5e754ec964fd90e332b9a021f" }
-grin_keychain = { git = "https://github.com/mimblewimble/grin", rev = "cf2ed3f3becd62b5e754ec964fd90e332b9a021f" }
-grin_util = { git = "https://github.com/mimblewimble/grin", rev = "cf2ed3f3becd62b5e754ec964fd90e332b9a021f" }
-grin_store = { git = "https://github.com/mimblewimble/grin", rev = "cf2ed3f3becd62b5e754ec964fd90e332b9a021f" }
-
-# For local testing
-# grin_core = { path = "../../grin/core"}
-# grin_keychain = { path = "../../grin/keychain"}
-# grin_util = { path = "../../grin/util"}
-# grin_store = { path = "../../grin/store"}
+grin_core = { path = "../grin/core"}
+grin_keychain = { path = "../grin/keychain"}
+grin_util = { path = "../grin/util"}
+grin_store = { path = "../grin/store"}
 
 #####

--- a/util/Cargo.toml
+++ b/util/Cargo.toml
@@ -21,18 +21,8 @@ thiserror = "1"
 ##### Grin Imports
 
 # For Release
-#grin_util = "5.4.0"
 
-# For beta release
-
-# grin_util = { git = "https://github.com/mimblewimble/grin", tag = "v5.2.0-beta.3" }
-
-# For bleeding edge
-grin_util = { git = "https://github.com/mimblewimble/grin", rev = "cf2ed3f3becd62b5e754ec964fd90e332b9a021f" }
-
-# For local testing
-
-# grin_util = { path = "../../grin/util"}
+grin_util = { path = "../grin/util"}
 
 #####
 


### PR DESCRIPTION
- Use node submodule for grin dependencies to make things easier for development and to avoid downloading grin dependencies from 3rd party resources like crates.io
- Update Github CI to checkout submodules
- Add contributing and build instructions to README

NOTE: before release it needs to change git submodule branch to master with:
```
git submodule set-branch -b master grin
git submodule sync
git submodule update --init --remote grin
```

TODO: change repo and branch to staging after merge of https://github.com/mimblewimble/grin/pull/3851