### PR TITLE
Optimize tor sync flow

### DIFF
--- a/api/src/foreign.rs
+++ b/api/src/foreign.rs
@@ -373,7 +373,7 @@ where
 			Some(a) => {
 				let tc = self.tor_config.lock();
 				let can_send = if let Some(tc) = tc.as_ref() {
-					tc.skip_send(None)
+					tc.send_tor(None)
 				} else {
 					false
 				};

--- a/api/src/foreign.rs
+++ b/api/src/foreign.rs
@@ -24,6 +24,7 @@ use crate::libwallet::{
 use crate::try_slatepack_sync_workflow;
 use crate::util::secp::key::SecretKey;
 use crate::util::Mutex;
+use libwallet::api_impl::types::update_tx_slate_state;
 use std::sync::Arc;
 
 /// ForeignAPI Middleware Check callback
@@ -381,7 +382,16 @@ where
 				}
 				let res = try_slatepack_sync_workflow(&ret_slate, &a, tc.clone(), None, true);
 				match res {
-					Ok(s) => Ok(s),
+					Ok(s) => {
+						let parent_key_id = w.parent_key_id();
+						let _ = update_tx_slate_state(
+							w,
+							(&self.keychain_mask).as_ref(),
+							&parent_key_id,
+							&s,
+						);
+						Ok(s)
+					}
 					Err(e) => {
 						error!("Error on sending over Tor: {}", e);
 						Ok(ret_slate)

--- a/api/src/foreign.rs
+++ b/api/src/foreign.rs
@@ -384,12 +384,15 @@ where
 				match res {
 					Ok(s) => {
 						let parent_key_id = w.parent_key_id();
-						let _ = update_tx_slate_state(
+						match update_tx_slate_state(
 							w,
 							(&self.keychain_mask).as_ref(),
 							&parent_key_id,
 							&s,
-						);
+						) {
+							Ok(_) => {}
+							Err(e) => error!("Error on updating slate state: {}", e),
+						}
 						Ok(s)
 					}
 					Err(e) => {

--- a/api/src/foreign.rs
+++ b/api/src/foreign.rs
@@ -370,18 +370,22 @@ where
 		)?;
 		match r_addr {
 			Some(a) => {
-				let tor_config_lock = self.tor_config.lock();
-				let res = try_slatepack_sync_workflow(
-					&ret_slate,
-					&a,
-					tor_config_lock.clone(),
-					None,
-					true,
-					self.doctest_mode,
-				);
+				let tc = self.tor_config.lock();
+				let can_send = if let Some(tc) = tc.as_ref() {
+					tc.skip_send(None)
+				} else {
+					false
+				};
+				if self.doctest_mode || !can_send {
+					return Ok(ret_slate);
+				}
+				let res = try_slatepack_sync_workflow(&ret_slate, &a, tc.clone(), None, true);
 				match res {
-					Ok(s) => Ok(s.unwrap()),
-					Err(_) => Ok(ret_slate),
+					Ok(s) => Ok(s),
+					Err(e) => {
+						error!("Error on sending over Tor: {}", e);
+						Ok(ret_slate)
+					}
 				}
 			}
 			None => Ok(ret_slate),

--- a/api/src/owner.rs
+++ b/api/src/owner.rs
@@ -37,6 +37,7 @@ use crate::util::logger::LoggingConfig;
 use crate::util::secp::{key::SecretKey, pedersen::Commitment};
 use crate::util::{from_hex, static_secp_instance, Mutex, ZeroingString};
 use grin_wallet_util::OnionV3Address;
+use libwallet::api_impl::types::update_tx_slate_state;
 use std::convert::TryFrom;
 use std::sync::atomic::{AtomicBool, Ordering};
 use std::sync::mpsc::{channel, Sender};
@@ -673,28 +674,27 @@ where
 			Some(sa) => {
 				let tor_config_lock = self.tor_config.lock();
 				let tc = tor_config_lock.clone();
-				let tc = match tc {
-					Some(mut c) => {
-						if let Some(skip_tor) = sa.skip_tor {
-							c.skip_send_attempt = Some(skip_tor);
-						}
-						Some(c)
-					}
-					None => None,
+				let can_send = if let Some(tc) = tc.as_ref() {
+					tc.skip_send(sa.skip_tor)
+				} else {
+					false
 				};
-				let res = try_slatepack_sync_workflow(
-					&slate,
-					&sa.dest,
-					tc,
-					None,
-					false,
-					self.doctest_mode,
-				);
+				if self.doctest_mode || !can_send {
+					return Ok(slate);
+				}
+				let res = try_slatepack_sync_workflow(&slate, &sa.dest, tc, None, false);
 				match res {
-					Ok(Some(s)) => {
+					Ok(s) => {
+						self.tx_lock_outputs(keychain_mask, &s)?;
+						let ret_slate = self.finalize_tx(keychain_mask, &s)?;
+						// Update slate state to actual.
+						{
+							let mut w_lock = self.wallet_inst.lock();
+							let w = w_lock.lc_provider()?.wallet_inst()?;
+							let parent_key_id = w.parent_key_id();
+							let _ = update_tx_slate_state(w, keychain_mask, &parent_key_id, &s);
+						}
 						if sa.post_tx {
-							self.tx_lock_outputs(keychain_mask, &s)?;
-							let ret_slate = self.finalize_tx(keychain_mask, &s)?;
 							let result = self.post_tx(keychain_mask, &ret_slate, sa.fluff);
 							match result {
 								Ok(_) => {
@@ -707,13 +707,13 @@ where
 								}
 							}
 						} else {
-							self.tx_lock_outputs(keychain_mask, &s)?;
-							let ret_slate = self.finalize_tx(keychain_mask, &s)?;
 							Ok(ret_slate)
 						}
 					}
-					Ok(None) => Ok(slate),
-					Err(_) => Ok(slate),
+					Err(e) => {
+						error!("Error on sending over Tor: {}", e);
+						Ok(slate)
+					}
 				}
 			}
 			None => Ok(slate),
@@ -841,26 +841,25 @@ where
 			Some(sa) => {
 				let tor_config_lock = self.tor_config.lock();
 				let tc = tor_config_lock.clone();
-				let tc = match tc {
-					Some(mut c) => {
-						if let Some(skip_tor) = sa.skip_tor {
-							c.skip_send_attempt = Some(skip_tor);
-						}
-						Some(c)
-					}
-					None => None,
+				let can_send = if let Some(tc) = tc.as_ref() {
+					tc.skip_send(sa.skip_tor)
+				} else {
+					false
 				};
-				let res = try_slatepack_sync_workflow(
-					&slate,
-					&sa.dest,
-					tc,
-					None,
-					true,
-					self.doctest_mode,
-				);
+				if self.doctest_mode || !can_send {
+					return Ok(slate);
+				}
+				let res = try_slatepack_sync_workflow(&slate, &sa.dest, tc, None, true);
 				match res {
-					Ok(s) => Ok(s.unwrap()),
-					Err(_) => Ok(slate),
+					Ok(s) => {
+						let parent_key_id = w.parent_key_id();
+						let _ = update_tx_slate_state(w, keychain_mask, &parent_key_id, &s);
+						Ok(s)
+					}
+					Err(e) => {
+						error!("Error on sending over Tor: {}", e);
+						Ok(slate)
+					}
 				}
 			}
 			None => Ok(slate),
@@ -2497,13 +2496,7 @@ pub fn try_slatepack_sync_workflow(
 	tor_config: Option<TorConfig>,
 	tor_sender: Option<TorSlateSender>,
 	send_to_finalize: bool,
-	test_mode: bool,
-) -> Result<Option<Slate>, Error> {
-	if let Some(tc) = &tor_config {
-		if tc.skip_send_attempt == Some(true) {
-			return Ok(None);
-		}
-	}
+) -> Result<Slate, Error> {
 	let mut ret_slate = Slate::blank(2, false);
 	let mut send_sync = |mut sender: TorSlateSender, method_str: &str| match sender
 		.send_tx(&slate, send_to_finalize)
@@ -2521,55 +2514,43 @@ pub fn try_slatepack_sync_workflow(
 		}
 	};
 
-	// Try parsing Slatepack address
+	// Try parsing Slatepack address.
 	match SlatepackAddress::try_from(dest) {
 		Ok(address) => {
-			let tor_addr = OnionV3Address::try_from(&address).unwrap();
-			// Try sending to the destination via TOR
+			let tor_addr = OnionV3Address::try_from(&address).map_err(|_| {
+				Error::SlatepackAddress(format!(
+					"Destination {} is not a valid Onion address.",
+					dest
+				))
+			})?;
+			// Try sending to the destination via Tor.
 			let sender = match tor_sender {
 				None => {
-					if test_mode {
-						None
-					} else {
-						if let Some(tc) = tor_config {
-							match TorSlateSender::new(&tor_addr.to_http_str(), tc) {
-								Ok(s) => Some(s),
-								Err(e) => {
-									debug!("Send (TOR): Cannot create TOR Slate sender {:?}", e);
-									None
-								}
+					if let Some(tc) = tor_config {
+						match TorSlateSender::new(&tor_addr.to_http_str(), tc) {
+							Ok(s) => s,
+							Err(e) => {
+								debug!("Send (Tor): Cannot create TOR Slate sender {:?}", e);
+								return Err(e);
 							}
-						} else {
-							return Err(Error::TorConfig("Tor config is not set".to_string()));
 						}
-					}
-				}
-				Some(s) => {
-					if test_mode {
-						None
 					} else {
-						Some(s)
+						return Err(Error::TorConfig("Tor config is not set".to_string()));
 					}
 				}
+				Some(s) => s,
 			};
-			if let Some(s) = sender {
-				warn!("Attempting to send transaction via TOR");
-				match send_sync(s, "TOR") {
-					Ok(_) => return Ok(Some(ret_slate)),
-					Err(e) => {
-						debug!("Unable to send via TOR: {}", e);
-						warn!("Unable to send transaction via TOR");
-					}
-				}
+			warn!("Attempting to send transaction via Tor");
+			match send_sync(sender, "Tor") {
+				Ok(_) => Ok(ret_slate),
+				Err(e) => Err(e),
 			}
 		}
 		Err(e) => {
-			debug!("Send (TOR): Destination is not SlatepackAddress {:?}", e);
-			warn!("Destination is not a valid Slatepack address. Will output Slatepack.")
+			error!("Destination {} is not a valid Slatepack address.", dest);
+			Err(e)
 		}
 	}
-
-	Ok(None)
 }
 
 #[doc(hidden)]

--- a/api/src/owner.rs
+++ b/api/src/owner.rs
@@ -677,7 +677,7 @@ where
 				let tor_config_lock = self.tor_config.lock();
 				let tc = tor_config_lock.clone();
 				let can_send = if let Some(tc) = tc.as_ref() {
-					tc.skip_send(sa.skip_tor)
+					tc.send_tor(sa.skip_tor)
 				} else {
 					false
 				};
@@ -837,7 +837,7 @@ where
 				let tor_config_lock = self.tor_config.lock();
 				let tc = tor_config_lock.clone();
 				let can_send = if let Some(tc) = tc.as_ref() {
-					tc.skip_send(sa.skip_tor)
+					tc.send_tor(sa.skip_tor)
 				} else {
 					false
 				};

--- a/api/src/owner.rs
+++ b/api/src/owner.rs
@@ -854,10 +854,16 @@ where
 							let mut w_lock = self.wallet_inst.lock();
 							let w = w_lock.lc_provider()?.wallet_inst()?;
 							let parent_key_id = w.parent_key_id();
-							let _ = update_tx_slate_state(w, keychain_mask, &parent_key_id, &s);
+							match update_tx_slate_state(w, keychain_mask, &parent_key_id, &s) {
+								Ok(_) => {}
+								Err(e) => error!("Error on updating slate state: {}", e),
+							}
 						}
 						// Output slatepack message to file.
-						let _ = output_slatepack_file(&self, keychain_mask, &s, &sa.dest);
+						match output_slatepack_file(&self, keychain_mask, &s, &sa.dest) {
+							Ok(_) => {}
+							Err(e) => error!("Error on saving output slatepack message: {}", e),
+						}
 						Ok(s)
 					}
 					Err(e) => {

--- a/api/src/owner.rs
+++ b/api/src/owner.rs
@@ -39,6 +39,8 @@ use crate::util::{from_hex, static_secp_instance, Mutex, ZeroingString};
 use grin_wallet_util::OnionV3Address;
 use libwallet::api_impl::types::update_tx_slate_state;
 use std::convert::TryFrom;
+use std::fs::File;
+use std::io::Write;
 use std::sync::atomic::{AtomicBool, Ordering};
 use std::sync::mpsc::{channel, Sender};
 use std::sync::Arc;
@@ -687,13 +689,6 @@ where
 					Ok(s) => {
 						self.tx_lock_outputs(keychain_mask, &s)?;
 						let ret_slate = self.finalize_tx(keychain_mask, &s)?;
-						// Update slate state to actual.
-						{
-							let mut w_lock = self.wallet_inst.lock();
-							let w = w_lock.lc_provider()?.wallet_inst()?;
-							let parent_key_id = w.parent_key_id();
-							let _ = update_tx_slate_state(w, keychain_mask, &parent_key_id, &s);
-						}
 						if sa.post_tx {
 							let result = self.post_tx(keychain_mask, &ret_slate, sa.fluff);
 							match result {
@@ -854,6 +849,7 @@ where
 					Ok(s) => {
 						let parent_key_id = w.parent_key_id();
 						let _ = update_tx_slate_state(w, keychain_mask, &parent_key_id, &s);
+						let _ = output_slatepack_file(&self, keychain_mask, &s, &sa.dest);
 						Ok(s)
 					}
 					Err(e) => {
@@ -2617,4 +2613,39 @@ macro_rules! doctest_helper_setup_doc_env {
 		lc.open_wallet(None, pw, false, false);
 		let mut $wallet = Arc::new(Mutex::new(wallet));
 	};
+}
+
+/// Output slatepack message to file.
+fn output_slatepack_file<L, C, K>(
+	api: &Owner<L, C, K>,
+	keychain_mask: Option<&SecretKey>,
+	slate: &Slate,
+	dest: &str,
+) -> Result<(), Error>
+where
+	L: WalletLCProvider<'static, C, K> + 'static,
+	C: NodeClient + 'static,
+	K: Keychain + 'static,
+{
+	let address = match SlatepackAddress::try_from(dest) {
+		Ok(a) => Some(a),
+		Err(_) => None,
+	};
+	// encrypt for recipient by default
+	let recipients = match address.clone() {
+		Some(a) => vec![a],
+		None => vec![],
+	};
+	let message = api.create_slatepack_message(keychain_mask, &slate, Some(0), recipients)?;
+	let tld = api.get_top_level_directory()?;
+
+	// Create a directory to which files will be output.
+	let slate_dir = format!("{}/{}", tld, "slatepack");
+	let _ = std::fs::create_dir_all(slate_dir.clone());
+	let out_file_name = format!("{}/{}.{}.slatepack", slate_dir, slate.id, slate.state);
+
+	let mut output = File::create(out_file_name.clone())?;
+	output.write_all(&message.as_bytes())?;
+	output.sync_all()?;
+	Ok(())
 }

--- a/api/src/owner.rs
+++ b/api/src/owner.rs
@@ -827,10 +827,12 @@ where
 		slate: &Slate,
 		args: InitTxArgs,
 	) -> Result<Slate, Error> {
-		let mut w_lock = self.wallet_inst.lock();
-		let w = w_lock.lc_provider()?.wallet_inst()?;
 		let send_args = args.send_args.clone();
-		let slate = owner::process_invoice_tx(w, keychain_mask, slate, args, self.doctest_mode)?;
+		let slate = {
+			let mut w_lock = self.wallet_inst.lock();
+			let w = w_lock.lc_provider()?.wallet_inst()?;
+			owner::process_invoice_tx(w, keychain_mask, slate, args, self.doctest_mode)?
+		};
 		// Helper functionality. If send arguments exist, attempt to send
 		match send_args {
 			Some(sa) => {
@@ -847,8 +849,14 @@ where
 				let res = try_slatepack_sync_workflow(&slate, &sa.dest, tc, None, true);
 				match res {
 					Ok(s) => {
-						let parent_key_id = w.parent_key_id();
-						let _ = update_tx_slate_state(w, keychain_mask, &parent_key_id, &s);
+						// Update slate state.
+						{
+							let mut w_lock = self.wallet_inst.lock();
+							let w = w_lock.lc_provider()?.wallet_inst()?;
+							let parent_key_id = w.parent_key_id();
+							let _ = update_tx_slate_state(w, keychain_mask, &parent_key_id, &s);
+						}
+						// Output slatepack message to file.
 						let _ = output_slatepack_file(&self, keychain_mask, &s, &sa.dest);
 						Ok(s)
 					}

--- a/config/src/types.rs
+++ b/config/src/types.rs
@@ -195,12 +195,12 @@ impl Default for TorConfig {
 }
 
 impl TorConfig {
-	/// Check if attempt to send over Tor must be skipped using provided possible argument at priority.
-	pub fn skip_send(&self, skip_arg: Option<bool>) -> bool {
+	/// Check if attempt to send over Tor is needed using provided possible argument at priority.
+	pub fn send_tor(&self, skip_arg: Option<bool>) -> bool {
 		if let Some(skip_tor) = skip_arg {
-			return skip_tor;
+			return !skip_tor;
 		}
-		self.skip_send_attempt.unwrap_or(false)
+		!self.skip_send_attempt.unwrap_or(false)
 	}
 }
 

--- a/config/src/types.rs
+++ b/config/src/types.rs
@@ -164,18 +164,18 @@ impl From<io::Error> for ConfigError {
 pub struct TorConfig {
 	/// whether to use integrated Tor library
 	pub use_integrated: Option<bool>,
-	/// whether to skip any attempts to send via TOR
+	/// whether to skip any attempts to send via Tor
 	pub skip_send_attempt: Option<bool>,
-	/// Whether to start tor listener on listener startup (default true)
+	/// Whether to start Tor listener on listener startup (default true)
 	pub use_tor_listener: bool,
 	/// Just the address of the socks proxy for now
 	pub socks_proxy_addr: String,
 	/// Send configuration directory
 	pub send_config_dir: String,
-	/// tor bridge config
+	/// Tor bridge config
 	#[serde(default)]
 	pub bridge: TorBridgeConfig,
-	/// tor proxy config
+	/// Tor proxy config
 	#[serde(default)]
 	pub proxy: TorProxyConfig,
 }
@@ -191,6 +191,16 @@ impl Default for TorConfig {
 			bridge: TorBridgeConfig::default(),
 			proxy: TorProxyConfig::default(),
 		}
+	}
+}
+
+impl TorConfig {
+	/// Check if attempt to send over Tor must be skipped using provided possible argument at priority.
+	pub fn skip_send(&self, skip_arg: Option<bool>) -> bool {
+		if let Some(skip_tor) = skip_arg {
+			return skip_tor;
+		}
+		self.skip_send_attempt.unwrap_or(false)
 	}
 }
 

--- a/controller/src/command.rs
+++ b/controller/src/command.rs
@@ -450,7 +450,7 @@ where
 	};
 
 	let can_send = if let Some(tc) = tor_config.as_ref() {
-		tc.skip_send(args.skip_tor)
+		tc.send_tor(args.skip_tor)
 	} else {
 		false
 	};
@@ -707,7 +707,7 @@ where
 	};
 
 	let can_send = if let Some(tc) = tor_config.as_ref() {
-		tc.skip_send(args.skip_tor)
+		tc.send_tor(args.skip_tor)
 	} else {
 		false
 	};
@@ -1050,7 +1050,7 @@ where
 	};
 
 	let can_send = if let Some(tc) = tor_config.as_ref() {
-		tc.skip_send(args.skip_tor)
+		tc.send_tor(args.skip_tor)
 	} else {
 		false
 	};

--- a/controller/src/command.rs
+++ b/controller/src/command.rs
@@ -40,6 +40,7 @@ use std::sync::Arc;
 use std::thread;
 use std::time::Duration;
 use uuid::Uuid;
+use grin_wallet_libwallet::api_impl::types::update_tx_slate_state;
 
 fn show_recovery_phrase(phrase: ZeroingString) {
 	println!("Your recovery phrase is:");
@@ -718,7 +719,17 @@ where
 	let res = try_slatepack_sync_workflow(&slate, &dest, tor_config, None, true);
 
 	match res {
-		Ok(_) => {
+		Ok(s) => {
+			// Update slate state.
+			{
+				let mut w_lock = owner_api.wallet_inst.lock();
+				let w = w_lock.lc_provider()?.wallet_inst()?;
+				let parent_key_id = w.parent_key_id();
+				match update_tx_slate_state(w, keychain_mask, &parent_key_id, &s) {
+					Ok(_) => {}
+					Err(e) => error!("Error on updating slate state: {}", e),
+				}
+			}
 			println!();
 			println!(
 				"Transaction received and sent back to sender at {} for finalization.",
@@ -1061,7 +1072,17 @@ where
 	let res = try_slatepack_sync_workflow(&slate, &dest, tor_config, None, true);
 
 	match res {
-		Ok(_) => {
+		Ok(s) => {
+			// Update slate state.
+			{
+				let mut w_lock = owner_api.wallet_inst.lock();
+				let w = w_lock.lc_provider()?.wallet_inst()?;
+				let parent_key_id = w.parent_key_id();
+				match update_tx_slate_state(w, keychain_mask, &parent_key_id, &s) {
+					Ok(_) => {}
+					Err(e) => error!("Error on updating slate state: {}", e),
+				}
+			}
 			println!();
 			println!(
 				"Transaction paid and sent back to initiator at {} for finalization.",

--- a/controller/src/command.rs
+++ b/controller/src/command.rs
@@ -431,18 +431,37 @@ where
 			if let Some(b) = args.bridge.clone() {
 				c.bridge.bridge_line = Some(b);
 			}
-			if let Some(s) = args.skip_tor {
-				c.skip_send_attempt = Some(s);
-			}
 			Some(c)
 		}
 		None => None,
 	};
 
-	let res = try_slatepack_sync_workflow(&slate, &args.dest, tor_config, None, false, test_mode);
+	let output_sp = || -> Result<(), Error> {
+		Ok(output_slatepack(
+			owner_api,
+			keychain_mask,
+			&slate,
+			args.dest.as_str(),
+			args.outfile,
+			true,
+			false,
+			args.slatepack_qr,
+		)?)
+	};
+
+	let can_send = if let Some(tc) = tor_config.as_ref() {
+		tc.skip_send(args.skip_tor)
+	} else {
+		false
+	};
+	if test_mode || !can_send {
+		return output_sp();
+	}
+
+	let res = try_slatepack_sync_workflow(&slate, &args.dest, tor_config, None, false);
 
 	match res {
-		Ok(Some(s)) => {
+		Ok(s) => {
 			controller::owner_single_use(None, keychain_mask, Some(owner_api), |api, m| {
 				api.tx_lock_outputs(m, &s)?;
 				let ret_slate = api.finalize_tx(m, &s)?;
@@ -459,19 +478,10 @@ where
 				}
 			})?;
 		}
-		Ok(None) => {
-			output_slatepack(
-				owner_api,
-				keychain_mask,
-				&slate,
-				args.dest.as_str(),
-				args.outfile,
-				true,
-				false,
-				args.slatepack_qr,
-			)?;
+		Err(e) => {
+			error!("Error sending slate sync: {}", e);
+			output_sp()?;
 		}
-		Err(e) => return Err(e.into()),
 	}
 	Ok(())
 }
@@ -668,9 +678,6 @@ where
 			if let Some(b) = args.bridge {
 				c.bridge.bridge_line = Some(b);
 			}
-			if let Some(s) = args.skip_tor {
-				c.skip_send_attempt = Some(s);
-			}
 			Some(c)
 		}
 		None => None,
@@ -686,33 +693,45 @@ where
 		None => String::from(""),
 	};
 
-	let res = try_slatepack_sync_workflow(&slate, &dest, tor_config, None, true, test_mode);
+	let output_sp = || -> Result<(), Error> {
+		Ok(output_slatepack(
+			owner_api,
+			keychain_mask,
+			&slate,
+			&dest,
+			args.outfile,
+			false,
+			false,
+			args.slatepack_qr,
+		)?)
+	};
+
+	let can_send = if let Some(tc) = tor_config.as_ref() {
+		tc.skip_send(args.skip_tor)
+	} else {
+		false
+	};
+	if test_mode || !can_send {
+		return output_sp();
+	}
+
+	let res = try_slatepack_sync_workflow(&slate, &dest, tor_config, None, true);
 
 	match res {
-		Ok(Some(_)) => {
+		Ok(_) => {
 			println!();
 			println!(
 				"Transaction received and sent back to sender at {} for finalization.",
 				dest
 			);
 			println!();
-			Ok(())
 		}
-		Ok(None) => {
-			output_slatepack(
-				owner_api,
-				keychain_mask,
-				&slate,
-				&dest,
-				args.outfile,
-				false,
-				false,
-				args.slatepack_qr,
-			)?;
-			Ok(())
+		Err(e) => {
+			error!("Error sending slate sync: {}", e);
+			output_sp()?;
 		}
-		Err(e) => Err(e.into()),
 	}
+	Ok(())
 }
 
 pub fn unpack<L, C, K>(
@@ -1012,41 +1031,50 @@ where
 			if let Some(b) = args.bridge {
 				c.bridge.bridge_line = Some(b);
 			}
-			if let Some(skip_tor) = args.skip_tor {
-				c.skip_send_attempt = Some(skip_tor);
-			}
 			Some(c)
 		}
 		None => None,
 	};
 
-	let res = try_slatepack_sync_workflow(&slate, &dest, tor_config, None, true, test_mode);
+	let output_sp = || -> Result<(), Error> {
+		Ok(output_slatepack(
+			owner_api,
+			keychain_mask,
+			&slate,
+			&dest,
+			args.outfile,
+			true,
+			false,
+			args.slatepack_qr,
+		)?)
+	};
+
+	let can_send = if let Some(tc) = tor_config.as_ref() {
+		tc.skip_send(args.skip_tor)
+	} else {
+		false
+	};
+	if test_mode || !can_send {
+		return output_sp();
+	}
+
+	let res = try_slatepack_sync_workflow(&slate, &dest, tor_config, None, true);
 
 	match res {
-		Ok(Some(_)) => {
+		Ok(_) => {
 			println!();
 			println!(
 				"Transaction paid and sent back to initiator at {} for finalization.",
 				dest
 			);
 			println!();
-			Ok(())
 		}
-		Ok(None) => {
-			output_slatepack(
-				owner_api,
-				keychain_mask,
-				&slate,
-				&dest,
-				args.outfile,
-				true,
-				false,
-				args.slatepack_qr,
-			)?;
-			Ok(())
+		Err(e) => {
+			error!("Error sending slate sync: {}", e);
+			output_sp()?;
 		}
-		Err(e) => Err(e.into()),
 	}
+	Ok(())
 }
 
 /// Info command args

--- a/impls/src/tor/arti.rs
+++ b/impls/src/tor/arti.rs
@@ -300,9 +300,7 @@ fn init_client(
 				cached_client_config.replace((client.clone(), config.clone()));
 				Ok((client, config))
 			}
-			Err(e) => {
-				Err(e)
-			},
+			Err(e) => Err(e),
 		};
 	}
 

--- a/libwallet/src/api_impl/foreign.rs
+++ b/libwallet/src/api_impl/foreign.rs
@@ -14,11 +14,11 @@
 
 //! Generic implementation of owner API functions
 
-use grin_keychain::Identifier;
 use strum::IntoEnumIterator;
 
 use super::owner::tx_lock_outputs;
 use crate::api_impl::owner::{check_ttl, post_tx};
+use crate::api_impl::types::update_tx_slate_state;
 use crate::backend::WalletBackend;
 use crate::grin_core::core::FeeFields;
 use crate::grin_keychain::Keychain;
@@ -235,40 +235,4 @@ where
 		post_tx(w.w2n_client(), sl.tx_or_err()?, true)?;
 	}
 	Ok(sl)
-}
-
-/// Update transaction slate state.
-fn update_tx_slate_state<C, K>(
-	wallet: &mut WalletBackend<C, K>,
-	keychain_mask: Option<&SecretKey>,
-	parent_key_id: &Identifier,
-	slate: &Slate,
-) -> Result<(), Error>
-where
-	C: NodeClient,
-	K: Keychain,
-{
-	let mut bad_records = 0;
-	let tx = wallet
-		.tx_log_iter()?
-		.filter(|tx| {
-			if tx.is_err() {
-				bad_records += 1;
-			}
-			tx.is_ok()
-		})
-		.map(|tx| tx.unwrap())
-		.find(|tx| tx.tx_slate_id == Some(slate.id));
-	if let Some(mut tx) = tx {
-		let mut batch = wallet.batch(keychain_mask)?;
-		tx.tx_slate_state = Some(slate.state.clone());
-		batch.save_tx_log_entry(tx.clone(), parent_key_id)?;
-		batch.commit()?;
-	} else {
-		return Err(Error::Backend(format!(
-			"Tx log entry with slate id {} not found, there are {} bad tx log records",
-			slate.id, bad_records
-		)));
-	}
-	Ok(())
 }

--- a/libwallet/src/api_impl/types.rs
+++ b/libwallet/src/api_impl/types.rs
@@ -21,10 +21,12 @@ use crate::grin_util::secp::pedersen;
 use crate::slate_versions::ser as dalek_ser;
 use crate::slate_versions::SlateVersion;
 use crate::types::OutputData;
-use crate::SlatepackAddress;
+use crate::{Error, NodeClient, Slate, SlatepackAddress, WalletBackend};
 
 use chrono::prelude::*;
 use ed25519_dalek::Signature as DalekSignature;
+use grin_keychain::Keychain;
+use grin_util::secp::SecretKey;
 
 pub use crate::mwixnet::{Hop, MixnetReqCreationParams, SwapReq};
 
@@ -343,4 +345,40 @@ pub struct BuiltOutput {
 	pub key_id: Identifier,
 	/// Output
 	pub output: Output,
+}
+
+/// Update transaction slate state.
+pub fn update_tx_slate_state<C, K>(
+	wallet: &mut WalletBackend<C, K>,
+	keychain_mask: Option<&SecretKey>,
+	parent_key_id: &Identifier,
+	slate: &Slate,
+) -> Result<(), Error>
+where
+	C: NodeClient,
+	K: Keychain,
+{
+	let mut bad_records = 0;
+	let tx = wallet
+		.tx_log_iter()?
+		.filter(|tx| {
+			if tx.is_err() {
+				bad_records += 1;
+			}
+			tx.is_ok()
+		})
+		.map(|tx| tx.unwrap())
+		.find(|tx| tx.tx_slate_id == Some(slate.id));
+	if let Some(mut tx) = tx {
+		let mut batch = wallet.batch(keychain_mask)?;
+		tx.tx_slate_state = Some(slate.state.clone());
+		batch.save_tx_log_entry(tx.clone(), parent_key_id)?;
+		batch.commit()?;
+	} else {
+		return Err(Error::Backend(format!(
+			"Tx log entry with slate id {} not found, there are {} bad tx log records",
+			slate.id, bad_records
+		)));
+	}
+	Ok(())
 }


### PR DESCRIPTION
- Return concrete error on sync workflow instead of `None`
- Update slate state after finalize over Tor
- Output slate to file after finalize request