### PR TITLE
Optimize outputs scan and selection

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2648,6 +2648,7 @@ dependencies = [
  "log",
  "num-bigint 0.2.6",
  "rand 0.6.5",
+ "rayon",
  "regex",
  "serde",
  "serde_derive",

--- a/api/src/foreign_rpc.rs
+++ b/api/src/foreign_rpc.rs
@@ -375,7 +375,7 @@ pub fn run_doctest_foreign(
 
 	util::init_test_logger();
 	let _ = fs::remove_dir_all(test_dir);
-	global::set_local_chain_type(ChainTypes::AutomatedTesting);
+	global::set_global_chain_type(ChainTypes::AutomatedTesting);
 
 	let _ = fs::create_dir_all(test_dir);
 	let config = initial_setup_wallet(

--- a/api/src/owner.rs
+++ b/api/src/owner.rs
@@ -473,7 +473,7 @@ where
 		)
 	}
 
-	/// Returns max available value to send for provided selection strategy.
+	/// Returns max available value to send for selecting all outputs.
 	///
 	/// # Arguments
 	/// * `keychain_mask` - Wallet secret mask to XOR against the stored wallet seed before using, if
@@ -495,7 +495,7 @@ where
 	/// argument was set to `true`).
 	/// * The second `u64` is amount to send.
 	/// * The third element is fee
-	/// * The forth is maximum input count for selected strategy
+	/// * The fourth is maximum input count
 	///
 	/// # Example
 	/// Set up as in [`new`](struct.Owner.html#method.new) method above.

--- a/api/src/owner.rs
+++ b/api/src/owner.rs
@@ -473,6 +473,69 @@ where
 		)
 	}
 
+	/// Returns max available value to send for provided selection strategy.
+	///
+	/// # Arguments
+	/// * `keychain_mask` - Wallet secret mask to XOR against the stored wallet seed before using, if
+	/// being used.
+	/// * `refresh_from_node` - If true, the wallet will attempt to contact
+	/// a node (via the [`NodeClient`](../grin_wallet_libwallet/types/trait.NodeClient.html)
+	/// provided during wallet instantiation). If `false`, the results will
+	/// contain transaction information that may be out-of-date (from the last time
+	/// the wallet's output set was refreshed against the node).
+	/// Note this setting is ignored if the updater process is running via a call to
+	/// [`start_updater`](struct.Owner.html#method.start_updater)
+	/// * `minimum_confirmations` - The minimum number of confirmations an output
+	/// should have before it's included in the 'amount_currently_spendable' total
+	///
+	/// # Returns
+	/// * `(bool, u64, u64, u32)` - A tuple:
+	/// * The first `bool` element indicates whether the data was successfully
+	/// refreshed from the node (note this may be false even if the `refresh_from_node`
+	/// argument was set to `true`).
+	/// * The second `u64` is amount to send.
+	/// * The third element is fee
+	/// * The forth is maximum input count for selected strategy
+	///
+	/// # Example
+	/// Set up as in [`new`](struct.Owner.html#method.new) method above.
+	/// ```
+	/// # grin_wallet_api::doctest_helper_setup_doc_env!(wallet, wallet_config);
+	///
+	/// let api_owner = Owner::new(wallet.clone(), None, std::path::PathBuf::from("grin-wallet.toml"));
+	/// let selection_strategy_is_use_all = false;
+	///
+	/// let result = api_owner.estimate_max_sendable(selection_strategy_is_use_all);
+	///
+	/// if let Ok((was_updated, output_mappings)) = result {
+	///     //...
+	/// }
+	/// ```
+
+	pub fn estimate_max_sendable(
+		&self,
+		keychain_mask: Option<&SecretKey>,
+		refresh_from_node: bool,
+		minimum_confirmations: u64,
+	) -> Result<(bool, u64, u64, u32), Error> {
+		let tx = {
+			let t = self.status_tx.lock();
+			t.clone()
+		};
+		let refresh_from_node = match self.updater_running.load(Ordering::Relaxed) {
+			true => false,
+			false => refresh_from_node,
+		};
+
+		owner::estimate_max_sendable(
+			self.wallet_inst.clone(),
+			keychain_mask,
+			&tx,
+			refresh_from_node,
+			minimum_confirmations,
+		)
+	}
+
 	/// Returns a list of [Transaction Log Entries](../grin_wallet_libwallet/types/struct.TxLogEntry.html)
 	/// from the active account in the wallet.
 	///

--- a/api/src/owner.rs
+++ b/api/src/owner.rs
@@ -507,7 +507,7 @@ where
 	/// let minimum_confirmations = 10;
 	/// let result = api_owner.estimate_max_sendable(None, update_from_node, minimum_confirmations);
 	///
-	/// if let Ok((was_updated, output_mappings)) = result {
+	/// if let Ok((was_updated, amount, fee, max_inputs)) = result {
 	///     //...
 	/// }
 	/// ```

--- a/api/src/owner.rs
+++ b/api/src/owner.rs
@@ -503,9 +503,9 @@ where
 	/// # grin_wallet_api::doctest_helper_setup_doc_env!(wallet, wallet_config);
 	///
 	/// let api_owner = Owner::new(wallet.clone(), None, std::path::PathBuf::from("grin-wallet.toml"));
-	/// let selection_strategy_is_use_all = false;
-	///
-	/// let result = api_owner.estimate_max_sendable(selection_strategy_is_use_all);
+	/// let update_from_node = true;
+	/// let minimum_confirmations = 10;
+	/// let result = api_owner.estimate_max_sendable(None, update_from_node, minimum_confirmations);
 	///
 	/// if let Ok((was_updated, output_mappings)) = result {
 	///     //...

--- a/api/src/owner.rs
+++ b/api/src/owner.rs
@@ -604,21 +604,34 @@ where
 		refresh_from_node: bool,
 		minimum_confirmations: u64,
 	) -> Result<(bool, WalletInfo), Error> {
+		let (updated, _, info) = self.retrieve_summary_info_with_refresh_status(
+			keychain_mask,
+			refresh_from_node,
+			minimum_confirmations,
+		)?;
+		Ok((updated, info))
+	}
+
+	/// Retrieve summary info and whether refresh was skipped.
+	pub fn retrieve_summary_info_with_refresh_status(
+		&self,
+		keychain_mask: Option<&SecretKey>,
+		refresh_from_node: bool,
+		minimum_confirmations: u64,
+	) -> Result<(bool, bool, WalletInfo), Error> {
 		let tx = {
 			let t = self.status_tx.lock();
 			t.clone()
 		};
-		let refresh_from_node = match self.updater_running.load(Ordering::Relaxed) {
-			true => false,
-			false => refresh_from_node,
-		};
-		owner::retrieve_summary_info(
+		let refresh_skipped = refresh_from_node && self.updater_running.load(Ordering::Relaxed);
+		let (updated, info) = owner::retrieve_summary_info(
 			self.wallet_inst.clone(),
 			keychain_mask,
 			&tx,
-			refresh_from_node,
+			refresh_from_node && !refresh_skipped,
 			minimum_confirmations,
-		)
+		)?;
+		Ok((updated, refresh_skipped, info))
 	}
 
 	/// Initiates a new transaction as the sender, creating a new

--- a/api/src/owner_rpc.rs
+++ b/api/src/owner_rpc.rs
@@ -229,7 +229,7 @@ pub trait OwnerRpc {
 	) -> Result<(bool, Vec<OutputCommitMapping>), Error>;
 
 	/**
-	Networked version of [Owner::retrieve_txs](struct.Owner.html#method.estimate_max_sendable).
+	Networked version of [Owner::estimate_max_sendable](struct.Owner.html#method.estimate_max_sendable).
 
 	# Json rpc example
 

--- a/api/src/owner_rpc.rs
+++ b/api/src/owner_rpc.rs
@@ -461,62 +461,62 @@ pub trait OwnerRpc {
 	) -> Result<(bool, WalletInfo), Error>;
 
 	/**
-		;Networked version of [Owner::init_send_tx](struct.Owner.html#method.init_send_tx).
-	z
-		```
-			# grin_wallet_api::doctest_helper_json_rpc_owner_assert_response!(
-			# r#"
-			{
-				"jsonrpc": "2.0",
-				"method": "init_send_tx",
-				"params": {
-					"token": "d202964900000000d302964900000000d402964900000000d502964900000000",
-					"args": {
-						"src_acct_name": null,
-						"amount": "6000000000",
-						"minimum_confirmations": 2,
-						"max_outputs": 500,
-						"num_change_outputs": 1,
-						"selection_strategy_is_use_all": true,
-						"refresh_outputs_from_node": true,
-						"target_slate_version": null,
-						"payment_proof_recipient_address": "tgrin1xtxavwfgs48ckf3gk8wwgcndmn0nt4tvkl8a7ltyejjcy2mc6nfs9gm2lp",
-						"ttl_blocks": null,
-						"send_args": null
-					}
-				},
-				"id": 1
-			}
-			# "#
-			# ,
-			# r#"
-			{
-			"id": 1,
-				"jsonrpc": "2.0",
-				"result": {
-					"Ok": {
-						"amt": "6000000000",
-						"fee": "23000000",
-						"id": "0436430c-2b02-624c-2032-570501212b00",
-						"proof": {
-							"raddr": "32cdd63928854f8b2628b1dce4626ddcdf35d56cb7cfdf7d64cca5822b78d4d3",
-							"saddr": "32cdd63928854f8b2628b1dce4626ddcdf35d56cb7cfdf7d64cca5822b78d4d3"
-						},
-						"sigs": [
-							{
-								"nonce": "031b84c5567b126440995d3ed5aaba0565d71e1834604819ff9c17f5e9d5dd078f",
-								"xs": "02e89cce4499ac1e9bb498dab9e3fab93cc40cd3d26c04a0292e00f4bf272499ec"
-							}
-						],
-						"sta": "S1",
-						"ver": "4:2"
-					}
+	Networked version of [Owner::init_send_tx](struct.Owner.html#method.init_send_tx).
+
+	```
+		# grin_wallet_api::doctest_helper_json_rpc_owner_assert_response!(
+		# r#"
+		{
+			"jsonrpc": "2.0",
+			"method": "init_send_tx",
+			"params": {
+				"token": "d202964900000000d302964900000000d402964900000000d502964900000000",
+				"args": {
+					"src_acct_name": null,
+					"amount": "6000000000",
+					"minimum_confirmations": 2,
+					"max_outputs": 500,
+					"num_change_outputs": 1,
+					"selection_strategy_is_use_all": true,
+					"refresh_outputs_from_node": true,
+					"target_slate_version": null,
+					"payment_proof_recipient_address": "tgrin1xtxavwfgs48ckf3gk8wwgcndmn0nt4tvkl8a7ltyejjcy2mc6nfs9gm2lp",
+					"ttl_blocks": null,
+					"send_args": null
+				}
+			},
+			"id": 1
+		}
+		# "#
+		# ,
+		# r#"
+		{
+		"id": 1,
+			"jsonrpc": "2.0",
+			"result": {
+				"Ok": {
+					"amt": "6000000000",
+					"fee": "23000000",
+					"id": "0436430c-2b02-624c-2032-570501212b00",
+					"proof": {
+						"raddr": "32cdd63928854f8b2628b1dce4626ddcdf35d56cb7cfdf7d64cca5822b78d4d3",
+						"saddr": "32cdd63928854f8b2628b1dce4626ddcdf35d56cb7cfdf7d64cca5822b78d4d3"
+					},
+					"sigs": [
+						{
+							"nonce": "031b84c5567b126440995d3ed5aaba0565d71e1834604819ff9c17f5e9d5dd078f",
+							"xs": "02e89cce4499ac1e9bb498dab9e3fab93cc40cd3d26c04a0292e00f4bf272499ec"
+						}
+					],
+					"sta": "S1",
+					"ver": "4:2"
 				}
 			}
-			# "#
-			# , 4, false, false, false, false);
-		```
-		*/
+		}
+		# "#
+		# , 4, false, false, false, false);
+	```
+	*/
 
 	fn init_send_tx(&self, token: Token, args: InitTxArgs) -> Result<VersionedSlate, Error>;
 

--- a/api/src/owner_rpc.rs
+++ b/api/src/owner_rpc.rs
@@ -461,62 +461,62 @@ pub trait OwnerRpc {
 	) -> Result<(bool, WalletInfo), Error>;
 
 	/**
-	;Networked version of [Owner::init_send_tx](struct.Owner.html#method.init_send_tx).
-
-	```
-		# grin_wallet_api::doctest_helper_json_rpc_owner_assert_response!(
-		# r#"
-		{
-			"jsonrpc": "2.0",
-			"method": "init_send_tx",
-			"params": {
-				"token": "d202964900000000d302964900000000d402964900000000d502964900000000",
-				"args": {
-					"src_acct_name": null,
-					"amount": "6000000000",
-					"minimum_confirmations": 2,
-					"max_outputs": 500,
-					"num_change_outputs": 1,
-					"selection_strategy_is_use_all": true,
-					"refresh_outputs_from_node": true,
-					"target_slate_version": null,
-					"payment_proof_recipient_address": "tgrin1xtxavwfgs48ckf3gk8wwgcndmn0nt4tvkl8a7ltyejjcy2mc6nfs9gm2lp",
-					"ttl_blocks": null,
-					"send_args": null
-				}
-			},
-			"id": 1
-		}
-		# "#
-		# ,
-		# r#"
-		{
-		"id": 1,
-			"jsonrpc": "2.0",
-			"result": {
-				"Ok": {
-					"amt": "6000000000",
-					"fee": "23000000",
-					"id": "0436430c-2b02-624c-2032-570501212b00",
-					"proof": {
-						"raddr": "32cdd63928854f8b2628b1dce4626ddcdf35d56cb7cfdf7d64cca5822b78d4d3",
-						"saddr": "32cdd63928854f8b2628b1dce4626ddcdf35d56cb7cfdf7d64cca5822b78d4d3"
-					},
-					"sigs": [
-						{
-							"nonce": "031b84c5567b126440995d3ed5aaba0565d71e1834604819ff9c17f5e9d5dd078f",
-							"xs": "02e89cce4499ac1e9bb498dab9e3fab93cc40cd3d26c04a0292e00f4bf272499ec"
-						}
-					],
-					"sta": "S1",
-					"ver": "4:2"
+		;Networked version of [Owner::init_send_tx](struct.Owner.html#method.init_send_tx).
+	z
+		```
+			# grin_wallet_api::doctest_helper_json_rpc_owner_assert_response!(
+			# r#"
+			{
+				"jsonrpc": "2.0",
+				"method": "init_send_tx",
+				"params": {
+					"token": "d202964900000000d302964900000000d402964900000000d502964900000000",
+					"args": {
+						"src_acct_name": null,
+						"amount": "6000000000",
+						"minimum_confirmations": 2,
+						"max_outputs": 500,
+						"num_change_outputs": 1,
+						"selection_strategy_is_use_all": true,
+						"refresh_outputs_from_node": true,
+						"target_slate_version": null,
+						"payment_proof_recipient_address": "tgrin1xtxavwfgs48ckf3gk8wwgcndmn0nt4tvkl8a7ltyejjcy2mc6nfs9gm2lp",
+						"ttl_blocks": null,
+						"send_args": null
+					}
+				},
+				"id": 1
+			}
+			# "#
+			# ,
+			# r#"
+			{
+			"id": 1,
+				"jsonrpc": "2.0",
+				"result": {
+					"Ok": {
+						"amt": "6000000000",
+						"fee": "23000000",
+						"id": "0436430c-2b02-624c-2032-570501212b00",
+						"proof": {
+							"raddr": "32cdd63928854f8b2628b1dce4626ddcdf35d56cb7cfdf7d64cca5822b78d4d3",
+							"saddr": "32cdd63928854f8b2628b1dce4626ddcdf35d56cb7cfdf7d64cca5822b78d4d3"
+						},
+						"sigs": [
+							{
+								"nonce": "031b84c5567b126440995d3ed5aaba0565d71e1834604819ff9c17f5e9d5dd078f",
+								"xs": "02e89cce4499ac1e9bb498dab9e3fab93cc40cd3d26c04a0292e00f4bf272499ec"
+							}
+						],
+						"sta": "S1",
+						"ver": "4:2"
+					}
 				}
 			}
-		}
-		# "#
-		# , 4, false, false, false, false);
-	```
-	*/
+			# "#
+			# , 4, false, false, false, false);
+		```
+		*/
 
 	fn init_send_tx(&self, token: Token, args: InitTxArgs) -> Result<VersionedSlate, Error>;
 
@@ -602,6 +602,7 @@ pub trait OwnerRpc {
 					"max_outputs": 500,
 					"num_change_outputs": 1,
 					"selection_strategy_is_use_all": true,
+					"refresh_outputs_from_node": true,
 					"target_slate_version": null,
 					"payment_proof_recipient_address": null,
 					"ttl_blocks": null,

--- a/api/src/owner_rpc.rs
+++ b/api/src/owner_rpc.rs
@@ -478,6 +478,7 @@ pub trait OwnerRpc {
 					"max_outputs": 500,
 					"num_change_outputs": 1,
 					"selection_strategy_is_use_all": true,
+					"refresh_outputs_from_node": true,
 					"target_slate_version": null,
 					"payment_proof_recipient_address": "tgrin1xtxavwfgs48ckf3gk8wwgcndmn0nt4tvkl8a7ltyejjcy2mc6nfs9gm2lp",
 					"ttl_blocks": null,

--- a/api/src/owner_rpc.rs
+++ b/api/src/owner_rpc.rs
@@ -229,6 +229,51 @@ pub trait OwnerRpc {
 	) -> Result<(bool, Vec<OutputCommitMapping>), Error>;
 
 	/**
+	Networked version of [Owner::retrieve_txs](struct.Owner.html#method.estimate_max_sendable).
+
+	# Json rpc example
+
+	```
+	# grin_wallet_api::doctest_helper_json_rpc_owner_assert_response!(
+	# r#"
+	{
+		"jsonrpc": "2.0",
+		"method": "estimate_max_sendable",
+		"params": {
+			"token": "d202964900000000d302964900000000d402964900000000d502964900000000",
+			"refresh_from_node": true,
+			"minimum_confirmations": 1
+		},
+		"id": 1
+	}
+	# "#
+	# ,
+	# r#"
+	{
+		"id": 1,
+		"jsonrpc": "2.0",
+		"result": {
+			   "Ok": [
+				 true,
+				 59987500000,
+				 12500000,
+				 1
+			   ]
+		  }
+	}
+	# "#
+	# , 4, false, false, false, false);
+	```
+	 */
+
+	fn estimate_max_sendable(
+		&self,
+		token: Token,
+		refresh_from_node: bool,
+		minimum_confirmations: u64,
+	) -> Result<(bool, u64, u64, u32), Error>;
+
+	/**
 	Networked version of [Owner::retrieve_txs](struct.Owner.html#method.retrieve_txs).
 
 	# Json rpc example
@@ -2065,6 +2110,20 @@ where
 			include_spent,
 			refresh_from_node,
 			tx_id,
+		)
+	}
+
+	fn estimate_max_sendable(
+		&self,
+		token: Token,
+		refresh_from_node: bool,
+		minimum_confirmations: u64,
+	) -> Result<(bool, u64, u64, u32), Error> {
+		Owner::estimate_max_sendable(
+			self,
+			(&token.keychain_mask).as_ref(),
+			refresh_from_node,
+			minimum_confirmations,
 		)
 	}
 

--- a/api/src/owner_rpc.rs
+++ b/api/src/owner_rpc.rs
@@ -1123,54 +1123,54 @@ pub trait OwnerRpc {
 	fn node_height(&self, token: Token) -> Result<NodeHeightResult, Error>;
 
 	/**
-		Initializes the secure JSON-RPC API. This function must be called and a shared key
-		established before any other OwnerAPI JSON-RPC function can be called.
+	Initializes the secure JSON-RPC API. This function must be called and a shared key
+	established before any other OwnerAPI JSON-RPC function can be called.
 
-		The shared key will be derived using ECDH with the provided public key on the secp256k1 curve. This
-		function will return its public key used in the derivation, which the caller should multiply by its
-		private key to derive the shared key.
+	The shared key will be derived using ECDH with the provided public key on the secp256k1 curve. This
+	function will return its public key used in the derivation, which the caller should multiply by its
+	private key to derive the shared key.
 
-		Once the key is established, all further requests and responses are encrypted and decrypted with the
-		following parameters:
-		* AES-256 in GCM mode with 128-bit tags and 96 bit nonces
-		* 12 byte nonce which must be included in each request/response to use on the decrypting side
-		* Empty vector for additional data
-		* Suffix length = AES-256 GCM mode tag length = 16 bytes
-		*
+	Once the key is established, all further requests and responses are encrypted and decrypted with the
+	following parameters:
+	* AES-256 in GCM mode with 128-bit tags and 96 bit nonces
+	* 12 byte nonce which must be included in each request/response to use on the decrypting side
+	* Empty vector for additional data
+	* Suffix length = AES-256 GCM mode tag length = 16 bytes
+	*
 
-		Fully-formed JSON-RPC requests (as documented) should be encrypted using these parameters, encoded
-		into base64 and included with the one-time nonce in a request for the `encrypted_request_v3` method
-		as follows:
+	Fully-formed JSON-RPC requests (as documented) should be encrypted using these parameters, encoded
+	into base64 and included with the one-time nonce in a request for the `encrypted_request_v3` method
+	as follows:
 
-		```
-		# let s = r#"
-		{
-			 "jsonrpc": "2.0",
-			 "method": "encrypted_request_v3",
-			 "id": "1",
-			 "params": {
-					"nonce": "ef32...",
-					"body_enc": "e0bcd..."
-			 }
-		}
-		# "#;
-		```
+	```
+	# let s = r#"
+	{
+		 "jsonrpc": "2.0",
+		 "method": "encrypted_request_v3",
+		 "id": "1",
+		 "params": {
+				"nonce": "ef32...",
+				"body_enc": "e0bcd..."
+		 }
+	}
+	# "#;
+	```
 
-		With a typical response being:
+	With a typical response being:
 
-		```
-		# let s = r#"{
-		{
-			 "jsonrpc": "2.0",
-			 "method": "encrypted_response_v3",
-			 "id": "1",
-			 "Ok": {
-					"nonce": "340b...",
-					"body_enc": "3f09c..."
-			 }
-		}
-		# }"#;
-		```
+	```
+	# let s = r#"{
+	{
+		 "jsonrpc": "2.0",
+		 "method": "encrypted_response_v3",
+		 "id": "1",
+		 "Ok": {
+				"nonce": "340b...",
+				"body_enc": "3f09c..."
+		 }
+	}
+	# }"#;
+	```
 
 	*/
 
@@ -2503,7 +2503,7 @@ pub fn run_doctest_owner(
 
 	util::init_test_logger();
 	let _ = fs::remove_dir_all(test_dir);
-	global::set_local_chain_type(ChainTypes::AutomatedTesting);
+	global::set_global_chain_type(ChainTypes::AutomatedTesting);
 
 	let _ = fs::create_dir_all(test_dir);
 	let config = initial_setup_wallet(

--- a/controller/src/command.rs
+++ b/controller/src/command.rs
@@ -376,6 +376,7 @@ where
 					max_outputs: args.max_outputs as u32,
 					num_change_outputs: args.change_outputs as u32,
 					selection_strategy_is_use_all: strategy == "all",
+					refresh_outputs_from_node: !info_updated,
 					estimate_only: Some(true),
 					..Default::default()
 				};
@@ -415,6 +416,7 @@ where
 			max_outputs: args.max_outputs as u32,
 			num_change_outputs: args.change_outputs as u32,
 			selection_strategy_is_use_all: args.selection_strategy == "all",
+			refresh_outputs_from_node: !info_updated,
 			target_slate_version: args.target_slate_version,
 			payment_proof_recipient_address,
 			ttl_blocks: args.ttl_blocks,
@@ -1013,6 +1015,7 @@ where
 			max_outputs: args.max_outputs as u32,
 			num_change_outputs: 1u32,
 			selection_strategy_is_use_all: args.selection_strategy == "all",
+			refresh_outputs_from_node: !info_updated,
 			ttl_blocks: args.ttl_blocks,
 			send_args: None,
 			..Default::default()

--- a/controller/src/command.rs
+++ b/controller/src/command.rs
@@ -351,9 +351,9 @@ where
 
 	let mut slate = Slate::blank(2, false);
 	let mut amount = args.amount;
+	let (_, wallet_info) =
+		owner_api.retrieve_summary_info(keychain_mask, true, args.minimum_confirmations)?;
 	if args.use_max_amount {
-		let (_, wallet_info) =
-			owner_api.retrieve_summary_info(keychain_mask, true, args.minimum_confirmations)?;
 		amount = wallet_info.amount_currently_spendable;
 	}
 	if args.estimate_selection_strategies {
@@ -926,6 +926,9 @@ where
 		.map(SlatepackAddress::try_from)
 		.transpose()?;
 	let mut slate = args.slate.clone();
+
+	// Refresh wallet state from node.
+	owner_api.retrieve_summary_info(keychain_mask, true, args.minimum_confirmations)?;
 
 	if args.estimate_selection_strategies {
 		let strategies = vec!["smallest", "all"]

--- a/controller/src/command.rs
+++ b/controller/src/command.rs
@@ -375,13 +375,8 @@ where
 	if args.use_max_amount {
 		amount = wallet_info.amount_currently_spendable;
 	}
-	if !info_updated {
-		let reason = if update_skipped {
-			"the updater is running"
-		} else {
-			"node connection error"
-		};
-		warn!("Wallet info update was skipped: {}", reason);
+	if !info_updated && !update_skipped {
+		warn!("Wallet info update was skipped: node connection error");
 	}
 	if args.estimate_selection_strategies {
 		let strategies = estimate_strategies(args.use_max_amount)
@@ -1002,13 +997,8 @@ where
 		true,
 		args.minimum_confirmations,
 	)?;
-	if !info_updated {
-		let reason = if update_skipped {
-			"the updater is running"
-		} else {
-			"node connection error"
-		};
-		warn!("Wallet info update was skipped: {}", reason);
+	if !info_updated && !update_skipped {
+		warn!("Wallet info update was skipped: node connection error");
 	}
 
 	if args.estimate_selection_strategies {

--- a/controller/src/command.rs
+++ b/controller/src/command.rs
@@ -327,6 +327,13 @@ pub struct SendArgs {
 	pub slatepack_qr: bool,
 }
 
+fn max_retry_args(mut init_args: InitTxArgs, amount: u64, max_inputs: u32) -> InitTxArgs {
+	init_args.amount = amount;
+	init_args.max_outputs = max_inputs;
+	init_args.selection_strategy_is_use_all = true;
+	init_args
+}
+
 pub fn send<L, C, K>(
 	owner_api: &mut Owner<L, C, K>,
 	keychain_mask: Option<&SecretKey>,
@@ -391,9 +398,7 @@ where
 						libwallet::Error::BigAmountError(a, max_inputs) => {
 							if args.use_max_amount {
 								amount = a;
-								init_args.amount = amount;
-								init_args.max_outputs = max_inputs;
-								init_args.selection_strategy_is_use_all = true;
+								init_args = max_retry_args(init_args, amount, max_inputs);
 								owner_api.init_send_tx(keychain_mask, init_args)?
 							} else {
 								return Err(grin_wallet_libwallet::Error::from(e));
@@ -454,9 +459,7 @@ where
 				libwallet::Error::BigAmountError(a, max_inputs) => {
 					if args.use_max_amount {
 						amount = a;
-						init_args.amount = amount;
-						init_args.max_outputs = max_inputs;
-						init_args.selection_strategy_is_use_all = true;
+						init_args = max_retry_args(init_args, amount, max_inputs);
 						init_send_tx(init_args).map_err(|e| {
 							info!("Tx not created: {}", e);
 							Error::from(e)
@@ -1511,5 +1514,25 @@ where
 			error!("Proof not valid: {}", e);
 			Err(Error::from(e))
 		}
+	}
+}
+
+#[cfg(test)]
+mod send_tests {
+	use super::*;
+
+	#[test]
+	fn max_retry_updates_args() {
+		let args = InitTxArgs {
+			amount: 100,
+			max_outputs: 500,
+			selection_strategy_is_use_all: false,
+			..Default::default()
+		};
+		let args = max_retry_args(args, 42, 7);
+
+		assert_eq!(args.amount, 42);
+		assert_eq!(args.max_outputs, 7);
+		assert!(args.selection_strategy_is_use_all);
 	}
 }

--- a/controller/src/command.rs
+++ b/controller/src/command.rs
@@ -383,10 +383,6 @@ where
 			.iter()
 			.copied()
 			.map(|strategy| {
-				let (_, a, fee, inputs) = owner_api
-					.estimate_max_sendable(keychain_mask, !info_updated, args.minimum_confirmations)
-					.unwrap();
-				debug!("Estimated: {}, {}, {}", a, fee, inputs);
 				let mut init_args = InitTxArgs {
 					src_acct_name: None,
 					amount,

--- a/controller/src/command.rs
+++ b/controller/src/command.rs
@@ -376,7 +376,7 @@ where
 		amount = wallet_info.amount_currently_spendable;
 	}
 	if !info_updated && !update_skipped {
-		warn!("Wallet info update was failed: node connection error");
+		warn!("Wallet info update failed: node connection error");
 	}
 	if args.estimate_selection_strategies {
 		let strategies = estimate_strategies(args.use_max_amount)
@@ -1000,7 +1000,7 @@ where
 		args.minimum_confirmations,
 	)?;
 	if !info_updated && !update_skipped {
-		warn!("Wallet info update was failed: node connection error");
+		warn!("Wallet info update failed: node connection error");
 	}
 
 	if args.estimate_selection_strategies {

--- a/controller/src/command.rs
+++ b/controller/src/command.rs
@@ -334,6 +334,14 @@ fn max_retry_args(mut init_args: InitTxArgs, amount: u64, max_inputs: u32) -> In
 	init_args
 }
 
+fn estimate_strategies(use_max_amount: bool) -> &'static [&'static str] {
+	if use_max_amount {
+		&["all"]
+	} else {
+		&["smallest", "all"]
+	}
+}
+
 pub fn send<L, C, K>(
 	owner_api: &mut Owner<L, C, K>,
 	keychain_mask: Option<&SecretKey>,
@@ -376,8 +384,9 @@ where
 		warn!("Wallet info update was skipped: {}", reason);
 	}
 	if args.estimate_selection_strategies {
-		let strategies = vec!["smallest", "all"]
-			.into_iter()
+		let strategies = estimate_strategies(args.use_max_amount)
+			.iter()
+			.copied()
 			.map(|strategy| {
 				let mut init_args = InitTxArgs {
 					src_acct_name: None,
@@ -1534,5 +1543,11 @@ mod send_tests {
 		assert_eq!(args.amount, 42);
 		assert_eq!(args.max_outputs, 7);
 		assert!(args.selection_strategy_is_use_all);
+	}
+
+	#[test]
+	fn max_estimate_uses_all() {
+		assert_eq!(estimate_strategies(true), &["all"]);
+		assert_eq!(estimate_strategies(false), &["smallest", "all"]);
 	}
 }

--- a/controller/src/command.rs
+++ b/controller/src/command.rs
@@ -357,7 +357,12 @@ where
 		amount = wallet_info.amount_currently_spendable;
 	}
 	if !info_updated {
-		warn!("Wallet info update was skipped");
+		let reason = if owner_api.updater_running.load(Ordering::SeqCst) {
+			"the updater is running"
+		} else {
+			"node connection error"
+		};
+		warn!("Wallet info update was skipped {}", reason);
 	}
 	if args.estimate_selection_strategies {
 		let strategies = vec!["smallest", "all"]
@@ -973,7 +978,12 @@ where
 	let (info_updated, _) =
 		owner_api.retrieve_summary_info(keychain_mask, true, args.minimum_confirmations)?;
 	if !info_updated {
-		warn!("Wallet info update was skipped");
+		let reason = if owner_api.updater_running.load(Ordering::SeqCst) {
+			"the updater is running"
+		} else {
+			"node connection error"
+		};
+		warn!("Wallet info update was skipped: {}", reason);
 	}
 
 	if args.estimate_selection_strategies {

--- a/controller/src/command.rs
+++ b/controller/src/command.rs
@@ -351,18 +351,22 @@ where
 
 	let mut slate = Slate::blank(2, false);
 	let mut amount = args.amount;
-	let (info_updated, wallet_info) =
-		owner_api.retrieve_summary_info(keychain_mask, true, args.minimum_confirmations)?;
+	let (info_updated, update_skipped, wallet_info) = owner_api
+		.retrieve_summary_info_with_refresh_status(
+			keychain_mask,
+			true,
+			args.minimum_confirmations,
+		)?;
 	if args.use_max_amount {
 		amount = wallet_info.amount_currently_spendable;
 	}
 	if !info_updated {
-		let reason = if owner_api.updater_running.load(Ordering::SeqCst) {
+		let reason = if update_skipped {
 			"the updater is running"
 		} else {
 			"node connection error"
 		};
-		warn!("Wallet info update was skipped {}", reason);
+		warn!("Wallet info update was skipped: {}", reason);
 	}
 	if args.estimate_selection_strategies {
 		let strategies = vec!["smallest", "all"]
@@ -384,10 +388,12 @@ where
 				let slate = match result {
 					Ok(s) => s,
 					Err(e) => match e {
-						libwallet::Error::BigAmountError(a) => {
+						libwallet::Error::BigAmountError(a, max_inputs) => {
 							if args.use_max_amount {
 								amount = a;
 								init_args.amount = amount;
+								init_args.max_outputs = max_inputs;
+								init_args.selection_strategy_is_use_all = true;
 								owner_api.init_send_tx(keychain_mask, init_args)?
 							} else {
 								return Err(grin_wallet_libwallet::Error::from(e));
@@ -445,10 +451,12 @@ where
 		slate = match init_send_tx(init_args.clone()) {
 			Ok(s) => s,
 			Err(e) => match e {
-				libwallet::Error::BigAmountError(a) => {
+				libwallet::Error::BigAmountError(a, max_inputs) => {
 					if args.use_max_amount {
 						amount = a;
 						init_args.amount = amount;
+						init_args.max_outputs = max_inputs;
+						init_args.selection_strategy_is_use_all = true;
 						init_send_tx(init_args).map_err(|e| {
 							info!("Tx not created: {}", e);
 							Error::from(e)
@@ -977,10 +985,13 @@ where
 	let mut slate = args.slate.clone();
 
 	// Refresh wallet state from node.
-	let (info_updated, _) =
-		owner_api.retrieve_summary_info(keychain_mask, true, args.minimum_confirmations)?;
+	let (info_updated, update_skipped, _) = owner_api.retrieve_summary_info_with_refresh_status(
+		keychain_mask,
+		true,
+		args.minimum_confirmations,
+	)?;
 	if !info_updated {
-		let reason = if owner_api.updater_running.load(Ordering::SeqCst) {
+		let reason = if update_skipped {
 			"the updater is running"
 		} else {
 			"node connection error"
@@ -999,13 +1010,14 @@ where
 					max_outputs: args.max_outputs as u32,
 					num_change_outputs: 1u32,
 					selection_strategy_is_use_all: strategy == "all",
+					refresh_outputs_from_node: !info_updated,
 					estimate_only: Some(true),
 					..Default::default()
 				};
-				let slate = owner_api.init_send_tx(keychain_mask, init_args).unwrap();
-				(strategy, slate.amount, slate.fee_fields)
+				let slate = owner_api.init_send_tx(keychain_mask, init_args)?;
+				Ok((strategy, slate.amount, slate.fee_fields))
 			})
-			.collect();
+			.collect::<Result<Vec<_>, libwallet::Error>>()?;
 		display::estimate(slate.amount, strategies, dark_scheme);
 	} else {
 		let init_args = InitTxArgs {

--- a/controller/src/command.rs
+++ b/controller/src/command.rs
@@ -376,13 +376,17 @@ where
 		amount = wallet_info.amount_currently_spendable;
 	}
 	if !info_updated && !update_skipped {
-		warn!("Wallet info update was skipped: node connection error");
+		warn!("Wallet info update was failed: node connection error");
 	}
 	if args.estimate_selection_strategies {
 		let strategies = estimate_strategies(args.use_max_amount)
 			.iter()
 			.copied()
 			.map(|strategy| {
+				let (_, a, fee, inputs) = owner_api
+					.estimate_max_sendable(keychain_mask, !info_updated, args.minimum_confirmations)
+					.unwrap();
+				debug!("Estimated: {}, {}, {}", a, fee, inputs);
 				let mut init_args = InitTxArgs {
 					src_acct_name: None,
 					amount,
@@ -998,7 +1002,7 @@ where
 		args.minimum_confirmations,
 	)?;
 	if !info_updated && !update_skipped {
-		warn!("Wallet info update was skipped: node connection error");
+		warn!("Wallet info update was failed: node connection error");
 	}
 
 	if args.estimate_selection_strategies {

--- a/controller/src/command.rs
+++ b/controller/src/command.rs
@@ -363,7 +363,7 @@ where
 		let strategies = vec!["smallest", "all"]
 			.into_iter()
 			.map(|strategy| {
-				let init_args = InitTxArgs {
+				let mut init_args = InitTxArgs {
 					src_acct_name: None,
 					amount,
 					amount_includes_fee: Some(args.amount_includes_fee),
@@ -374,7 +374,24 @@ where
 					estimate_only: Some(true),
 					..Default::default()
 				};
-				let slate = owner_api.init_send_tx(keychain_mask, init_args)?;
+				let result = owner_api.init_send_tx(keychain_mask, init_args.clone());
+				let slate = match result {
+					Ok(s) => s,
+					Err(e) => match e {
+						libwallet::Error::BigAmountError(a) => {
+							if args.use_max_amount {
+								amount = a;
+								init_args.amount = amount;
+								owner_api.init_send_tx(keychain_mask, init_args)?
+							} else {
+								return Err(grin_wallet_libwallet::Error::from(e));
+							}
+						}
+						_ => {
+							return Err(grin_wallet_libwallet::Error::from(e));
+						}
+					},
+				};
 				Ok((strategy, slate.amount, slate.fee_fields))
 			})
 			.collect::<Result<Vec<_>, grin_wallet_libwallet::Error>>()?;
@@ -385,7 +402,7 @@ where
 			.as_deref()
 			.map(SlatepackAddress::try_from)
 			.transpose()?;
-		let init_args = InitTxArgs {
+		let mut init_args = InitTxArgs {
 			src_acct_name: None,
 			amount,
 			amount_includes_fee: Some(args.amount_includes_fee),
@@ -400,23 +417,45 @@ where
 			late_lock: Some(args.late_lock),
 			..Default::default()
 		};
-		let result = owner_api.init_send_tx(keychain_mask, init_args);
-		slate = match result {
-			Ok(s) => {
-				info!(
-					"Tx created: {} grin to {} (strategy '{}')",
-					core::amount_to_hr_string(amount, false),
-					dest.as_ref()
-						.map(ToString::to_string)
-						.unwrap_or_else(|| "no destination".to_string()),
-					args.selection_strategy,
-				);
-				s
-			}
-			Err(e) => {
-				info!("Tx not created: {}", e);
-				return Err(Error::from(e));
-			}
+		let init_send_tx = |init_args: InitTxArgs| -> Result<Slate, libwallet::Error> {
+			let result = owner_api.init_send_tx(keychain_mask, init_args.clone());
+			let slate = match result {
+				Ok(s) => {
+					info!(
+						"Tx created: {} grin to {} (strategy '{}')",
+						core::amount_to_hr_string(init_args.amount, false),
+						dest.as_ref()
+							.map(ToString::to_string)
+							.unwrap_or_else(|| "no destination".to_string()),
+						args.selection_strategy,
+					);
+					s
+				}
+				Err(e) => return Err(e),
+			};
+			Ok(slate)
+		};
+		slate = match init_send_tx(init_args.clone()) {
+			Ok(s) => s,
+			Err(e) => match e {
+				libwallet::Error::BigAmountError(a) => {
+					if args.use_max_amount {
+						amount = a;
+						init_args.amount = amount;
+						init_send_tx(init_args).map_err(|e| {
+							info!("Tx not created: {}", e);
+							Error::from(e)
+						})?
+					} else {
+						info!("Tx not created: {}", e);
+						return Err(Error::from(e));
+					}
+				}
+				_ => {
+					info!("Tx not created: {}", e);
+					return Err(Error::from(e));
+				}
+			},
 		};
 	}
 

--- a/controller/src/command.rs
+++ b/controller/src/command.rs
@@ -403,7 +403,8 @@ where
 				let slate = match result {
 					Ok(s) => s,
 					Err(e) => match e {
-						libwallet::Error::BigAmountError(a, max_inputs) => {
+						libwallet::Error::BigAmountError(a, _fee, max_inputs) => {
+							debug!("{}", e);
 							if args.use_max_amount {
 								amount = a;
 								init_args = max_retry_args(init_args, amount, max_inputs);
@@ -464,7 +465,8 @@ where
 		slate = match init_send_tx(init_args.clone()) {
 			Ok(s) => s,
 			Err(e) => match e {
-				libwallet::Error::BigAmountError(a, max_inputs) => {
+				libwallet::Error::BigAmountError(a, _fee, max_inputs) => {
+					debug!("{}", e);
 					if args.use_max_amount {
 						amount = a;
 						init_args = max_retry_args(init_args, amount, max_inputs);

--- a/controller/src/command.rs
+++ b/controller/src/command.rs
@@ -357,7 +357,7 @@ where
 		amount = wallet_info.amount_currently_spendable;
 	}
 	if !info_updated {
-		warn!("Unable to contact Node to update wallet info");
+		warn!("Wallet info update was skipped");
 	}
 	if args.estimate_selection_strategies {
 		let strategies = vec!["smallest", "all"]
@@ -934,7 +934,7 @@ where
 	let (info_updated, _) =
 		owner_api.retrieve_summary_info(keychain_mask, true, args.minimum_confirmations)?;
 	if !info_updated {
-		warn!("Unable to contact Node to update wallet info");
+		warn!("Wallet info update was skipped");
 	}
 
 	if args.estimate_selection_strategies {

--- a/controller/src/command.rs
+++ b/controller/src/command.rs
@@ -351,10 +351,13 @@ where
 
 	let mut slate = Slate::blank(2, false);
 	let mut amount = args.amount;
-	let (_, wallet_info) =
+	let (info_updated, wallet_info) =
 		owner_api.retrieve_summary_info(keychain_mask, true, args.minimum_confirmations)?;
 	if args.use_max_amount {
 		amount = wallet_info.amount_currently_spendable;
+	}
+	if !info_updated {
+		warn!("Unable to contact Node to update wallet info");
 	}
 	if args.estimate_selection_strategies {
 		let strategies = vec!["smallest", "all"]
@@ -928,7 +931,11 @@ where
 	let mut slate = args.slate.clone();
 
 	// Refresh wallet state from node.
-	owner_api.retrieve_summary_info(keychain_mask, true, args.minimum_confirmations)?;
+	let (info_updated, _) =
+		owner_api.retrieve_summary_info(keychain_mask, true, args.minimum_confirmations)?;
+	if !info_updated {
+		warn!("Unable to contact Node to update wallet info");
+	}
 
 	if args.estimate_selection_strategies {
 		let strategies = vec!["smallest", "all"]

--- a/controller/tests/common/mod.rs
+++ b/controller/tests/common/mod.rs
@@ -84,6 +84,7 @@ pub fn clean_output_dir(test_dir: &str) {
 pub fn setup(test_dir: &str) {
 	util::init_test_logger();
 	clean_output_dir(test_dir);
+	global::set_local_chain_type(ChainTypes::AutomatedTesting);
 	setup_global_chain_type();
 }
 

--- a/controller/tests/common/mod.rs
+++ b/controller/tests/common/mod.rs
@@ -22,7 +22,6 @@ use grin_util as util;
 
 use self::core::global;
 use self::core::global::ChainTypes;
-use self::core::global::GLOBAL_CHAIN_TYPE;
 use self::keychain::ExtKeychain;
 use self::libwallet::WalletInst;
 use impls::test_framework::{LocalWalletClient, WalletProxy};
@@ -84,7 +83,6 @@ pub fn clean_output_dir(test_dir: &str) {
 pub fn setup(test_dir: &str) {
 	util::init_test_logger();
 	clean_output_dir(test_dir);
-	global::set_local_chain_type(ChainTypes::AutomatedTesting);
 	setup_global_chain_type();
 }
 
@@ -93,9 +91,7 @@ pub fn setup(test_dir: &str) {
 /// leaks across multiple tests and will likely have unintended consequences.
 #[allow(dead_code)]
 pub fn setup_global_chain_type() {
-	if !GLOBAL_CHAIN_TYPE.is_init() {
-		global::init_global_chain_type(ChainTypes::AutomatedTesting);
-	}
+	global::init_global_chain_type(ChainTypes::AutomatedTesting);
 }
 
 pub fn create_wallet_proxy(

--- a/controller/tests/common/mod.rs
+++ b/controller/tests/common/mod.rs
@@ -22,6 +22,7 @@ use grin_util as util;
 
 use self::core::global;
 use self::core::global::ChainTypes;
+use self::core::global::GLOBAL_CHAIN_TYPE;
 use self::keychain::ExtKeychain;
 use self::libwallet::WalletInst;
 use impls::test_framework::{LocalWalletClient, WalletProxy};
@@ -83,7 +84,7 @@ pub fn clean_output_dir(test_dir: &str) {
 pub fn setup(test_dir: &str) {
 	util::init_test_logger();
 	clean_output_dir(test_dir);
-	global::set_local_chain_type(ChainTypes::AutomatedTesting);
+	setup_global_chain_type();
 }
 
 /// Some tests require the global chain_type to be configured due to threads being spawned internally.
@@ -91,7 +92,9 @@ pub fn setup(test_dir: &str) {
 /// leaks across multiple tests and will likely have unintended consequences.
 #[allow(dead_code)]
 pub fn setup_global_chain_type() {
-	global::init_global_chain_type(global::ChainTypes::AutomatedTesting);
+	if !GLOBAL_CHAIN_TYPE.is_init() {
+		global::init_global_chain_type(ChainTypes::AutomatedTesting);
+	}
 }
 
 pub fn create_wallet_proxy(

--- a/controller/tests/transaction.rs
+++ b/controller/tests/transaction.rs
@@ -737,39 +737,42 @@ fn big_amount_error(test_dir: &'static str) -> Result<(), libwallet::Error> {
 	)?;
 
 	// test selecting max amount
-	let res = {
-		let mut w_lock = wallet1.lock();
-		let mut w = w_lock.lc_provider()?.wallet_inst()?;
-		let parent_key_id = w.parent_key_id();
-		let current_height = outputs_num + 5;
-		let max_outputs = 500;
-		let change_outputs = 1;
-		let res = libwallet::select_coins_and_fee(
-			&mut w,
-			reward * outputs_num as u64,
-			true,
-			current_height as u64,
-			min_confirmations,
-			max_outputs,
-			change_outputs,
-			true,
-			&parent_key_id,
-		);
-		res
-	};
+	let result = wallet::controller::owner_single_use(
+		wallet1.clone(),
+		mask1,
+		PathBuf::from(test_dir),
+		|api, m| {
+			api.init_send_tx(
+				m,
+				InitTxArgs {
+					amount: (reward * outputs_num as u64) - (cm * reward),
+					amount_includes_fee: Some(true),
+					minimum_confirmations: 0,
+					max_outputs: 500,
+					num_change_outputs: 1,
+					selection_strategy_is_use_all: true,
+					refresh_outputs_from_node: true,
+					..InitTxArgs::default()
+				},
+			)?;
+			Ok(())
+		},
+	);
+
+	println!("{:?}", result);
 
 	let max_tx_weight = global::max_tx_weight();
 	let tx_weight = Transaction::weight_by_iok(outputs_num as u64, 1, 1);
 
 	assert!(tx_weight > max_tx_weight);
 
-	assert!(res.is_err());
+	assert!(result.is_err());
 	assert!(matches!(
-		res.as_ref().err().unwrap(),
+		result.as_ref().err().unwrap(),
 		libwallet::Error::BigAmountError { .. }
 	));
 
-	match res {
+	match result {
 		Ok(_) => {}
 		Err(e) => match e {
 			libwallet::Error::BigAmountError(a, fee, num_inputs) => {

--- a/controller/tests/transaction.rs
+++ b/controller/tests/transaction.rs
@@ -21,6 +21,7 @@ extern crate grin_wallet_libwallet as libwallet;
 use grin_core as core;
 
 use self::core::core::transaction;
+use self::core::core::Transaction;
 use self::core::global;
 use self::libwallet::{InitTxArgs, OutputStatus, Slate, SlateState};
 use impls::test_framework::{self, LocalWalletClient};
@@ -677,6 +678,125 @@ fn tx_rollback(test_dir: &'static str) -> Result<(), libwallet::Error> {
 	Ok(())
 }
 
+fn big_amount_error(test_dir: &'static str) -> Result<(), libwallet::Error> {
+	// Create a new proxy to simulate server and wallet responses
+	let mut wallet_proxy = create_wallet_proxy(test_dir);
+	let chain = wallet_proxy.chain.clone();
+	let stopper = wallet_proxy.running.clone();
+
+	create_wallet_and_add!(
+		client1,
+		wallet1,
+		mask1_i,
+		test_dir,
+		"wallet1",
+		None,
+		&mut wallet_proxy,
+		true
+	);
+	let mask1 = (&mask1_i).as_ref();
+	println!("Mask1: {:?}", mask1);
+
+	// Set the wallet proxy listener running
+	thread::spawn(move || {
+		if let Err(e) = wallet_proxy.run() {
+			error!("Wallet Proxy error: {}", e);
+		}
+	});
+
+	let outputs_num = 255;
+
+	let reward = core::consensus::REWARD;
+	let cm = global::coinbase_maturity();
+	// mine a few blocks
+	let _ =
+		test_framework::award_blocks_to_wallet(&chain, wallet1.clone(), mask1, outputs_num, false);
+
+	let min_confirmations = 1;
+
+	// Check wallet 1 content are as expected
+	wallet::controller::owner_single_use(
+		wallet1.clone(),
+		mask1,
+		PathBuf::from(test_dir),
+		|api, m| {
+			let (wallet1_refreshed, wallet1_info) =
+				api.retrieve_summary_info(m, true, min_confirmations)?;
+			println!(
+				"Wallet 1 Info Pre-Transaction, after {} blocks: {:?}",
+				wallet1_info.last_confirmed_height, wallet1_info
+			);
+			assert!(wallet1_refreshed);
+			assert_eq!(
+				wallet1_info.amount_currently_spendable,
+				(wallet1_info.last_confirmed_height - cm) * reward
+			);
+			assert_eq!(wallet1_info.amount_immature, cm * reward);
+			Ok(())
+		},
+	)?;
+
+	// test selecting max amount
+	let res = {
+		let mut w_lock = wallet1.lock();
+		let mut w = w_lock.lc_provider()?.wallet_inst()?;
+		let parent_key_id = w.parent_key_id();
+		let current_height = outputs_num + 5;
+		let max_outputs = 500;
+		let change_outputs = 1;
+		let res = libwallet::select_coins_and_fee(
+			&mut w,
+			reward * outputs_num as u64,
+			true,
+			current_height as u64,
+			min_confirmations,
+			max_outputs,
+			change_outputs,
+			true,
+			&parent_key_id,
+		);
+		res
+	};
+
+	let max_tx_weight = global::max_tx_weight();
+	let tx_weight = Transaction::weight_by_iok(outputs_num as u64, 1, 1);
+
+	assert!(tx_weight > max_tx_weight);
+
+	assert!(res.is_err());
+	assert!(matches!(
+		res.as_ref().err().unwrap(),
+		libwallet::Error::BigAmountError { .. }
+	));
+
+	match res {
+		Ok(_) => {}
+		Err(e) => match e {
+			libwallet::Error::BigAmountError(a, fee, num_inputs) => {
+				wallet::controller::owner_single_use(
+					wallet1.clone(),
+					mask1,
+					PathBuf::from(test_dir),
+					|api, m| {
+						let (_, e_a, e_fee, e_num_inputs) =
+							api.estimate_max_sendable(m, true, min_confirmations)?;
+						assert_eq!(e_a, a - fee);
+						assert_eq!(e_fee, fee);
+						assert_eq!(e_num_inputs, num_inputs);
+						Ok(())
+					},
+				)?;
+			}
+			_ => {}
+		},
+	}
+
+	// let logging finish
+	stopper.store(false, Ordering::Relaxed);
+	thread::sleep(Duration::from_millis(200));
+	Ok(())
+}
+
 #[test]
 fn db_wallet_basic_transaction_api() {
 	let test_dir = "test_output/basic_transaction_api";
@@ -692,6 +812,16 @@ fn db_wallet_tx_rollback() {
 	let test_dir = "test_output/tx_rollback";
 	setup(test_dir);
 	if let Err(e) = tx_rollback(test_dir) {
+		panic!("Libwallet Error: {}", e);
+	}
+	clean_output_dir(test_dir);
+}
+
+#[test]
+fn db_wallet_big_amount_error() {
+	let test_dir = "test_output/big_amount_error";
+	setup(test_dir);
+	if let Err(e) = big_amount_error(test_dir) {
 		panic!("Libwallet Error: {}", e);
 	}
 	clean_output_dir(test_dir);

--- a/controller/tests/updater_thread.rs
+++ b/controller/tests/updater_thread.rs
@@ -19,9 +19,6 @@ extern crate grin_wallet_controller as wallet;
 extern crate grin_wallet_impls as impls;
 extern crate grin_wallet_libwallet as libwallet;
 
-// use crate::libwallet::api_impl::owner_updater::{start_updater_log_thread, StatusMessage};
-// use grin_wallet_util::grin_core as core;
-
 use impls::test_framework::{self, LocalWalletClient};
 use std::path::PathBuf;
 use std::sync::atomic::Ordering;
@@ -30,7 +27,7 @@ use std::time::Duration;
 
 #[macro_use]
 mod common;
-use common::{clean_output_dir, create_wallet_proxy, setup, setup_global_chain_type};
+use common::{clean_output_dir, create_wallet_proxy, setup};
 
 /// updater thread test impl
 fn updater_thread_test_impl(test_dir: &'static str) -> Result<(), libwallet::Error> {

--- a/controller/tests/updater_thread.rs
+++ b/controller/tests/updater_thread.rs
@@ -121,10 +121,6 @@ fn updater_thread_test_impl(test_dir: &'static str) -> Result<(), libwallet::Err
 
 #[test]
 fn updater_thread() {
-	// The "updater" kicks off a new thread so we need to ensure the global chain_type
-	// is set for this to work correctly.
-	setup_global_chain_type();
-
 	let test_dir = "test_output/updater_thread";
 	setup(test_dir);
 	if let Err(e) = updater_thread_test_impl(test_dir) {

--- a/impls/src/node_clients/http.rs
+++ b/impls/src/node_clients/http.rs
@@ -24,7 +24,7 @@ use crate::libwallet::{NodeClient, NodeVersionInfo};
 use crate::util::secp::pedersen;
 use crate::util::ToHex;
 use futures::stream::FuturesUnordered;
-use futures::TryStreamExt;
+use futures::StreamExt;
 use std::collections::HashMap;
 use std::env;
 use std::net::SocketAddr;
@@ -259,17 +259,27 @@ impl NodeClient for HTTPNodeClient {
 				reqs.push(build_request("get_outputs", p));
 			}
 
-			let mut tasks = Vec::with_capacity(params.len());
-			for req in &reqs {
-				tasks.push(cl.post_async::<Request, Response>(
-					url.as_str(),
-					req,
-					api_secret.clone(),
-				));
-			}
+			let mut outputs = Vec::new();
 
-			let task: FuturesUnordered<_> = tasks.into_iter().collect();
-			task.try_collect().await
+			let max_num_requests = 16;
+			for req_chunks in reqs.chunks(max_num_requests) {
+				for req in req_chunks {
+					let mut tasks = vec![];
+					tasks.push(cl.post_async::<Request, Response>(
+						url.as_str(),
+						req,
+						api_secret.clone(),
+					));
+					let mut task: FuturesUnordered<_> = tasks.into_iter().collect();
+					while let Some(item) = task.next().await {
+						match item {
+							Ok(i) => outputs.push(i),
+							Err(e) => return Err(e),
+						}
+					}
+				}
+			}
+			Ok(outputs)
 		};
 
 		let rt = RUNTIME.clone();

--- a/impls/src/node_clients/http.rs
+++ b/impls/src/node_clients/http.rs
@@ -263,19 +263,19 @@ impl NodeClient for HTTPNodeClient {
 
 			let max_num_requests = 16;
 			for req_chunks in reqs.chunks(max_num_requests) {
+				let mut tasks = vec![];
 				for req in req_chunks {
-					let mut tasks = vec![];
 					tasks.push(cl.post_async::<Request, Response>(
 						url.as_str(),
 						req,
 						api_secret.clone(),
 					));
-					let mut task: FuturesUnordered<_> = tasks.into_iter().collect();
-					while let Some(item) = task.next().await {
-						match item {
-							Ok(i) => outputs.push(i),
-							Err(e) => return Err(e),
-						}
+				}
+				let mut task: FuturesUnordered<_> = tasks.into_iter().collect();
+				while let Some(item) = task.next().await {
+					match item {
+						Ok(i) => outputs.push(i),
+						Err(e) => return Err(e),
 					}
 				}
 			}

--- a/libwallet/Cargo.toml
+++ b/libwallet/Cargo.toml
@@ -12,6 +12,7 @@ edition = "2021"
 [dependencies]
 blake2-rfc = "0.2"
 rand = "0.6"
+rayon = "1.12"
 serde = "1"
 serde_derive = "1"
 serde_json = "1"

--- a/libwallet/src/api_impl/owner.rs
+++ b/libwallet/src/api_impl/owner.rs
@@ -336,7 +336,7 @@ where
 		true,
 		&parent_key_id,
 	) {
-		Ok((coins, _total, amount, fee)) => (amount - fee, fee, coins.len() as u32),
+		Ok((coins, _total, amount, fee)) => (amount, fee, coins.len() as u32),
 		Err(e) => match e {
 			Error::BigAmountError(amount, input_count) => {
 				let fee = tx_fee(input_count as usize, change_outputs + 1, 1);

--- a/libwallet/src/api_impl/owner.rs
+++ b/libwallet/src/api_impl/owner.rs
@@ -21,6 +21,7 @@ use crate::api_impl::foreign::finalize_tx as foreign_finalize;
 use crate::grin_core::core::hash::Hashed;
 use crate::grin_core::core::{FeeFields, Output, OutputFeatures, Transaction};
 use crate::grin_core::libtx::proof;
+use crate::grin_core::libtx::tx_fee;
 use crate::grin_keychain::ViewKey;
 use crate::grin_util::secp::{key::SecretKey, pedersen::Commitment};
 use crate::grin_util::Mutex;
@@ -291,6 +292,61 @@ where
 		validated,
 		updater::retrieve_outputs(w, keychain_mask, include_spent, tx_id, Some(&parent_key_id))?,
 	))
+}
+
+/// Calculate max amount to send.
+pub fn estimate_max_sendable<'a, L, C, K>(
+	wallet_inst: Arc<Mutex<Box<dyn WalletInst<'a, L, C, K>>>>,
+	keychain_mask: Option<&SecretKey>,
+	status_send_channel: &Option<Sender<StatusMessage>>,
+	refresh_from_node: bool,
+	minimum_confirmations: u64,
+) -> Result<(bool, u64, u64, u32), Error>
+where
+	L: WalletLCProvider<'a, C, K>,
+	C: NodeClient + 'a,
+	K: Keychain + 'a,
+{
+	let validated = if refresh_from_node {
+		update_wallet_state(
+			wallet_inst.clone(),
+			keychain_mask,
+			status_send_channel,
+			false,
+		)?
+	} else {
+		false
+	};
+
+	wallet_lock!(wallet_inst, w);
+
+	let parent_key_id = w.parent_key_id();
+	let wallet_info = updater::retrieve_info(w, &parent_key_id, minimum_confirmations)?;
+	let current_height = w.last_confirmed_height()?;
+	let max_outputs = 500;
+	let change_outputs = 1;
+	let (amount, fee, input_count) = match selection::select_coins_and_fee(
+		w,
+		wallet_info.amount_currently_spendable,
+		true,
+		current_height,
+		minimum_confirmations,
+		max_outputs,
+		change_outputs,
+		true,
+		&parent_key_id,
+	) {
+		Ok((coins, _total, amount, fee)) => (amount, fee, coins.len() as u32),
+		Err(e) => match e {
+			Error::BigAmountError(amount, input_count) => {
+				let fee = tx_fee(input_count as usize, change_outputs + 1, 1);
+				(amount, fee, input_count)
+			}
+			_ => return Err(e),
+		},
+	};
+
+	Ok((validated, amount, fee, input_count))
 }
 
 /// Retrieve txs

--- a/libwallet/src/api_impl/owner.rs
+++ b/libwallet/src/api_impl/owner.rs
@@ -512,6 +512,7 @@ where
 			args.max_outputs as usize,
 			args.num_change_outputs as usize,
 			args.selection_strategy_is_use_all,
+			args.refresh_outputs_from_node,
 			&parent_key_id,
 		)?;
 		slate.amount = total;
@@ -540,6 +541,7 @@ where
 			args.max_outputs as usize,
 			args.num_change_outputs as usize,
 			args.selection_strategy_is_use_all,
+			args.refresh_outputs_from_node,
 			&parent_key_id,
 			true,
 			use_test_rng,
@@ -696,6 +698,7 @@ where
 		args.max_outputs as usize,
 		args.num_change_outputs as usize,
 		args.selection_strategy_is_use_all,
+		args.refresh_outputs_from_node,
 		&parent_key_id,
 		false,
 		use_test_rng,

--- a/libwallet/src/api_impl/owner.rs
+++ b/libwallet/src/api_impl/owner.rs
@@ -21,7 +21,6 @@ use crate::api_impl::foreign::finalize_tx as foreign_finalize;
 use crate::grin_core::core::hash::Hashed;
 use crate::grin_core::core::{FeeFields, Output, OutputFeatures, Transaction};
 use crate::grin_core::libtx::proof;
-use crate::grin_core::libtx::tx_fee;
 use crate::grin_keychain::ViewKey;
 use crate::grin_util::secp::{key::SecretKey, pedersen::Commitment};
 use crate::grin_util::Mutex;
@@ -338,10 +337,7 @@ where
 	) {
 		Ok((coins, _total, amount, fee)) => (amount, fee, coins.len() as u32),
 		Err(e) => match e {
-			Error::BigAmountError(amount, input_count) => {
-				let fee = tx_fee(input_count as usize, change_outputs + 1, 1);
-				(amount - fee, fee, input_count)
-			}
+			Error::BigAmountError(amount, fee, input_count) => (amount - fee, fee, input_count),
 			_ => return Err(e),
 		},
 	};

--- a/libwallet/src/api_impl/owner.rs
+++ b/libwallet/src/api_impl/owner.rs
@@ -336,11 +336,11 @@ where
 		true,
 		&parent_key_id,
 	) {
-		Ok((coins, _total, amount, fee)) => (amount, fee, coins.len() as u32),
+		Ok((coins, _total, amount, fee)) => (amount - fee, fee, coins.len() as u32),
 		Err(e) => match e {
 			Error::BigAmountError(amount, input_count) => {
 				let fee = tx_fee(input_count as usize, change_outputs + 1, 1);
-				(amount, fee, input_count)
+				(amount - fee, fee, input_count)
 			}
 			_ => return Err(e),
 		},

--- a/libwallet/src/api_impl/owner.rs
+++ b/libwallet/src/api_impl/owner.rs
@@ -18,6 +18,7 @@ use std::cmp;
 use uuid::Uuid;
 
 use crate::api_impl::foreign::finalize_tx as foreign_finalize;
+use crate::grin_core::core::amount_to_hr_string;
 use crate::grin_core::core::hash::Hashed;
 use crate::grin_core::core::{FeeFields, Output, OutputFeatures, Transaction};
 use crate::grin_core::libtx::proof;
@@ -337,7 +338,14 @@ where
 	) {
 		Ok((coins, _total, amount, fee)) => (amount, fee, coins.len() as u32),
 		Err(e) => match e {
-			Error::BigAmountError(amount, fee, input_count) => (amount - fee, fee, input_count),
+			Error::BigAmountError(amount, fee, input_count) => {
+				let amount = amount.checked_sub(fee).ok_or(Error::GenericError(format!(
+					"Transaction amount {} is too small to include fee {}, send lower amount",
+					amount_to_hr_string(amount, true),
+					amount_to_hr_string(fee, true)
+				)))?;
+				(amount, fee, input_count)
+			}
 			_ => return Err(e),
 		},
 	};

--- a/libwallet/src/api_impl/owner_updater.rs
+++ b/libwallet/src/api_impl/owner_updater.rs
@@ -73,8 +73,8 @@ pub fn start_updater_log_thread(
 					StatusMessage::UpdatingTransactions(s) => debug!("{}", s),
 					StatusMessage::FullScanWarn(s) => warn!("{}", s),
 					StatusMessage::Scanning(s, m) => {
+						debug!("{}", s);
 						if last_scan_percent < m {
-							debug!("{}", s);
 							warn!("Scanning - {}% complete", m);
 							last_scan_percent = m;
 						}

--- a/libwallet/src/api_impl/owner_updater.rs
+++ b/libwallet/src/api_impl/owner_updater.rs
@@ -58,6 +58,7 @@ pub fn start_updater_log_thread(
 	let _ = thread::Builder::new()
 		.name("wallet-updater-status".to_string())
 		.spawn(move || {
+			let mut last_scan_percent = 0;
 			while let Ok(m) = rx.recv() {
 				// save to our message queue to be read by other consumers
 				{
@@ -72,8 +73,11 @@ pub fn start_updater_log_thread(
 					StatusMessage::UpdatingTransactions(s) => debug!("{}", s),
 					StatusMessage::FullScanWarn(s) => warn!("{}", s),
 					StatusMessage::Scanning(s, m) => {
-						debug!("{}", s);
-						warn!("Scanning - {}% complete", m);
+						if last_scan_percent < m {
+							debug!("{}", s);
+							warn!("Scanning - {}% complete", m);
+							last_scan_percent = m;
+						}
 					}
 					StatusMessage::ScanningComplete(s) => warn!("{}", s),
 					StatusMessage::UpdateWarning(s) => warn!("{}", s),

--- a/libwallet/src/api_impl/owner_updater.rs
+++ b/libwallet/src/api_impl/owner_updater.rs
@@ -73,6 +73,9 @@ pub fn start_updater_log_thread(
 					StatusMessage::UpdatingTransactions(s) => debug!("{}", s),
 					StatusMessage::FullScanWarn(s) => warn!("{}", s),
 					StatusMessage::Scanning(s, m) => {
+						if m == 0 {
+							last_scan_percent = 0;
+						}
 						debug!("{}", s);
 						if last_scan_percent < m {
 							warn!("Scanning - {}% complete", m);

--- a/libwallet/src/api_impl/owner_updater.rs
+++ b/libwallet/src/api_impl/owner_updater.rs
@@ -79,7 +79,10 @@ pub fn start_updater_log_thread(
 							last_scan_percent = m;
 						}
 					}
-					StatusMessage::ScanningComplete(s) => warn!("{}", s),
+					StatusMessage::ScanningComplete(s) => {
+						warn!("{}", s);
+						last_scan_percent = 0;
+					}
 					StatusMessage::UpdateWarning(s) => warn!("{}", s),
 				}
 			}

--- a/libwallet/src/api_impl/types.rs
+++ b/libwallet/src/api_impl/types.rs
@@ -69,6 +69,7 @@ pub struct InitTxArgs {
 	/// value outputs.
 	pub selection_strategy_is_use_all: bool,
 	/// Flag to refresh outputs from node.
+	#[serde(default = "default_refresh_outputs_from_node")]
 	pub refresh_outputs_from_node: bool,
 	/// Optionally set the output target slate version (acceptable
 	/// down to the minimum slate version compatible with the current. If `None` the slate
@@ -350,6 +351,10 @@ pub struct BuiltOutput {
 	pub output: Output,
 }
 
+fn default_refresh_outputs_from_node() -> bool {
+	true
+}
+
 /// Update transaction slate state.
 pub fn update_tx_slate_state<C, K>(
 	wallet: &mut WalletBackend<C, K>,
@@ -384,4 +389,21 @@ where
 		)));
 	}
 	Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+	use super::InitTxArgs;
+
+	#[test]
+	fn legacy_refresh_default() {
+		let mut value = serde_json::to_value(InitTxArgs::default()).unwrap();
+		value
+			.as_object_mut()
+			.unwrap()
+			.remove("refresh_outputs_from_node");
+
+		let args: InitTxArgs = serde_json::from_value(value).unwrap();
+		assert!(args.refresh_outputs_from_node);
+	}
 }

--- a/libwallet/src/api_impl/types.rs
+++ b/libwallet/src/api_impl/types.rs
@@ -68,6 +68,8 @@ pub struct InitTxArgs {
 	/// as many outputs as are needed to meet the amount, (and no more) starting with the smallest
 	/// value outputs.
 	pub selection_strategy_is_use_all: bool,
+	/// Flag to refresh outputs from node.
+	pub refresh_outputs_from_node: bool,
 	/// Optionally set the output target slate version (acceptable
 	/// down to the minimum slate version compatible with the current. If `None` the slate
 	/// is generated with the latest version.
@@ -117,6 +119,7 @@ impl Default for InitTxArgs {
 			max_outputs: 500,
 			num_change_outputs: 1,
 			selection_strategy_is_use_all: true,
+			refresh_outputs_from_node: true,
 			target_slate_version: None,
 			ttl_blocks: None,
 			estimate_only: Some(false),

--- a/libwallet/src/error.rs
+++ b/libwallet/src/error.rs
@@ -14,7 +14,7 @@
 
 //! Error types for libwallet
 
-use crate::grin_core::core::{committed, transaction};
+use crate::grin_core::core::{amount_to_hr_string, committed, transaction};
 use crate::grin_core::libtx;
 use crate::grin_keychain;
 use crate::grin_util::secp;
@@ -38,7 +38,10 @@ pub enum Error {
 	},
 
 	/// Big amount error.
-	#[error("Big amount error, can send maximum {0} nanogrins")]
+	#[error(
+		"Amount too large for a single transaction; can send at most {} using {1} inputs. Send that amount to yourself to consolidate outputs",
+		amount_to_hr_string(*.0, true)
+	)]
 	BigAmountError(u64, u32),
 
 	/// Fee error
@@ -369,5 +372,18 @@ impl From<&str> for Error {
 impl From<bech32::Error> for Error {
 	fn from(error: bech32::Error) -> Error {
 		Error::SlatepackAddress(format!("{}", error))
+	}
+}
+
+#[cfg(test)]
+mod tests {
+	use super::*;
+
+	#[test]
+	fn big_amount_message() {
+		let message = Error::BigAmountError(3_000_000_000, 2).to_string();
+		assert!(message.contains("3.0"));
+		assert!(message.contains("2 inputs"));
+		assert!(message.contains("consolidate outputs"));
 	}
 }

--- a/libwallet/src/error.rs
+++ b/libwallet/src/error.rs
@@ -384,7 +384,14 @@ mod tests {
 	fn big_amount_message() {
 		let message = Error::BigAmountError(3_000_000_000, 12_500_000, 2).to_string();
 		assert!(message.contains("3.0"));
-		assert!(message.contains("2 inputs"));
+		assert_eq!(
+			message
+				.as_bytes()
+				.windows("2 inputs".len())
+				.filter(|&w| w == "2 inputs".as_bytes())
+				.count(),
+			2
+		);
 		assert!(message.contains("'all' selection strategy"));
 		assert!(message.contains("consolidate outputs"));
 	}

--- a/libwallet/src/error.rs
+++ b/libwallet/src/error.rs
@@ -39,7 +39,7 @@ pub enum Error {
 
 	/// Big amount error.
 	#[error(
-		"Amount too large for a single transaction; can send at most {} using {1} inputs. Send that amount to yourself using the 'all' selection strategy and a maximum of {1} inputs to consolidate outputs",
+		"Amount too large for a single transaction; can send at most {} using {2} inputs. Send that amount to yourself using the 'all' selection strategy and a maximum of {1} inputs to consolidate outputs",
 		amount_to_hr_string(*.0, true)
 	)]
 	BigAmountError(u64, u64, u32),

--- a/libwallet/src/error.rs
+++ b/libwallet/src/error.rs
@@ -39,7 +39,8 @@ pub enum Error {
 
 	/// Big amount error.
 	#[error(
-		"Amount too large for a single transaction; can send at most {} using {2} inputs. Send that amount to yourself using the 'all' selection strategy and a maximum of {1} inputs to consolidate outputs",
+		"Amount too large for a single transaction; can send at most {} using {2} inputs. Send that amount \
+		to yourself using the 'all' selection strategy and a maximum of {2} inputs to consolidate outputs",
 		amount_to_hr_string(*.0, true)
 	)]
 	BigAmountError(u64, u64, u32),

--- a/libwallet/src/error.rs
+++ b/libwallet/src/error.rs
@@ -383,7 +383,6 @@ mod tests {
 	fn big_amount_message() {
 		let message = Error::BigAmountError(3_000_000_000, 12_500_000, 2).to_string();
 		assert!(message.contains("3.0"));
-		assert!(message.contains("0.0125"));
 		assert!(message.contains("2 inputs"));
 		assert!(message.contains("'all' selection strategy"));
 		assert!(message.contains("consolidate outputs"));

--- a/libwallet/src/error.rs
+++ b/libwallet/src/error.rs
@@ -37,6 +37,10 @@ pub enum Error {
 		needed_disp: String,
 	},
 
+	/// Big amount error.
+	#[error("Big amount error, can send maximum {0} nanogrins")]
+	BigAmountError(u64),
+
 	/// Fee error
 	#[error("Fee Error: {0}")]
 	Fee(String),

--- a/libwallet/src/error.rs
+++ b/libwallet/src/error.rs
@@ -42,7 +42,7 @@ pub enum Error {
 		"Amount too large for a single transaction; can send at most {} using {1} inputs. Send that amount to yourself using the 'all' selection strategy and a maximum of {1} inputs to consolidate outputs",
 		amount_to_hr_string(*.0, true)
 	)]
-	BigAmountError(u64, u32),
+	BigAmountError(u64, u64, u32),
 
 	/// Fee error
 	#[error("Fee Error: {0}")]
@@ -381,8 +381,9 @@ mod tests {
 
 	#[test]
 	fn big_amount_message() {
-		let message = Error::BigAmountError(3_000_000_000, 2).to_string();
+		let message = Error::BigAmountError(3_000_000_000, 12_500_000, 2).to_string();
 		assert!(message.contains("3.0"));
+		assert!(message.contains("0.0125"));
 		assert!(message.contains("2 inputs"));
 		assert!(message.contains("'all' selection strategy"));
 		assert!(message.contains("consolidate outputs"));

--- a/libwallet/src/error.rs
+++ b/libwallet/src/error.rs
@@ -39,7 +39,7 @@ pub enum Error {
 
 	/// Big amount error.
 	#[error("Big amount error, can send maximum {0} nanogrins")]
-	BigAmountError(u64),
+	BigAmountError(u64, u32),
 
 	/// Fee error
 	#[error("Fee Error: {0}")]

--- a/libwallet/src/error.rs
+++ b/libwallet/src/error.rs
@@ -39,7 +39,7 @@ pub enum Error {
 
 	/// Big amount error.
 	#[error(
-		"Amount too large for a single transaction; can send at most {} using {1} inputs. Send that amount to yourself to consolidate outputs",
+		"Amount too large for a single transaction; can send at most {} using {1} inputs. Send that amount to yourself using the 'all' selection strategy and a maximum of {1} inputs to consolidate outputs",
 		amount_to_hr_string(*.0, true)
 	)]
 	BigAmountError(u64, u32),
@@ -384,6 +384,7 @@ mod tests {
 		let message = Error::BigAmountError(3_000_000_000, 2).to_string();
 		assert!(message.contains("3.0"));
 		assert!(message.contains("2 inputs"));
+		assert!(message.contains("'all' selection strategy"));
 		assert!(message.contains("consolidate outputs"));
 	}
 }

--- a/libwallet/src/internal/scan.rs
+++ b/libwallet/src/internal/scan.rs
@@ -68,10 +68,15 @@ where
 	let builder = proof::ProofBuilder::new(keychain);
 	let legacy_version = HeaderVersion(1);
 
+	let chain_type = global::get_chain_type();
+
 	let identified = outputs
 		.par_iter()
 		.map(
 			|output| -> Result<Option<(OutputResult, SwitchCommitmentType)>, Error> {
+				// set chain type for thread
+				global::set_local_chain_type(chain_type);
+
 				let (commit, proof, is_coinbase, height, mmr_index) = output;
 				// attempt to unwind message from the RP and get a value
 				// will fail if it's not ours

--- a/libwallet/src/internal/scan.rs
+++ b/libwallet/src/internal/scan.rs
@@ -285,6 +285,8 @@ where
 	Ok((result_vec, last_retrieved_return_index, perc_complete))
 }
 
+const MISSING_OUTPUTS_BATCH_SIZE: usize = 10000;
+
 fn restore_missing_outputs<'a, L, C, K>(
 	wallet_inst: Arc<Mutex<Box<dyn WalletInst<'a, L, C, K>>>>,
 	keychain_mask: Option<&SecretKey>,
@@ -302,86 +304,88 @@ where
 	wallet_lock!(wallet_inst, w);
 
 	let keychain = w.keychain(keychain_mask)?;
-	let mut batch = w.batch(keychain_mask)?;
-	for output in outputs.iter() {
-		let msg = format!(
-			"Confirmed output for {} with ID {} ({:?}, index {}) exists in UTXO set but not in wallet. \
+	for o_chunks in outputs.chunks(MISSING_OUTPUTS_BATCH_SIZE).into_iter() {
+		let mut batch = w.batch(keychain_mask)?;
+		for output in o_chunks {
+			let msg = format!(
+				"Confirmed output for {} with ID {} ({:?}, index {}) exists in UTXO set but not in wallet. \
 				 Restoring.",
-			output.value, output.key_id, output.commit, output.mmr_index
-		);
-		if let Some(ref s) = status_send_channel {
-			let _ = s.send(StatusMessage::Scanning(msg, perc_complete));
-		}
+				output.value, output.key_id, output.commit, output.mmr_index
+			);
+			if let Some(ref s) = status_send_channel {
+				let _ = s.send(StatusMessage::Scanning(msg, perc_complete));
+			}
 
-		let commit = keychain
-			.commit(output.value, &output.key_id, SwitchCommitmentType::Regular)?
-			.0
-			.to_vec()
-			.to_hex();
+			let commit = keychain
+				.commit(output.value, &output.key_id, SwitchCommitmentType::Regular)?
+				.0
+				.to_vec()
+				.to_hex();
 
-		let parent_key_id = output.key_id.parent_path();
-		if !found_parents.contains_key(&parent_key_id) {
-			found_parents.insert(parent_key_id.clone(), 0);
-			if let Some(ref mut s) = tx_stats {
+			let parent_key_id = output.key_id.parent_path();
+			if !found_parents.contains_key(&parent_key_id) {
+				found_parents.insert(parent_key_id.clone(), 0);
+				if let Some(ref mut s) = tx_stats {
+					s.insert(
+						parent_key_id.clone(),
+						RestoredTxStats {
+							log_id: batch.next_tx_log_id(&parent_key_id)?,
+							amount_credited: 0,
+							num_outputs: 0,
+						},
+					);
+				}
+			}
+
+			let log_id = if tx_stats.is_none() || output.is_coinbase {
+				let log_id = batch.next_tx_log_id(&parent_key_id)?;
+				let entry_type = match output.is_coinbase {
+					true => TxLogEntryType::ConfirmedCoinbase,
+					false => TxLogEntryType::TxReceived,
+				};
+				let mut t = TxLogEntry::new(parent_key_id.clone(), entry_type, log_id);
+				t.confirmed = true;
+				t.amount_credited = output.value;
+				t.num_outputs = 1;
+				t.update_confirmation_ts();
+				batch.save_tx_log_entry(t, &parent_key_id)?;
+				log_id
+			} else if let Some(ref mut s) = tx_stats {
+				let ts = s.get(&parent_key_id).unwrap().clone();
 				s.insert(
 					parent_key_id.clone(),
 					RestoredTxStats {
-						log_id: batch.next_tx_log_id(&parent_key_id)?,
-						amount_credited: 0,
-						num_outputs: 0,
+						log_id: ts.log_id,
+						amount_credited: ts.amount_credited + output.value,
+						num_outputs: ts.num_outputs + 1,
 					},
 				);
+				ts.log_id
+			} else {
+				0
+			};
+
+			let _ = batch.save(OutputData {
+				root_key_id: parent_key_id.clone(),
+				key_id: output.key_id.clone(),
+				n_child: output.n_child,
+				mmr_index: Some(output.mmr_index),
+				commit: Some(commit),
+				value: output.value,
+				status: OutputStatus::Unspent,
+				height: output.height,
+				lock_height: output.lock_height,
+				is_coinbase: output.is_coinbase,
+				tx_log_entry: Some(log_id),
+			});
+
+			let max_child_index = *found_parents.get(&parent_key_id).unwrap();
+			if output.n_child >= max_child_index {
+				found_parents.insert(parent_key_id, output.n_child);
 			}
 		}
-
-		let log_id = if tx_stats.is_none() || output.is_coinbase {
-			let log_id = batch.next_tx_log_id(&parent_key_id)?;
-			let entry_type = match output.is_coinbase {
-				true => TxLogEntryType::ConfirmedCoinbase,
-				false => TxLogEntryType::TxReceived,
-			};
-			let mut t = TxLogEntry::new(parent_key_id.clone(), entry_type, log_id);
-			t.confirmed = true;
-			t.amount_credited = output.value;
-			t.num_outputs = 1;
-			t.update_confirmation_ts();
-			batch.save_tx_log_entry(t, &parent_key_id)?;
-			log_id
-		} else if let Some(ref mut s) = tx_stats {
-			let ts = s.get(&parent_key_id).unwrap().clone();
-			s.insert(
-				parent_key_id.clone(),
-				RestoredTxStats {
-					log_id: ts.log_id,
-					amount_credited: ts.amount_credited + output.value,
-					num_outputs: ts.num_outputs + 1,
-				},
-			);
-			ts.log_id
-		} else {
-			0
-		};
-
-		let _ = batch.save(OutputData {
-			root_key_id: parent_key_id.clone(),
-			key_id: output.key_id.clone(),
-			n_child: output.n_child,
-			mmr_index: Some(output.mmr_index),
-			commit: Some(commit),
-			value: output.value,
-			status: OutputStatus::Unspent,
-			height: output.height,
-			lock_height: output.lock_height,
-			is_coinbase: output.is_coinbase,
-			tx_log_entry: Some(log_id),
-		});
-
-		let max_child_index = *found_parents.get(&parent_key_id).unwrap();
-		if output.n_child >= max_child_index {
-			found_parents.insert(parent_key_id, output.n_child);
-		}
+		batch.commit()?;
 	}
-	batch.commit()?;
 	Ok(())
 }
 
@@ -587,7 +591,7 @@ where
 			let _ = s.send(StatusMessage::Scanning(msg, perc_complete));
 		}
 		o.status = OutputStatus::Unspent;
-		// any transactions associated with this should be cancelled
+		// any transactions associated with this should be canceled
 		cancel_tx_log_entry(wallet_inst.clone(), keychain_mask, &o)?;
 		wallet_lock!(wallet_inst, w);
 		let mut batch = w.batch(keychain_mask)?;
@@ -596,6 +600,8 @@ where
 	}
 
 	let mut found_parents: HashMap<Identifier, u32> = HashMap::new();
+
+	debug!("scan: restoring {} missing outputs", missing_outs.len());
 
 	// Restore missing outputs, adding transaction for it back to the log
 	restore_missing_outputs(

--- a/libwallet/src/internal/scan.rs
+++ b/libwallet/src/internal/scan.rs
@@ -28,6 +28,7 @@ use crate::internal::{keys, updater};
 use crate::types::*;
 use crate::{wallet_lock, Error, OutputCommitMapping};
 use blake2_rfc::blake2b::blake2b;
+use rayon::prelude::*;
 use std::cmp;
 use std::collections::HashMap;
 use std::sync::mpsc::Sender;
@@ -54,17 +55,9 @@ struct OutputResult {
 	pub is_coinbase: bool,
 }
 
-#[derive(Debug, Clone)]
-/// Collect stats in case we want to just output a single tx log entry
-/// for restored non-coinbase outputs
-struct RestoredTxStats {
-	///
-	pub log_id: u32,
-	///
-	pub amount_credited: u64,
-	///
-	pub num_outputs: usize,
-}
+/// Keep restore transactions bounded while avoiding a durable LMDB commit for
+/// every individual output.
+const RESTORE_BATCH_SIZE: usize = 1_000;
 
 fn identify_utxo_outputs<K>(
 	keychain: &K,
@@ -75,49 +68,69 @@ fn identify_utxo_outputs<K>(
 where
 	K: Keychain,
 {
-	let mut wallet_outputs: Vec<OutputResult> = Vec::new();
-
 	let legacy_builder = proof::LegacyProofBuilder::new(keychain);
 	let builder = proof::ProofBuilder::new(keychain);
 	let legacy_version = HeaderVersion(1);
 
-	for output in outputs.iter() {
-		let (commit, proof, is_coinbase, height, mmr_index) = output;
-		// attempt to unwind message from the RP and get a value
-		// will fail if it's not ours
-		let info = {
-			// Before HF+2wk, try legacy rewind first
-			let info_legacy =
-				if valid_header_version(height.saturating_sub(2 * WEEK_HEIGHT), legacy_version) {
-					proof::rewind(keychain.secp(), &legacy_builder, *commit, None, *proof)?
-				} else {
-					None
+	let identified = outputs
+		.par_iter()
+		.map(
+			|output| -> Result<Option<(OutputResult, SwitchCommitmentType)>, Error> {
+				let (commit, proof, is_coinbase, height, mmr_index) = output;
+				// attempt to unwind message from the RP and get a value
+				// will fail if it's not ours
+				let info = {
+					// Before HF+2wk, try legacy rewind first
+					let info_legacy = if valid_header_version(
+						height.saturating_sub(2 * WEEK_HEIGHT),
+						legacy_version,
+					) {
+						proof::rewind(keychain.secp(), &legacy_builder, *commit, None, *proof)?
+					} else {
+						None
+					};
+
+					// If legacy didn't work, try new rewind
+					if info_legacy.is_none() {
+						proof::rewind(keychain.secp(), &builder, *commit, None, *proof)?
+					} else {
+						info_legacy
+					}
 				};
 
-			// If legacy didn't work, try new rewind
-			if info_legacy.is_none() {
-				proof::rewind(keychain.secp(), &builder, *commit, None, *proof)?
-			} else {
-				info_legacy
-			}
-		};
+				let (amount, key_id, switch) = match info {
+					Some(i) => i,
+					None => return Ok(None),
+				};
 
-		let (amount, key_id, switch) = match info {
-			Some(i) => i,
-			None => {
-				continue;
-			}
-		};
+				let lock_height = if *is_coinbase {
+					*height + global::coinbase_maturity()
+				} else {
+					*height
+				};
 
-		let lock_height = if *is_coinbase {
-			*height + global::coinbase_maturity()
-		} else {
-			*height
-		};
+				Ok(Some((
+					OutputResult {
+						commit: *commit,
+						key_id: key_id.clone(),
+						n_child: key_id.to_path().last_path_index(),
+						value: amount,
+						height: *height,
+						lock_height,
+						is_coinbase: *is_coinbase,
+						mmr_index: *mmr_index,
+					},
+					switch,
+				)))
+			},
+		)
+		.collect::<Result<Vec<_>, Error>>()?;
 
+	let mut wallet_outputs = Vec::new();
+	for (output, switch) in identified.into_iter().flatten() {
 		let msg = format!(
 			"Output found: {:?}, amount: {:?}, key_id: {:?}, mmr_index: {},",
-			commit, amount, key_id, mmr_index,
+			output.commit, output.value, output.key_id, output.mmr_index,
 		);
 
 		if let Some(ref s) = status_send_channel {
@@ -131,16 +144,7 @@ where
 			}
 		}
 
-		wallet_outputs.push(OutputResult {
-			commit: *commit,
-			key_id: key_id.clone(),
-			n_child: key_id.to_path().last_path_index(),
-			value: amount,
-			height: *height,
-			lock_height,
-			is_coinbase: *is_coinbase,
-			mmr_index: *mmr_index,
-		});
+		wallet_outputs.push(output);
 	}
 	Ok(wallet_outputs)
 }
@@ -266,7 +270,7 @@ where
 
 		result_vec.append(&mut identify_utxo_outputs(
 			keychain,
-			outputs.clone(),
+			outputs,
 			status_send_channel,
 			perc_complete,
 		)?);
@@ -285,12 +289,11 @@ where
 	Ok((result_vec, last_retrieved_return_index, perc_complete))
 }
 
-fn restore_missing_output<'a, L, C, K>(
+fn restore_missing_outputs<'a, L, C, K>(
 	wallet_inst: Arc<Mutex<Box<dyn WalletInst<'a, L, C, K>>>>,
 	keychain_mask: Option<&SecretKey>,
-	output: OutputResult,
+	outputs: &[OutputResult],
 	found_parents: &mut HashMap<Identifier, u32>,
-	tx_stats: &mut Option<&mut HashMap<Identifier, RestoredTxStats>>,
 ) -> Result<(), Error>
 where
 	L: WalletLCProvider<'a, C, K>,
@@ -299,25 +302,14 @@ where
 {
 	wallet_lock!(wallet_inst, w);
 
-	let commit = w.calc_commit_for_cache(keychain_mask, output.value, &output.key_id)?;
 	let mut batch = w.batch(keychain_mask)?;
 
-	let parent_key_id = output.key_id.parent_path();
-	if !found_parents.contains_key(&parent_key_id) {
-		found_parents.insert(parent_key_id.clone(), 0);
-		if let Some(ref mut s) = tx_stats {
-			s.insert(
-				parent_key_id.clone(),
-				RestoredTxStats {
-					log_id: batch.next_tx_log_id(&parent_key_id)?,
-					amount_credited: 0,
-					num_outputs: 0,
-				},
-			);
+	for output in outputs.iter().cloned() {
+		let parent_key_id = output.key_id.parent_path();
+		if !found_parents.contains_key(&parent_key_id) {
+			found_parents.insert(parent_key_id.clone(), 0);
 		}
-	}
 
-	let log_id = if tx_stats.is_none() || output.is_coinbase {
 		let log_id = batch.next_tx_log_id(&parent_key_id)?;
 		let entry_type = match output.is_coinbase {
 			true => TxLogEntryType::ConfirmedCoinbase,
@@ -329,39 +321,25 @@ where
 		t.num_outputs = 1;
 		t.update_confirmation_ts();
 		batch.save_tx_log_entry(t, &parent_key_id)?;
-		log_id
-	} else if let Some(ref mut s) = tx_stats {
-		let ts = s.get(&parent_key_id).unwrap().clone();
-		s.insert(
-			parent_key_id.clone(),
-			RestoredTxStats {
-				log_id: ts.log_id,
-				amount_credited: ts.amount_credited + output.value,
-				num_outputs: ts.num_outputs + 1,
-			},
-		);
-		ts.log_id
-	} else {
-		0
-	};
 
-	let _ = batch.save(OutputData {
-		root_key_id: parent_key_id.clone(),
-		key_id: output.key_id,
-		n_child: output.n_child,
-		mmr_index: Some(output.mmr_index),
-		commit: commit,
-		value: output.value,
-		status: OutputStatus::Unspent,
-		height: output.height,
-		lock_height: output.lock_height,
-		is_coinbase: output.is_coinbase,
-		tx_log_entry: Some(log_id),
-	});
+		batch.save(OutputData {
+			root_key_id: parent_key_id.clone(),
+			key_id: output.key_id,
+			n_child: output.n_child,
+			mmr_index: Some(output.mmr_index),
+			commit: Some(output.commit.0.to_vec().to_hex()),
+			value: output.value,
+			status: OutputStatus::Unspent,
+			height: output.height,
+			lock_height: output.lock_height,
+			is_coinbase: output.is_coinbase,
+			tx_log_entry: Some(log_id),
+		})?;
 
-	let max_child_index = *found_parents.get(&parent_key_id).unwrap();
-	if output.n_child >= max_child_index {
-		found_parents.insert(parent_key_id, output.n_child);
+		let max_child_index = *found_parents.get(&parent_key_id).unwrap();
+		if output.n_child >= max_child_index {
+			found_parents.insert(parent_key_id, output.n_child);
+		}
 	}
 
 	batch.commit()?;
@@ -581,21 +559,22 @@ where
 	let mut found_parents: HashMap<Identifier, u32> = HashMap::new();
 
 	// Restore missing outputs, adding transaction for it back to the log
-	for m in missing_outs.into_iter() {
-		let msg = format!(
-				"Confirmed output for {} with ID {} ({:?}, index {}) exists in UTXO set but not in wallet. \
-				 Restoring.",
-				m.value, m.key_id, m.commit, m.mmr_index
-			);
-		if let Some(ref s) = status_send_channel {
-			let _ = s.send(StatusMessage::Scanning(msg, perc_complete));
+	for outputs in missing_outs.chunks(RESTORE_BATCH_SIZE) {
+		for m in outputs {
+			let msg = format!(
+					"Confirmed output for {} with ID {} ({:?}, index {}) exists in UTXO set but not in wallet. \
+					 Restoring.",
+					m.value, m.key_id, m.commit, m.mmr_index
+				);
+			if let Some(ref s) = status_send_channel {
+				let _ = s.send(StatusMessage::Scanning(msg, perc_complete));
+			}
 		}
-		restore_missing_output(
+		restore_missing_outputs(
 			wallet_inst.clone(),
 			keychain_mask,
-			m,
+			outputs,
 			&mut found_parents,
-			&mut None,
 		)?;
 	}
 

--- a/libwallet/src/internal/scan.rs
+++ b/libwallet/src/internal/scan.rs
@@ -302,7 +302,7 @@ where
 {
 	wallet_lock!(wallet_inst, w);
 
-	for o_chunks in outputs.chunks(MISSING_OUTPUTS_BATCH_SIZE).into_iter() {
+	for o_chunks in outputs.chunks(MISSING_OUTPUTS_BATCH_SIZE) {
 		let mut batch = w.batch(keychain_mask)?;
 		for output in o_chunks {
 			let msg = format!(

--- a/libwallet/src/internal/scan.rs
+++ b/libwallet/src/internal/scan.rs
@@ -285,7 +285,7 @@ where
 	Ok((result_vec, last_retrieved_return_index, perc_complete))
 }
 
-const MISSING_OUTPUTS_BATCH_SIZE: usize = 10000;
+const MISSING_OUTPUTS_BATCH_SIZE: usize = 1000;
 
 fn restore_missing_outputs<'a, L, C, K>(
 	wallet_inst: Arc<Mutex<Box<dyn WalletInst<'a, L, C, K>>>>,

--- a/libwallet/src/internal/scan.rs
+++ b/libwallet/src/internal/scan.rs
@@ -300,9 +300,8 @@ where
 	C: NodeClient + 'a,
 	K: Keychain + 'a,
 {
-	wallet_lock!(wallet_inst, w);
-
 	for o_chunks in outputs.chunks(MISSING_OUTPUTS_BATCH_SIZE) {
+		wallet_lock!(wallet_inst, w);
 		let mut batch = w.batch(keychain_mask)?;
 		for output in o_chunks {
 			let msg = format!(

--- a/libwallet/src/internal/scan.rs
+++ b/libwallet/src/internal/scan.rs
@@ -285,12 +285,14 @@ where
 	Ok((result_vec, last_retrieved_return_index, perc_complete))
 }
 
-fn restore_missing_output<'a, L, C, K>(
+fn restore_missing_outputs<'a, L, C, K>(
 	wallet_inst: Arc<Mutex<Box<dyn WalletInst<'a, L, C, K>>>>,
 	keychain_mask: Option<&SecretKey>,
-	output: OutputResult,
+	outputs: Vec<OutputResult>,
 	found_parents: &mut HashMap<Identifier, u32>,
 	tx_stats: &mut Option<&mut HashMap<Identifier, RestoredTxStats>>,
+	status_send_channel: &Option<Sender<StatusMessage>>,
+	perc_complete: u8,
 ) -> Result<(), Error>
 where
 	L: WalletLCProvider<'a, C, K>,
@@ -299,71 +301,86 @@ where
 {
 	wallet_lock!(wallet_inst, w);
 
-	let commit = w.calc_commit_for_cache(keychain_mask, output.value, &output.key_id)?;
+	let keychain = w.keychain(keychain_mask)?;
 	let mut batch = w.batch(keychain_mask)?;
+	for output in outputs.iter() {
+		let msg = format!(
+			"Confirmed output for {} with ID {} ({:?}, index {}) exists in UTXO set but not in wallet. \
+				 Restoring.",
+			output.value, output.key_id, output.commit, output.mmr_index
+		);
+		if let Some(ref s) = status_send_channel {
+			let _ = s.send(StatusMessage::Scanning(msg, perc_complete));
+		}
 
-	let parent_key_id = output.key_id.parent_path();
-	if !found_parents.contains_key(&parent_key_id) {
-		found_parents.insert(parent_key_id.clone(), 0);
-		if let Some(ref mut s) = tx_stats {
+		let commit = keychain
+			.commit(output.value, &output.key_id, SwitchCommitmentType::Regular)?
+			.0
+			.to_vec()
+			.to_hex();
+
+		let parent_key_id = output.key_id.parent_path();
+		if !found_parents.contains_key(&parent_key_id) {
+			found_parents.insert(parent_key_id.clone(), 0);
+			if let Some(ref mut s) = tx_stats {
+				s.insert(
+					parent_key_id.clone(),
+					RestoredTxStats {
+						log_id: batch.next_tx_log_id(&parent_key_id)?,
+						amount_credited: 0,
+						num_outputs: 0,
+					},
+				);
+			}
+		}
+
+		let log_id = if tx_stats.is_none() || output.is_coinbase {
+			let log_id = batch.next_tx_log_id(&parent_key_id)?;
+			let entry_type = match output.is_coinbase {
+				true => TxLogEntryType::ConfirmedCoinbase,
+				false => TxLogEntryType::TxReceived,
+			};
+			let mut t = TxLogEntry::new(parent_key_id.clone(), entry_type, log_id);
+			t.confirmed = true;
+			t.amount_credited = output.value;
+			t.num_outputs = 1;
+			t.update_confirmation_ts();
+			batch.save_tx_log_entry(t, &parent_key_id)?;
+			log_id
+		} else if let Some(ref mut s) = tx_stats {
+			let ts = s.get(&parent_key_id).unwrap().clone();
 			s.insert(
 				parent_key_id.clone(),
 				RestoredTxStats {
-					log_id: batch.next_tx_log_id(&parent_key_id)?,
-					amount_credited: 0,
-					num_outputs: 0,
+					log_id: ts.log_id,
+					amount_credited: ts.amount_credited + output.value,
+					num_outputs: ts.num_outputs + 1,
 				},
 			);
+			ts.log_id
+		} else {
+			0
+		};
+
+		let _ = batch.save(OutputData {
+			root_key_id: parent_key_id.clone(),
+			key_id: output.key_id.clone(),
+			n_child: output.n_child,
+			mmr_index: Some(output.mmr_index),
+			commit: Some(commit),
+			value: output.value,
+			status: OutputStatus::Unspent,
+			height: output.height,
+			lock_height: output.lock_height,
+			is_coinbase: output.is_coinbase,
+			tx_log_entry: Some(log_id),
+		});
+
+		let max_child_index = *found_parents.get(&parent_key_id).unwrap();
+		if output.n_child >= max_child_index {
+			found_parents.insert(parent_key_id, output.n_child);
 		}
 	}
-
-	let log_id = if tx_stats.is_none() || output.is_coinbase {
-		let log_id = batch.next_tx_log_id(&parent_key_id)?;
-		let entry_type = match output.is_coinbase {
-			true => TxLogEntryType::ConfirmedCoinbase,
-			false => TxLogEntryType::TxReceived,
-		};
-		let mut t = TxLogEntry::new(parent_key_id.clone(), entry_type, log_id);
-		t.confirmed = true;
-		t.amount_credited = output.value;
-		t.num_outputs = 1;
-		t.update_confirmation_ts();
-		batch.save_tx_log_entry(t, &parent_key_id)?;
-		log_id
-	} else if let Some(ref mut s) = tx_stats {
-		let ts = s.get(&parent_key_id).unwrap().clone();
-		s.insert(
-			parent_key_id.clone(),
-			RestoredTxStats {
-				log_id: ts.log_id,
-				amount_credited: ts.amount_credited + output.value,
-				num_outputs: ts.num_outputs + 1,
-			},
-		);
-		ts.log_id
-	} else {
-		0
-	};
-
-	let _ = batch.save(OutputData {
-		root_key_id: parent_key_id.clone(),
-		key_id: output.key_id,
-		n_child: output.n_child,
-		mmr_index: Some(output.mmr_index),
-		commit: commit,
-		value: output.value,
-		status: OutputStatus::Unspent,
-		height: output.height,
-		lock_height: output.lock_height,
-		is_coinbase: output.is_coinbase,
-		tx_log_entry: Some(log_id),
-	});
-
-	let max_child_index = *found_parents.get(&parent_key_id).unwrap();
-	if output.n_child >= max_child_index {
-		found_parents.insert(parent_key_id, output.n_child);
-	}
-
 	batch.commit()?;
 	Ok(())
 }
@@ -581,23 +598,15 @@ where
 	let mut found_parents: HashMap<Identifier, u32> = HashMap::new();
 
 	// Restore missing outputs, adding transaction for it back to the log
-	for m in missing_outs.into_iter() {
-		let msg = format!(
-				"Confirmed output for {} with ID {} ({:?}, index {}) exists in UTXO set but not in wallet. \
-				 Restoring.",
-				m.value, m.key_id, m.commit, m.mmr_index
-			);
-		if let Some(ref s) = status_send_channel {
-			let _ = s.send(StatusMessage::Scanning(msg, perc_complete));
-		}
-		restore_missing_output(
-			wallet_inst.clone(),
-			keychain_mask,
-			m,
-			&mut found_parents,
-			&mut None,
-		)?;
-	}
+	restore_missing_outputs(
+		wallet_inst.clone(),
+		keychain_mask,
+		missing_outs,
+		&mut found_parents,
+		&mut None,
+		status_send_channel,
+		perc_complete,
+	)?;
 
 	if delete_unconfirmed {
 		// Unlock locked outputs

--- a/libwallet/src/internal/selection.rs
+++ b/libwallet/src/internal/selection.rs
@@ -115,19 +115,6 @@ where
 		);
 	}
 
-	let input_len = inputs.len();
-	let output_len = change_amounts_derivations.len();
-	let tx_weight = Transaction::weight_by_iok(input_len as u64, output_len as u64, 1u64);
-	let max_tx_weight = global::max_tx_weight();
-	if tx_weight > max_tx_weight {
-		let err = format!(
-			"Transaction weight {}, exceeds global max_tx_weight {}",
-			tx_weight, max_tx_weight
-		);
-		error!("{}", err);
-		return Err(Error::GenericError(err));
-	}
-
 	Ok(context)
 }
 
@@ -491,6 +478,29 @@ where
 			};
 		}
 	}
+
+	let input_len = coins.len();
+	let tx_weight = Transaction::weight_by_iok(input_len as u64, change_outputs as u64, 1u64);
+	let max_tx_weight = global::max_tx_weight();
+	if tx_weight > max_tx_weight {
+		let mut max_amount = 0;
+		let mut input_len = 0;
+		for c in &coins {
+			input_len += 1;
+			let tx_weight =
+				Transaction::weight_by_iok(input_len as u64, change_outputs as u64, 1u64);
+			if tx_weight >= max_tx_weight {
+				break;
+			}
+			max_amount += c.value;
+		}
+		error!("{}", format!(
+			"Transaction weight {}, exceeds global max_tx_weight {}, can send maximum {}, send such amount to yourself for outputs consolidation",
+			tx_weight, max_tx_weight, amount_to_hr_string(max_amount, true)
+		));
+		return Err(Error::BigAmountError(max_amount));
+	}
+
 	// If original amount includes fee, the new amount should
 	// be reduced, to accommodate the fee.
 	let new_amount = match amount_includes_fee {

--- a/libwallet/src/internal/selection.rs
+++ b/libwallet/src/internal/selection.rs
@@ -480,25 +480,20 @@ where
 	}
 
 	let input_len = coins.len();
-	let tx_weight = Transaction::weight_by_iok(input_len as u64, change_outputs as u64 + 1, 1u64);
+	let output_len = if total == amount_with_fee {
+		1
+	} else {
+		change_outputs + 1
+	};
+	let tx_weight = Transaction::weight_by_iok(input_len as u64, output_len as u64, 1u64);
 	let max_tx_weight = global::max_tx_weight();
 	if tx_weight > max_tx_weight {
-		let mut max_amount = 0;
-		let mut input_len = 0;
-		for c in &coins {
-			input_len += 1;
-			let tx_weight =
-				Transaction::weight_by_iok(input_len as u64, change_outputs as u64 + 1, 1u64);
-			if tx_weight >= max_tx_weight {
-				break;
-			}
-			max_amount += c.value;
-		}
-		error!("{}", format!(
+		let (max_amount, max_inputs) = max_spendable_amount(&coins, max_tx_weight);
+		error!(
 			"Transaction weight {}, exceeds global max_tx_weight {}, can send maximum {}, send such amount to yourself for outputs consolidation",
 			tx_weight, max_tx_weight, amount_to_hr_string(max_amount, true)
-		));
-		return Err(Error::BigAmountError(max_amount));
+		);
+		return Err(Error::BigAmountError(max_amount, max_inputs));
 	}
 
 	// If original amount includes fee, the new amount should
@@ -510,6 +505,20 @@ where
 		false => amount,
 	};
 	Ok((coins, total, new_amount, fee))
+}
+
+fn max_spendable_amount(coins: &[OutputData], max_tx_weight: u64) -> (u64, u32) {
+	let mut values = coins.iter().map(|coin| coin.value).collect::<Vec<_>>();
+	values.sort_unstable_by(|a, b| b.cmp(a));
+	values
+		.into_iter()
+		.enumerate()
+		.take_while(|(index, _)| {
+			Transaction::weight_by_iok(*index as u64 + 1, 1, 1) <= max_tx_weight
+		})
+		.fold((0, 0), |(amount, inputs), (_, value)| {
+			(amount + value, inputs + 1)
+		})
 }
 
 /// Selects inputs and change for a transaction
@@ -733,4 +742,33 @@ where
 	// restore the original offset
 	slate.tx_or_err_mut()?.offset = slate.offset.clone();
 	Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+	use super::*;
+
+	fn output(value: u64) -> OutputData {
+		OutputData {
+			root_key_id: Identifier::zero(),
+			key_id: Identifier::zero(),
+			n_child: 0,
+			commit: None,
+			mmr_index: None,
+			value,
+			status: OutputStatus::Unspent,
+			height: 0,
+			lock_height: 0,
+			is_coinbase: false,
+			tx_log_entry: None,
+		}
+	}
+
+	#[test]
+	fn max_spendable_uses_largest_outputs() {
+		let coins = vec![output(1), output(2), output(100)];
+		let max_weight = Transaction::weight_by_iok(2, 1, 1);
+
+		assert_eq!(max_spendable_amount(&coins, max_weight), (102, 2));
+	}
 }

--- a/libwallet/src/internal/selection.rs
+++ b/libwallet/src/internal/selection.rs
@@ -394,11 +394,6 @@ where
 	C: NodeClient,
 	K: Keychain,
 {
-	debug!(
-		"selection_strategy_is_use_all: {}",
-		selection_strategy_is_use_all
-	);
-	debug!("max_outputs: {}", max_outputs);
 	// select some spendable coins from the wallet
 	let (max_outputs, mut coins) = select_coins(
 		wallet,
@@ -409,7 +404,6 @@ where
 		selection_strategy_is_use_all,
 		parent_key_id,
 	)?;
-	debug!("max_outputs2: {}", max_outputs);
 
 	// sender is responsible for setting the fee on the partial tx
 	// recipient should double-check the fee calculation and not blindly trust the

--- a/libwallet/src/internal/selection.rs
+++ b/libwallet/src/internal/selection.rs
@@ -488,7 +488,10 @@ where
 	let tx_weight = Transaction::weight_by_iok(input_len as u64, output_len as u64, 1u64);
 	let max_tx_weight = global::max_tx_weight();
 	if tx_weight > max_tx_weight {
-		let (max_amount, max_inputs) = max_spendable_amount(&coins, max_tx_weight);
+		let eligible =
+			eligible_outputs(wallet, current_height, minimum_confirmations, parent_key_id)?;
+		let (max_amount, max_inputs) =
+			max_spendable_amount(&eligible, max_tx_weight, amount_includes_fee);
 		error!(
 			"Transaction weight {}, exceeds global max_tx_weight {}, can send maximum {}, send such amount to yourself for outputs consolidation",
 			tx_weight, max_tx_weight, amount_to_hr_string(max_amount, true)
@@ -507,10 +510,17 @@ where
 	Ok((coins, total, new_amount, fee))
 }
 
-fn max_spendable_amount(coins: &[OutputData], max_tx_weight: u64) -> (u64, u32) {
-	let mut values = coins.iter().map(|coin| coin.value).collect::<Vec<_>>();
+fn max_spendable_amount(
+	outputs: &[OutputData],
+	max_tx_weight: u64,
+	amount_includes_fee: bool,
+) -> (u64, u32) {
+	let mut values = outputs
+		.iter()
+		.map(|output| output.value)
+		.collect::<Vec<_>>();
 	values.sort_unstable_by(|a, b| b.cmp(a));
-	values
+	let (amount, inputs) = values
 		.into_iter()
 		.enumerate()
 		.take_while(|(index, _)| {
@@ -518,7 +528,32 @@ fn max_spendable_amount(coins: &[OutputData], max_tx_weight: u64) -> (u64, u32) 
 		})
 		.fold((0, 0), |(amount, inputs), (_, value)| {
 			(amount + value, inputs + 1)
+		});
+	let amount = if amount_includes_fee {
+		amount
+	} else {
+		amount.saturating_sub(tx_fee(inputs as usize, 1, 1))
+	};
+	(amount, inputs)
+}
+
+fn eligible_outputs<C, K>(
+	wallet: &WalletBackend<C, K>,
+	current_height: u64,
+	minimum_confirmations: u64,
+	parent_key_id: &Identifier,
+) -> Result<Vec<OutputData>, Error>
+where
+	C: NodeClient,
+	K: Keychain,
+{
+	Ok(wallet
+		.iter()?
+		.filter(|output| {
+			output.root_key_id == *parent_key_id
+				&& output.eligible_to_spend(current_height, minimum_confirmations)
 		})
+		.collect())
 }
 
 /// Selects inputs and change for a transaction
@@ -614,13 +649,8 @@ where
 	K: Keychain,
 {
 	// first find all eligible outputs based on number of confirmations
-	let mut eligible = wallet
-		.iter()?
-		.filter(|out| {
-			out.root_key_id == *parent_key_id
-				&& out.eligible_to_spend(current_height, minimum_confirmations)
-		})
-		.collect::<Vec<OutputData>>();
+	let mut eligible =
+		eligible_outputs(wallet, current_height, minimum_confirmations, parent_key_id)?;
 
 	let max_available = eligible.len();
 
@@ -765,10 +795,24 @@ mod tests {
 	}
 
 	#[test]
-	fn max_spendable_uses_largest_outputs() {
-		let coins = vec![output(1), output(2), output(100)];
+	fn max_spendable_uses_all_outputs() {
+		let selected = vec![output(1), output(2)];
+		let eligible = vec![output(1), output(2), output(100)];
 		let max_weight = Transaction::weight_by_iok(2, 1, 1);
 
-		assert_eq!(max_spendable_amount(&coins, max_weight), (102, 2));
+		assert_eq!(max_spendable_amount(&selected, max_weight, true), (3, 2));
+		assert_eq!(max_spendable_amount(&eligible, max_weight, true), (102, 2));
+	}
+
+	#[test]
+	fn max_spendable_excludes_fee() {
+		global::set_local_accept_fee_base(500_000);
+		let coins = vec![output(1_000_000_000), output(2_000_000_000)];
+		let max_weight = Transaction::weight_by_iok(2, 1, 1);
+
+		assert_eq!(
+			max_spendable_amount(&coins, max_weight, false),
+			(3_000_000_000 - tx_fee(2, 1, 1), 2)
+		);
 	}
 }

--- a/libwallet/src/internal/selection.rs
+++ b/libwallet/src/internal/selection.rs
@@ -29,6 +29,8 @@ use crate::slate::Slate;
 use crate::types::*;
 use crate::util::OnionV3Address;
 use crate::{address, WalletBackend};
+use grin_core::core::Transaction;
+use grin_core::global;
 use std::collections::HashMap;
 use std::convert::TryInto;
 
@@ -98,7 +100,7 @@ where
 	context.amount = slate.amount;
 
 	// Store our private identifiers for each input
-	for input in inputs {
+	for input in &inputs {
 		context.add_input(&input.key_id, &input.mmr_index, input.value);
 	}
 
@@ -111,6 +113,19 @@ where
 			id.clone(),
 			wallet.calc_commit_for_cache(keychain_mask, *change_amount, &id)?,
 		);
+	}
+
+	let input_len = inputs.len();
+	let output_len = change_amounts_derivations.len();
+	let tx_weight = Transaction::weight_by_iok(input_len as u64, output_len as u64, 1u64);
+	let max_tx_weight = global::max_tx_weight();
+	if tx_weight > max_tx_weight {
+		let err = format!(
+			"Transaction weight {}, exceeds global max_tx_weight {}",
+			tx_weight, max_tx_weight
+		);
+		error!("{}", err);
+		return Err(Error::GenericError(err));
 	}
 
 	Ok(context)

--- a/libwallet/src/internal/selection.rs
+++ b/libwallet/src/internal/selection.rs
@@ -804,24 +804,69 @@ mod tests {
 
 	#[test]
 	fn max_spendable_uses_all_outputs() {
-		let selected = vec![output(1), output(2)];
-		let eligible = vec![output(1), output(2), output(100)];
+		global::set_local_accept_fee_base(1);
+
+		let selected = vec![output(100), output(200)];
+		let eligible = vec![output(100), output(200), output(10000)];
 		let output_len = 1;
 		let max_weight = Transaction::weight_by_iok(2, output_len, 1);
 		assert_eq!(
 			max_spendable_amount(&selected, output_len, max_weight, true),
-			(3, 2)
+			(300, 2)
 		);
 		assert_eq!(
 			max_spendable_amount(&eligible, output_len, max_weight, true),
-			(3, 2)
+			(300, 2)
 		);
 
 		let max_weight = Transaction::weight_by_iok(3, output_len, 1);
 		assert_eq!(
 			max_spendable_amount(&eligible, output_len, max_weight, true),
-			(103, 3)
+			(10300, 3)
 		);
+	}
+
+	#[test]
+	fn max_spendable_fee_amount() {
+		global::set_local_accept_fee_base(1);
+
+		// Can not make txs when fee equals amount and not enough outputs.
+		{
+			let fee = tx_fee(2, 1, 1);
+			let coins = vec![output(13), output(13)];
+			let output_len = 2;
+			let max_weight = Transaction::weight_by_iok(2, output_len, 1);
+			assert_eq!(fee, coins.iter().map(|o| o.value).sum::<u64>());
+			assert_eq!(
+				max_spendable_amount(&coins, output_len, max_weight, false),
+				(0, 0)
+			);
+		}
+
+		// Can not make txs when fee more than amount and not enough outputs.
+		{
+			let fee = tx_fee(2, 1, 1);
+			let coins = vec![output(12), output(13)];
+			let output_len = 2;
+			let max_weight = Transaction::weight_by_iok(2, output_len, 1);
+			assert!(fee > coins.iter().map(|o| o.value).sum::<u64>());
+			assert_eq!(
+				max_spendable_amount(&coins, output_len, max_weight, false),
+				(0, 0)
+			);
+		}
+
+		// Select not all outputs to cover fee.
+		{
+			let fee = tx_fee(3, 1, 1);
+			let coins = vec![output(fee), output(1), output(1)];
+			let output_len = 2;
+			let max_weight = Transaction::weight_by_iok(2, output_len, 1);
+			assert_eq!(
+				max_spendable_amount(&coins, output_len, max_weight, false),
+				(2, 2)
+			);
+		}
 	}
 
 	#[test]

--- a/libwallet/src/internal/selection.rs
+++ b/libwallet/src/internal/selection.rs
@@ -480,7 +480,7 @@ where
 	}
 
 	let input_len = coins.len();
-	let tx_weight = Transaction::weight_by_iok(input_len as u64, change_outputs as u64, 1u64);
+	let tx_weight = Transaction::weight_by_iok(input_len as u64, change_outputs as u64 + 1, 1u64);
 	let max_tx_weight = global::max_tx_weight();
 	if tx_weight > max_tx_weight {
 		let mut max_amount = 0;
@@ -488,7 +488,7 @@ where
 		for c in &coins {
 			input_len += 1;
 			let tx_weight =
-				Transaction::weight_by_iok(input_len as u64, change_outputs as u64, 1u64);
+				Transaction::weight_by_iok(input_len as u64, change_outputs as u64 + 1, 1u64);
 			if tx_weight >= max_tx_weight {
 				break;
 			}

--- a/libwallet/src/internal/selection.rs
+++ b/libwallet/src/internal/selection.rs
@@ -530,21 +530,19 @@ fn max_spendable_amount(
 		.collect();
 
 	// sort outputs by decreasing value to calculate the best fee
-	values.sort_by_key(|out| -(*out as i64));
+	values.sort_by(|a, b| b.cmp(a));
 
 	let mut total_value = 0;
-	let (amount, inputs) = values
-		.into_iter()
-		.enumerate()
-		.take_while(|(index, value)| {
-			let inputs_len = *index as u64 + 1;
-			let fee = tx_fee(inputs_len as usize, 1, 1);
-			total_value += value;
-			total_value > fee
-		})
-		.fold((0, 0), |(amount, inputs), (_, value)| {
-			(amount + value, inputs + 1)
-		});
+	let mut amount = 0;
+	let mut inputs = 0;
+	for (index, value) in values.into_iter().enumerate() {
+		let inputs_len = index + 1;
+		total_value += value;
+		if total_value > tx_fee(inputs_len, 1, 1) {
+			amount = total_value;
+			inputs = inputs_len as u32;
+		}
+	}
 
 	let amount = if amount_includes_fee {
 		amount
@@ -888,6 +886,37 @@ mod tests {
 		assert_eq!(
 			max_spendable_amount(&coins, output_len, max_weight, false),
 			(3_000_000_000 - tx_fee(2, 1, 1), 2)
+		);
+	}
+
+	#[test]
+	fn covers_fee_with_multiple_outputs() {
+		global::set_local_accept_fee_base(1);
+		let coins = vec![output(20), output(20)];
+		let output_len = 1;
+		let max_weight = Transaction::weight_by_iok(2, output_len, 1);
+
+		assert_eq!(
+			max_spendable_amount(&coins, output_len, max_weight, true),
+			(40, 2)
+		);
+		assert_eq!(
+			max_spendable_amount(&coins, output_len, max_weight, false),
+			(40 - tx_fee(2, 1, 1), 2)
+		);
+	}
+
+	#[test]
+	fn sorts_large_values() {
+		global::set_local_accept_fee_base(1);
+		let high_value = 1_u64 << 63;
+		let coins = vec![output(1), output(high_value)];
+		let output_len = 1;
+		let max_weight = Transaction::weight_by_iok(2, output_len, 1);
+
+		assert_eq!(
+			max_spendable_amount(&coins, output_len, max_weight, true),
+			(high_value + 1, 2)
 		);
 	}
 }

--- a/libwallet/src/internal/selection.rs
+++ b/libwallet/src/internal/selection.rs
@@ -523,11 +523,16 @@ fn max_spendable_amount(
 		.iter()
 		.map(|output| output.value)
 		.collect::<Vec<_>>();
+	let mut total_value = 0;
 	let (amount, inputs) = values
 		.into_iter()
 		.enumerate()
-		.take_while(|(index, _)| {
-			Transaction::weight_by_iok(*index as u64 + 1, output_len, 1) <= max_tx_weight
+		.take_while(|(index, value)| {
+			let inputs_len = *index as u64 + 1;
+			let fee = tx_fee(inputs_len as usize, 1, 1);
+			total_value += value;
+			Transaction::weight_by_iok(inputs_len, output_len, 1) <= max_tx_weight
+				&& total_value > fee
 		})
 		.fold((0, 0), |(amount, inputs), (_, value)| {
 			(amount + value, inputs + 1)

--- a/libwallet/src/internal/selection.rs
+++ b/libwallet/src/internal/selection.rs
@@ -498,7 +498,7 @@ where
 			"Transaction weight {}, exceeds global max_tx_weight {}, can send maximum {}, send such amount to yourself for outputs consolidation",
 			tx_weight, max_tx_weight, amount_to_hr_string(max_amount, true)
 		);
-		let fee = tx_fee(max_inputs as usize, output_len, 1);
+		let fee = tx_fee(max_inputs as usize, 1, 1);
 		return Err(Error::BigAmountError(max_amount, fee, max_inputs));
 	}
 

--- a/libwallet/src/internal/selection.rs
+++ b/libwallet/src/internal/selection.rs
@@ -519,10 +519,19 @@ fn max_spendable_amount(
 	max_tx_weight: u64,
 	amount_includes_fee: bool,
 ) -> (u64, u32) {
-	let values = outputs
+	let mut values: Vec<u64> = outputs
 		.iter()
 		.map(|output| output.value)
-		.collect::<Vec<_>>();
+		.enumerate()
+		.take_while(|(index, _)| {
+			Transaction::weight_by_iok(*index as u64 + 1, output_len, 1) <= max_tx_weight
+		})
+		.map(|(_, value)| value)
+		.collect();
+
+	// sort outputs by decreasing value to calculate the best fee
+	values.sort_by_key(|out| -(*out as i64));
+
 	let mut total_value = 0;
 	let (amount, inputs) = values
 		.into_iter()
@@ -531,12 +540,12 @@ fn max_spendable_amount(
 			let inputs_len = *index as u64 + 1;
 			let fee = tx_fee(inputs_len as usize, 1, 1);
 			total_value += value;
-			Transaction::weight_by_iok(inputs_len, output_len, 1) <= max_tx_weight
-				&& total_value > fee
+			total_value > fee
 		})
 		.fold((0, 0), |(amount, inputs), (_, value)| {
 			(amount + value, inputs + 1)
 		});
+
 	let amount = if amount_includes_fee {
 		amount
 	} else {

--- a/libwallet/src/internal/selection.rs
+++ b/libwallet/src/internal/selection.rs
@@ -394,6 +394,11 @@ where
 	C: NodeClient,
 	K: Keychain,
 {
+	debug!(
+		"selection_strategy_is_use_all: {}",
+		selection_strategy_is_use_all
+	);
+	debug!("max_outputs: {}", max_outputs);
 	// select some spendable coins from the wallet
 	let (max_outputs, mut coins) = select_coins(
 		wallet,
@@ -404,6 +409,7 @@ where
 		selection_strategy_is_use_all,
 		parent_key_id,
 	)?;
+	debug!("max_outputs2: {}", max_outputs);
 
 	// sender is responsible for setting the fee on the partial tx
 	// recipient should double-check the fee calculation and not blindly trust the
@@ -488,10 +494,12 @@ where
 	let tx_weight = Transaction::weight_by_iok(input_len as u64, output_len as u64, 1u64);
 	let max_tx_weight = global::max_tx_weight();
 	if tx_weight > max_tx_weight {
-		let eligible =
-			eligible_outputs(wallet, current_height, minimum_confirmations, parent_key_id)?;
-		let (max_amount, max_inputs) =
-			max_spendable_amount(&eligible, max_tx_weight, amount_includes_fee);
+		let (max_amount, max_inputs) = max_spendable_amount(
+			&coins,
+			output_len as u64,
+			max_tx_weight,
+			amount_includes_fee,
+		);
 		error!(
 			"Transaction weight {}, exceeds global max_tx_weight {}, can send maximum {}, send such amount to yourself for outputs consolidation",
 			tx_weight, max_tx_weight, amount_to_hr_string(max_amount, true)
@@ -512,19 +520,19 @@ where
 
 fn max_spendable_amount(
 	outputs: &[OutputData],
+	output_len: u64,
 	max_tx_weight: u64,
 	amount_includes_fee: bool,
 ) -> (u64, u32) {
-	let mut values = outputs
+	let values = outputs
 		.iter()
 		.map(|output| output.value)
 		.collect::<Vec<_>>();
-	values.sort_unstable_by(|a, b| b.cmp(a));
 	let (amount, inputs) = values
 		.into_iter()
 		.enumerate()
 		.take_while(|(index, _)| {
-			Transaction::weight_by_iok(*index as u64 + 1, 1, 1) <= max_tx_weight
+			Transaction::weight_by_iok(*index as u64 + 1, output_len, 1) <= max_tx_weight
 		})
 		.fold((0, 0), |(amount, inputs), (_, value)| {
 			(amount + value, inputs + 1)
@@ -798,20 +806,33 @@ mod tests {
 	fn max_spendable_uses_all_outputs() {
 		let selected = vec![output(1), output(2)];
 		let eligible = vec![output(1), output(2), output(100)];
-		let max_weight = Transaction::weight_by_iok(2, 1, 1);
+		let output_len = 1;
+		let max_weight = Transaction::weight_by_iok(2, output_len, 1);
+		assert_eq!(
+			max_spendable_amount(&selected, output_len, max_weight, true),
+			(3, 2)
+		);
+		assert_eq!(
+			max_spendable_amount(&eligible, output_len, max_weight, true),
+			(3, 2)
+		);
 
-		assert_eq!(max_spendable_amount(&selected, max_weight, true), (3, 2));
-		assert_eq!(max_spendable_amount(&eligible, max_weight, true), (102, 2));
+		let max_weight = Transaction::weight_by_iok(3, output_len, 1);
+		assert_eq!(
+			max_spendable_amount(&eligible, output_len, max_weight, true),
+			(103, 3)
+		);
 	}
 
 	#[test]
 	fn max_spendable_excludes_fee() {
 		global::set_local_accept_fee_base(500_000);
 		let coins = vec![output(1_000_000_000), output(2_000_000_000)];
-		let max_weight = Transaction::weight_by_iok(2, 1, 1);
+		let output_len = 2;
+		let max_weight = Transaction::weight_by_iok(2, output_len, 1);
 
 		assert_eq!(
-			max_spendable_amount(&coins, max_weight, false),
+			max_spendable_amount(&coins, output_len, max_weight, false),
 			(3_000_000_000 - tx_fee(2, 1, 1), 2)
 		);
 	}

--- a/libwallet/src/internal/selection.rs
+++ b/libwallet/src/internal/selection.rs
@@ -498,7 +498,8 @@ where
 			"Transaction weight {}, exceeds global max_tx_weight {}, can send maximum {}, send such amount to yourself for outputs consolidation",
 			tx_weight, max_tx_weight, amount_to_hr_string(max_amount, true)
 		);
-		return Err(Error::BigAmountError(max_amount, max_inputs));
+		let fee = tx_fee(max_inputs as usize, output_len, 1);
+		return Err(Error::BigAmountError(max_amount, fee, max_inputs));
 	}
 
 	// If original amount includes fee, the new amount should

--- a/libwallet/src/internal/selection.rs
+++ b/libwallet/src/internal/selection.rs
@@ -685,8 +685,11 @@ where
 	slate.add_participant_info(&keychain, &context, None)?;
 
 	let mut parts = vec![];
-	for (id, _, value) in &context.get_inputs() {
-		let input = wallet.iter()?.find(|out| out.key_id == *id);
+	for (id, mmr_index, value) in &context.get_inputs() {
+		let input = match wallet.get(id, mmr_index) {
+			Ok(o) => Some(o),
+			Err(_) => wallet.iter()?.find(|out| out.key_id == *id),
+		};
 		if let Some(i) = input {
 			if i.is_coinbase {
 				parts.push(build::coinbase_input(*value, i.key_id.clone()));

--- a/libwallet/src/internal/tx.rs
+++ b/libwallet/src/internal/tx.rs
@@ -160,7 +160,7 @@ where
 	C: NodeClient,
 	K: Keychain,
 {
-	// sender should always refresh outputs
+	// Refresh unless the caller already updated the wallet state.
 	if refresh_outputs {
 		updater::refresh_outputs(wallet, keychain_mask, parent_key_id, false)?;
 	}
@@ -266,7 +266,7 @@ where
 	C: NodeClient,
 	K: Keychain,
 {
-	// sender should always refresh outputs
+	// Refresh unless the caller already updated the wallet state.
 	if init_tx_args.refresh_outputs_from_node {
 		updater::refresh_outputs(wallet, keychain_mask, parent_key_id, false)?;
 	}

--- a/libwallet/src/internal/tx.rs
+++ b/libwallet/src/internal/tx.rs
@@ -99,6 +99,7 @@ pub fn estimate_send_tx<C, K>(
 	max_outputs: usize,
 	num_change_outputs: usize,
 	selection_strategy_is_use_all: bool,
+	refresh_outputs: bool,
 	parent_key_id: &Identifier,
 ) -> Result<
 	(
@@ -114,7 +115,9 @@ where
 	// Get lock height
 	let current_height = wallet.w2n_client().get_chain_tip()?.0;
 	// ensure outputs we're selecting are up to date
-	updater::refresh_outputs(wallet, keychain_mask, parent_key_id, false)?;
+	if refresh_outputs {
+		updater::refresh_outputs(wallet, keychain_mask, parent_key_id, false)?;
+	}
 
 	// Sender selects outputs into a new slate and save our corresponding keys in
 	// a transaction context. The secret key in our transaction context will be
@@ -147,6 +150,7 @@ pub fn add_inputs_to_slate<C, K>(
 	max_outputs: usize,
 	num_change_outputs: usize,
 	selection_strategy_is_use_all: bool,
+	refresh_outputs: bool,
 	parent_key_id: &Identifier,
 	is_initiator: bool,
 	use_test_rng: bool,
@@ -157,7 +161,9 @@ where
 	K: Keychain,
 {
 	// sender should always refresh outputs
-	updater::refresh_outputs(wallet, keychain_mask, parent_key_id, false)?;
+	if refresh_outputs {
+		updater::refresh_outputs(wallet, keychain_mask, parent_key_id, false)?;
+	}
 
 	// Sender selects outputs into a new slate and save our corresponding keys in
 	// a transaction context. The secret key in our transaction context will be
@@ -261,7 +267,9 @@ where
 	K: Keychain,
 {
 	// sender should always refresh outputs
-	updater::refresh_outputs(wallet, keychain_mask, parent_key_id, false)?;
+	if init_tx_args.refresh_outputs_from_node {
+		updater::refresh_outputs(wallet, keychain_mask, parent_key_id, false)?;
+	}
 
 	// we're just going to run a selection to get the potential fee,
 	// but this won't be locked

--- a/libwallet/src/lib.rs
+++ b/libwallet/src/lib.rs
@@ -72,7 +72,6 @@ pub use api_impl::types::{
 };
 pub use backend::{WalletBackend, WalletBatch};
 pub use internal::scan::scan;
-pub use internal::selection::select_coins_and_fee;
 pub use slate_versions::ser as dalek_ser;
 pub use types::{
 	AcctPathMapping, BlockIdentifier, CbData, Context, NodeClient, NodeVersionInfo, OutputData,

--- a/libwallet/src/lib.rs
+++ b/libwallet/src/lib.rs
@@ -72,6 +72,7 @@ pub use api_impl::types::{
 };
 pub use backend::{WalletBackend, WalletBatch};
 pub use internal::scan::scan;
+pub use internal::selection::select_coins_and_fee;
 pub use slate_versions::ser as dalek_ser;
 pub use types::{
 	AcctPathMapping, BlockIdentifier, CbData, Context, NodeClient, NodeVersionInfo, OutputData,

--- a/libwallet/src/types.rs
+++ b/libwallet/src/types.rs
@@ -679,7 +679,7 @@ impl ser::Writeable for TxLogEntry {
 
 impl ser::Readable for TxLogEntry {
 	fn read<R: ser::Reader>(reader: &mut R) -> Result<TxLogEntry, ser::Error> {
-		let data = read_bytes_len_prefix(reader)?;
+		let data = reader.read_bytes_len_prefix()?;
 		serde_json::from_slice(&data[..]).map_err(|_| ser::Error::CorruptedData)
 	}
 }

--- a/libwallet/src/types.rs
+++ b/libwallet/src/types.rs
@@ -358,6 +358,10 @@ impl fmt::Display for OutputStatus {
 	}
 }
 
+/// Maximum private transaction context size.
+/// Verified against `max_tx_weight()` below.
+const MAX_CONTEXT_SIZE: usize = 4 * 1024 * 1024;
+
 #[derive(Serialize, Deserialize, Clone, Debug)]
 /// Holds the context for a single aggsig transaction
 pub struct Context {
@@ -892,8 +896,6 @@ impl ViewWalletOutputResult {
 	}
 }
 
-const MAX_CONTEXT_SIZE: usize = 4 * 1024 * 1024;
-
 fn read_bytes_len_prefix<R: ser::Reader>(reader: &mut R) -> Result<Vec<u8>, ser::Error> {
 	let len = reader.read_u64()?;
 	if len > MAX_CONTEXT_SIZE as u64 {
@@ -1064,6 +1066,31 @@ mod tests {
 		assert_eq!(
 			ser::ser_vec(&context, protocol_ver).unwrap_err(),
 			ser::Error::TooLargeReadErr
+		);
+	}
+
+	#[test]
+	fn max_weight_context_size() {
+		global::set_local_chain_type(global::ChainTypes::Mainnet);
+		let max_tx_weight = global::max_tx_weight();
+		let max_inputs = (1..)
+			.take_while(|inputs| Transaction::weight_by_iok(*inputs, 1, 1) <= max_tx_weight)
+			.last()
+			.unwrap();
+
+		let parent = ExtKeychainPath::new(1, 1, 0, 0, 0).to_identifier();
+		let sender_keychain = ExtKeychain::from_random_seed(true).unwrap();
+		let mut context = Context::new(sender_keychain.secp(), &parent, true, true);
+		for i in 0..max_inputs {
+			let key_id = ExtKeychain::derive_key_id(1, 1, i as u32, 0, 0);
+			context.add_input(&key_id, &Some(u64::MAX), u64::MAX);
+		}
+
+		let size = serde_json::to_vec(&context).unwrap().len();
+		println!("max-weight Context: {size} bytes ({max_inputs} inputs)");
+		assert!(
+			size <= MAX_CONTEXT_SIZE,
+			"max-weight Context is {size} bytes, limit is {MAX_CONTEXT_SIZE}"
 		);
 	}
 }

--- a/libwallet/src/types.rs
+++ b/libwallet/src/types.rs
@@ -891,8 +891,11 @@ impl ViewWalletOutputResult {
 fn read_bytes_len_prefix<R: ser::Reader>(reader: &mut R) -> Result<Vec<u8>, ser::Error> {
 	let mut len = reader.read_u64()? as usize;
 	match reader.read_limit() {
-		None => reader.read_bytes_len_prefix(),
+		None => reader.read_fixed_bytes(len),
 		Some(limit) => {
+			if limit == 0 {
+				return reader.read_fixed_bytes(len);
+			}
 			let mut data = vec![];
 			loop {
 				if len == 0 {

--- a/libwallet/src/types.rs
+++ b/libwallet/src/types.rs
@@ -890,18 +890,22 @@ impl ViewWalletOutputResult {
 
 fn read_bytes_len_prefix<R: ser::Reader>(reader: &mut R) -> Result<Vec<u8>, ser::Error> {
 	let mut len = reader.read_u64()? as usize;
-	let limit = reader.read_limit().unwrap();
-	let mut data = vec![];
-	loop {
-		if len == 0 {
-			break;
+	match reader.read_limit() {
+		None => reader.read_bytes_len_prefix(),
+		Some(limit) => {
+			let mut data = vec![];
+			loop {
+				if len == 0 {
+					break;
+				}
+				let read_size = cmp::min(len, limit);
+				let read_data = reader.read_fixed_bytes(read_size)?;
+				data.extend_from_slice(&read_data);
+				len -= read_size;
+			}
+			Ok(data)
 		}
-		let read_size = cmp::min(len, limit);
-		let read_data = reader.read_fixed_bytes(read_size)?;
-		data.extend_from_slice(&read_data);
-		len -= read_size;
 	}
-	Ok(data)
 }
 
 /// Serializes an Option<Duration> to and from a string

--- a/libwallet/src/types.rs
+++ b/libwallet/src/types.rs
@@ -945,6 +945,8 @@ pub mod option_duration_as_secs {
 #[cfg(test)]
 mod tests {
 	use super::*;
+	use grin_core::ser::{DeserializationMode, ProtocolVersion};
+	use grin_keychain::{ExtKeychain, ExtKeychainPath};
 	use serde_json::Value;
 
 	#[derive(Serialize, Deserialize, PartialEq, Clone, Debug)]
@@ -985,5 +987,26 @@ mod tests {
 
 		let none2 = serde_json::from_str::<TestSer>("{}").unwrap();
 		assert_eq!(none, none2);
+	}
+
+	#[test]
+	fn big_context_read() {
+		let parent = ExtKeychainPath::new(1, 1, 0, 0, 0).to_identifier();
+		let sender_keychain = ExtKeychain::from_random_seed(true).unwrap();
+
+		let mut context = Context::new(sender_keychain.secp(), &parent, false, true);
+		for i in 0..3000 {
+			let key_id = ExtKeychain::derive_key_id(1, 1, i, 0, 0);
+			context.add_output(&key_id, &None, i as u64);
+		}
+		let ser_value = ser::ser_vec(&context, ProtocolVersion(3)).unwrap();
+		let mut value = ser_value.as_slice();
+		assert!(value.len() > 100_000);
+		let context = ser::deserialize::<Context, &[u8]>(
+			&mut value,
+			ProtocolVersion(3),
+			DeserializationMode::Full,
+		);
+		assert!(context.is_ok());
 	}
 }

--- a/libwallet/src/types.rs
+++ b/libwallet/src/types.rs
@@ -948,7 +948,7 @@ pub mod option_duration_as_secs {
 #[cfg(test)]
 mod tests {
 	use super::*;
-	use grin_core::ser::{DeserializationMode, ProtocolVersion, Reader, StreamingReader};
+	use grin_core::ser::{DeserializationMode, ProtocolVersion, Readable, Reader, StreamingReader};
 	use grin_keychain::{ExtKeychain, ExtKeychainPath};
 	use serde_json::Value;
 
@@ -994,27 +994,40 @@ mod tests {
 
 	#[test]
 	fn big_context_read() {
-		let parent = ExtKeychainPath::new(1, 1, 0, 0, 0).to_identifier();
-		let sender_keychain = ExtKeychain::from_random_seed(true).unwrap();
-
 		let protocol_ver = ProtocolVersion(3);
 
-		let mut context = Context::new(sender_keychain.secp(), &parent, false, true);
-		for i in 0..3000 {
-			let key_id = ExtKeychain::derive_key_id(1, 1, i, 0, 0);
-			context.add_output(&key_id, &None, i as u64);
+		let create_context = || {
+			let parent = ExtKeychainPath::new(1, 1, 0, 0, 0).to_identifier();
+			let sender_keychain = ExtKeychain::from_random_seed(true).unwrap();
+
+			let mut context = Context::new(sender_keychain.secp(), &parent, false, true);
+			for i in 0..3000 {
+				let key_id = ExtKeychain::derive_key_id(1, 1, i, 0, 0);
+				context.add_output(&key_id, &None, i as u64);
+			}
+			context
+		};
+
+		{
+			let context = create_context();
+			let ser_value = ser::ser_vec(&context, protocol_ver).unwrap();
+			let mut value = ser_value.as_slice();
+			assert!(value.len() > 100_000);
+			let context = ser::deserialize::<Context, &[u8]>(
+				&mut value,
+				protocol_ver,
+				DeserializationMode::Full,
+			);
+			assert!(context.is_ok());
 		}
-		let ser_value = ser::ser_vec(&context, protocol_ver).unwrap();
-		let mut value = ser_value.as_slice();
-		assert!(value.len() > 100_000);
-		let context =
-			ser::deserialize::<Context, &[u8]>(&mut value, protocol_ver, DeserializationMode::Full);
-		assert!(context.is_ok());
 
 		// Big read for StreamingReader returns an error, cause limit is not set.
+		let context = create_context();
+		let ser_value = ser::ser_vec(&context, protocol_ver).unwrap();
+		let mut value = ser_value.as_slice();
 		let mut streaming_reader = StreamingReader::new(&mut value, protocol_ver);
 		assert!(streaming_reader.read_limit().is_none());
-		let res = streaming_reader.read_bytes_len_prefix();
-		assert!(res.is_err());
+		let res = Context::read(&mut streaming_reader);
+		assert!(res.is_ok());
 	}
 }

--- a/libwallet/src/types.rs
+++ b/libwallet/src/types.rs
@@ -25,7 +25,7 @@ use crate::grin_core::{global, ser};
 use crate::grin_keychain::{Identifier, Keychain};
 use crate::grin_util::logger::LoggingConfig;
 use crate::grin_util::secp::key::{PublicKey, SecretKey};
-use crate::grin_util::secp::{self, pedersen, Secp256k1};
+use crate::grin_util::secp::{pedersen, Secp256k1};
 use crate::grin_util::{ToHex, ZeroingString};
 use crate::slate_versions::ser as dalek_ser;
 use crate::{InitTxArgs, SlateState, WalletBackend};
@@ -37,8 +37,8 @@ use rand::thread_rng;
 use serde;
 use serde_json;
 use std::collections::HashMap;
-use std::fmt;
 use std::time::Duration;
+use std::{cmp, fmt};
 use uuid::Uuid;
 
 /// Combined trait to allow dynamic wallet dispatch
@@ -396,7 +396,7 @@ pub struct Context {
 impl Context {
 	/// Create a new context with defaults
 	pub fn new(
-		secp: &secp::Secp256k1,
+		secp: &Secp256k1,
 		parent_key_id: &Identifier,
 		use_test_rng: bool,
 		is_initiator: bool,
@@ -418,7 +418,7 @@ impl Context {
 
 	/// Create a new context with a specific excess
 	pub fn with_excess(
-		secp: &secp::Secp256k1,
+		secp: &Secp256k1,
 		sec_key: SecretKey,
 		parent_key_id: &Identifier,
 		use_test_rng: bool,
@@ -490,7 +490,7 @@ impl ser::Writeable for Context {
 
 impl ser::Readable for Context {
 	fn read<R: ser::Reader>(reader: &mut R) -> Result<Context, ser::Error> {
-		let data = reader.read_bytes_len_prefix()?;
+		let data = read_bytes_len_prefix(reader)?;
 		serde_json::from_slice(&data[..]).map_err(|_| ser::Error::CorruptedData)
 	}
 }
@@ -679,7 +679,7 @@ impl ser::Writeable for TxLogEntry {
 
 impl ser::Readable for TxLogEntry {
 	fn read<R: ser::Reader>(reader: &mut R) -> Result<TxLogEntry, ser::Error> {
-		let data = reader.read_bytes_len_prefix()?;
+		let data = read_bytes_len_prefix(reader)?;
 		serde_json::from_slice(&data[..]).map_err(|_| ser::Error::CorruptedData)
 	}
 }
@@ -752,7 +752,7 @@ impl ser::Writeable for StoredProofInfo {
 
 impl ser::Readable for StoredProofInfo {
 	fn read<R: ser::Reader>(reader: &mut R) -> Result<StoredProofInfo, ser::Error> {
-		let data = reader.read_bytes_len_prefix()?;
+		let data = read_bytes_len_prefix(reader)?;
 		serde_json::from_slice(&data[..]).map_err(|_| ser::Error::CorruptedData)
 	}
 }
@@ -774,7 +774,7 @@ impl ser::Writeable for AcctPathMapping {
 
 impl ser::Readable for AcctPathMapping {
 	fn read<R: ser::Reader>(reader: &mut R) -> Result<AcctPathMapping, ser::Error> {
-		let data = reader.read_bytes_len_prefix()?;
+		let data = read_bytes_len_prefix(reader)?;
 		serde_json::from_slice(&data[..]).map_err(|_| ser::Error::CorruptedData)
 	}
 }
@@ -807,7 +807,7 @@ impl ser::Writeable for ScannedBlockInfo {
 
 impl ser::Readable for ScannedBlockInfo {
 	fn read<R: ser::Reader>(reader: &mut R) -> Result<ScannedBlockInfo, ser::Error> {
-		let data = reader.read_bytes_len_prefix()?;
+		let data = read_bytes_len_prefix(reader)?;
 		serde_json::from_slice(&data[..]).map_err(|_| ser::Error::CorruptedData)
 	}
 }
@@ -844,7 +844,7 @@ impl ser::Writeable for WalletInitStatus {
 
 impl ser::Readable for WalletInitStatus {
 	fn read<R: ser::Reader>(reader: &mut R) -> Result<WalletInitStatus, ser::Error> {
-		let data = reader.read_bytes_len_prefix()?;
+		let data = read_bytes_len_prefix(reader)?;
 		serde_json::from_slice(&data[..]).map_err(|_| ser::Error::CorruptedData)
 	}
 }
@@ -886,6 +886,22 @@ impl ViewWalletOutputResult {
 			1 + (tip_height - self.height)
 		}
 	}
+}
+
+fn read_bytes_len_prefix<R: ser::Reader>(reader: &mut R) -> Result<Vec<u8>, ser::Error> {
+	let mut len = reader.read_u64()? as usize;
+	let limit = reader.read_limit().unwrap();
+	let mut data = vec![];
+	loop {
+		if len == 0 {
+			break;
+		}
+		let read_size = cmp::min(len, limit);
+		let read_data = reader.read_fixed_bytes(read_size)?;
+		data.extend_from_slice(&read_data);
+		len -= read_size;
+	}
+	Ok(data)
 }
 
 /// Serializes an Option<Duration> to and from a string

--- a/libwallet/src/types.rs
+++ b/libwallet/src/types.rs
@@ -948,7 +948,7 @@ pub mod option_duration_as_secs {
 #[cfg(test)]
 mod tests {
 	use super::*;
-	use grin_core::ser::{DeserializationMode, ProtocolVersion};
+	use grin_core::ser::{DeserializationMode, ProtocolVersion, Reader, StreamingReader};
 	use grin_keychain::{ExtKeychain, ExtKeychainPath};
 	use serde_json::Value;
 
@@ -997,19 +997,24 @@ mod tests {
 		let parent = ExtKeychainPath::new(1, 1, 0, 0, 0).to_identifier();
 		let sender_keychain = ExtKeychain::from_random_seed(true).unwrap();
 
+		let protocol_ver = ProtocolVersion(3);
+
 		let mut context = Context::new(sender_keychain.secp(), &parent, false, true);
 		for i in 0..3000 {
 			let key_id = ExtKeychain::derive_key_id(1, 1, i, 0, 0);
 			context.add_output(&key_id, &None, i as u64);
 		}
-		let ser_value = ser::ser_vec(&context, ProtocolVersion(3)).unwrap();
+		let ser_value = ser::ser_vec(&context, protocol_ver).unwrap();
 		let mut value = ser_value.as_slice();
 		assert!(value.len() > 100_000);
-		let context = ser::deserialize::<Context, &[u8]>(
-			&mut value,
-			ProtocolVersion(3),
-			DeserializationMode::Full,
-		);
+		let context =
+			ser::deserialize::<Context, &[u8]>(&mut value, protocol_ver, DeserializationMode::Full);
 		assert!(context.is_ok());
+
+		// Big read for StreamingReader returns an error, cause limit is not set.
+		let mut streaming_reader = StreamingReader::new(&mut value, protocol_ver);
+		assert!(streaming_reader.read_limit().is_none());
+		let res = streaming_reader.read_bytes_len_prefix();
+		assert!(res.is_err());
 	}
 }

--- a/libwallet/src/types.rs
+++ b/libwallet/src/types.rs
@@ -752,7 +752,7 @@ impl ser::Writeable for StoredProofInfo {
 
 impl ser::Readable for StoredProofInfo {
 	fn read<R: ser::Reader>(reader: &mut R) -> Result<StoredProofInfo, ser::Error> {
-		let data = read_bytes_len_prefix(reader)?;
+		let data = reader.read_bytes_len_prefix()?;
 		serde_json::from_slice(&data[..]).map_err(|_| ser::Error::CorruptedData)
 	}
 }
@@ -774,7 +774,7 @@ impl ser::Writeable for AcctPathMapping {
 
 impl ser::Readable for AcctPathMapping {
 	fn read<R: ser::Reader>(reader: &mut R) -> Result<AcctPathMapping, ser::Error> {
-		let data = read_bytes_len_prefix(reader)?;
+		let data = reader.read_bytes_len_prefix()?;
 		serde_json::from_slice(&data[..]).map_err(|_| ser::Error::CorruptedData)
 	}
 }
@@ -807,7 +807,7 @@ impl ser::Writeable for ScannedBlockInfo {
 
 impl ser::Readable for ScannedBlockInfo {
 	fn read<R: ser::Reader>(reader: &mut R) -> Result<ScannedBlockInfo, ser::Error> {
-		let data = read_bytes_len_prefix(reader)?;
+		let data = reader.read_bytes_len_prefix()?;
 		serde_json::from_slice(&data[..]).map_err(|_| ser::Error::CorruptedData)
 	}
 }
@@ -844,7 +844,7 @@ impl ser::Writeable for WalletInitStatus {
 
 impl ser::Readable for WalletInitStatus {
 	fn read<R: ser::Reader>(reader: &mut R) -> Result<WalletInitStatus, ser::Error> {
-		let data = read_bytes_len_prefix(reader)?;
+		let data = reader.read_bytes_len_prefix()?;
 		serde_json::from_slice(&data[..]).map_err(|_| ser::Error::CorruptedData)
 	}
 }

--- a/libwallet/src/types.rs
+++ b/libwallet/src/types.rs
@@ -484,7 +484,11 @@ impl Context {
 
 impl ser::Writeable for Context {
 	fn write<W: ser::Writer>(&self, writer: &mut W) -> Result<(), ser::Error> {
-		writer.write_bytes(&serde_json::to_vec(self).map_err(|_| ser::Error::CorruptedData)?)
+		let data = serde_json::to_vec(self).map_err(|_| ser::Error::CorruptedData)?;
+		if data.len() > MAX_CONTEXT_SIZE {
+			return Err(ser::Error::TooLargeReadErr);
+		}
+		writer.write_bytes(&data)
 	}
 }
 
@@ -888,8 +892,14 @@ impl ViewWalletOutputResult {
 	}
 }
 
+const MAX_CONTEXT_SIZE: usize = 4 * 1024 * 1024;
+
 fn read_bytes_len_prefix<R: ser::Reader>(reader: &mut R) -> Result<Vec<u8>, ser::Error> {
-	let mut len = reader.read_u64()? as usize;
+	let len = reader.read_u64()?;
+	if len > MAX_CONTEXT_SIZE as u64 {
+		return Err(ser::Error::TooLargeReadErr);
+	}
+	let mut len = len as usize;
 	match reader.read_limit() {
 		None => reader.read_fixed_bytes(len),
 		Some(limit) => {
@@ -1021,13 +1031,39 @@ mod tests {
 			assert!(context.is_ok());
 		}
 
-		// Big read for StreamingReader returns an error, cause limit is not set.
+		// StreamingReader has no per-read limit and reads the complete Context.
 		let context = create_context();
 		let ser_value = ser::ser_vec(&context, protocol_ver).unwrap();
 		let mut value = ser_value.as_slice();
 		let mut streaming_reader = StreamingReader::new(&mut value, protocol_ver);
 		assert!(streaming_reader.read_limit().is_none());
 		let res = Context::read(&mut streaming_reader);
-		assert!(res.is_ok());
+		assert_eq!(res.unwrap().get_outputs().len(), 3000);
+	}
+
+	#[test]
+	fn context_size_limit() {
+		let protocol_ver = ProtocolVersion(3);
+		let oversized_len = ((MAX_CONTEXT_SIZE + 1) as u64).to_be_bytes();
+		let mut oversized_prefix = oversized_len.as_slice();
+		let read = ser::deserialize::<Context, &[u8]>(
+			&mut oversized_prefix,
+			protocol_ver,
+			DeserializationMode::Full,
+		);
+		assert_eq!(read.unwrap_err(), ser::Error::TooLargeReadErr);
+
+		let parent = ExtKeychainPath::new(1, 1, 0, 0, 0).to_identifier();
+		let sender_keychain = ExtKeychain::from_random_seed(true).unwrap();
+		let mut context = Context::new(sender_keychain.secp(), &parent, false, true);
+		context.late_lock_args = Some(InitTxArgs {
+			src_acct_name: Some("x".repeat(MAX_CONTEXT_SIZE)),
+			..Default::default()
+		});
+
+		assert_eq!(
+			ser::ser_vec(&context, protocol_ver).unwrap_err(),
+			ser::Error::TooLargeReadErr
+		);
 	}
 }

--- a/tests/common/mod.rs
+++ b/tests/common/mod.rs
@@ -132,7 +132,7 @@ pub fn clean_output_dir(test_dir: &str) {
 pub fn setup(test_dir: &str) {
 	util::init_test_logger();
 	clean_output_dir(test_dir);
-	global::set_local_chain_type(ChainTypes::AutomatedTesting);
+	setup_global_chain_type();
 }
 
 /// Some tests require the global chain_type to be configured.

--- a/tests/common/mod.rs
+++ b/tests/common/mod.rs
@@ -24,7 +24,7 @@ use std::sync::Arc;
 use std::{env, fs};
 use util::{Mutex, ZeroingString};
 
-use grin_core::global::{self, ChainTypes};
+use grin_core::global::{self, ChainTypes, GLOBAL_CHAIN_TYPE};
 use grin_keychain::ExtKeychain;
 use grin_util::{from_hex, static_secp_instance};
 use grin_wallet_api::{EncryptedRequest, EncryptedResponse, JsonId};
@@ -142,7 +142,9 @@ pub fn setup(test_dir: &str) {
 /// leaks across multiple tests and will likely have unintended consequences.
 #[allow(dead_code)]
 pub fn setup_global_chain_type() {
-	global::init_global_chain_type(ChainTypes::AutomatedTesting);
+	if !GLOBAL_CHAIN_TYPE.is_init() {
+		global::init_global_chain_type(ChainTypes::AutomatedTesting);
+	}
 }
 
 /// Create a wallet config file in the given current directory

--- a/tests/common/mod.rs
+++ b/tests/common/mod.rs
@@ -24,7 +24,7 @@ use std::sync::Arc;
 use std::{env, fs};
 use util::{Mutex, ZeroingString};
 
-use grin_core::global::{self, ChainTypes, GLOBAL_CHAIN_TYPE};
+use grin_core::global::{self, ChainTypes};
 use grin_keychain::ExtKeychain;
 use grin_util::{from_hex, static_secp_instance};
 use grin_wallet_api::{EncryptedRequest, EncryptedResponse, JsonId};
@@ -132,7 +132,6 @@ pub fn clean_output_dir(test_dir: &str) {
 pub fn setup(test_dir: &str) {
 	util::init_test_logger();
 	clean_output_dir(test_dir);
-	global::set_local_chain_type(ChainTypes::AutomatedTesting);
 	setup_global_chain_type();
 }
 
@@ -143,9 +142,7 @@ pub fn setup(test_dir: &str) {
 /// leaks across multiple tests and will likely have unintended consequences.
 #[allow(dead_code)]
 pub fn setup_global_chain_type() {
-	if !GLOBAL_CHAIN_TYPE.is_init() {
-		global::init_global_chain_type(ChainTypes::AutomatedTesting);
-	}
+	global::init_global_chain_type(ChainTypes::AutomatedTesting);
 }
 
 /// Create a wallet config file in the given current directory

--- a/tests/common/mod.rs
+++ b/tests/common/mod.rs
@@ -132,6 +132,7 @@ pub fn clean_output_dir(test_dir: &str) {
 pub fn setup(test_dir: &str) {
 	util::init_test_logger();
 	clean_output_dir(test_dir);
+	global::set_local_chain_type(ChainTypes::AutomatedTesting);
 	setup_global_chain_type();
 }
 


### PR DESCRIPTION
- commit outputs under single batch with chunks saving on chain commitment instead of reconstructing a regular one for speed-up
- parallel iteration over `proof::rewind` checks
- bypass read limit to read data from database in chunks (fixes https://github.com/mimblewimble/grin-wallet/issues/472)
- optimize outputs selection
- update wallet state before send and process invoice
- calculate right max amount to send to not overtake tx weight
- owner api/rpc calls to calculate max amount to send with fee and max inputs size