### PR TITLE
expose mwixnet onion apis for external consumers

### DIFF
--- a/libwallet/Cargo.toml
+++ b/libwallet/Cargo.toml
@@ -9,6 +9,9 @@ keywords = [ "crypto", "grin", "mimblewimble" ]
 exclude = ["**/*.grin", "**/*.grin2"]
 edition = "2021"
 
+[features]
+mwixnet-test = []
+
 [dependencies]
 blake2-rfc = "0.2"
 rand = "0.6"

--- a/libwallet/src/mwixnet/mod.rs
+++ b/libwallet/src/mwixnet/mod.rs
@@ -13,7 +13,7 @@
 // limitations under the License.
 
 //! Onion modules for mxmixnet
-mod onion;
+pub mod onion;
 mod types;
 
 pub use onion::{

--- a/libwallet/src/mwixnet/onion/crypto/dalek.rs
+++ b/libwallet/src/mwixnet/onion/crypto/dalek.rs
@@ -69,7 +69,6 @@ impl AsRef<VerifyingKey> for DalekPublicKey {
 	}
 }
 
-#[cfg(test)]
 /// Serializes an Option<DalekPublicKey> to and from hex
 pub mod option_dalek_pubkey_serde {
 	use super::DalekPublicKey;
@@ -152,7 +151,6 @@ impl AsRef<ed25519_dalek::Signature> for DalekSignature {
 }
 
 /// Serializes a DalekSignature to and from hex
-#[cfg(test)]
 pub mod dalek_sig_serde {
 	use super::DalekSignature;
 	use grin_util::ToHex;
@@ -179,8 +177,6 @@ pub mod dalek_sig_serde {
 }
 
 /// Dalek signature sign wrapper
-// TODO: This is likely duplicated throughout crate, check
-#[cfg(test)]
 pub fn sign(sk: &SecretKey, message: &[u8]) -> Result<DalekSignature, DalekError> {
 	use ed25519_dalek::{Signer, SigningKey};
 	let secret = SigningKey::from_bytes(&sk.0);

--- a/libwallet/src/mwixnet/onion/crypto/secp.rs
+++ b/libwallet/src/mwixnet/onion/crypto/secp.rs
@@ -18,7 +18,7 @@ pub use grin_util::secp::{
 	self as secp256k1zkp,
 	constants::SECRET_KEY_SIZE,
 	key::{SecretKey, ZERO_KEY},
-	pedersen::Commitment,
+	pedersen::{Commitment, RangeProof},
 	rand::thread_rng,
 	ContextFlag, Secp256k1,
 };
@@ -47,7 +47,6 @@ pub fn read_secret_key<R: Reader>(reader: &mut R) -> Result<SecretKey, ser::Erro
 }
 
 /// Build a Pedersen Commitment using the provided value and blinding factor
-#[cfg(test)]
 pub fn commit(value: u64, blind: &SecretKey) -> Result<Commitment, secp256k1zkp::Error> {
 	let secp = Secp256k1::with_caps(ContextFlag::Commit);
 	let commit = secp.commit(value, blind.clone())?;
@@ -76,7 +75,6 @@ pub fn sub_value(commitment: &Commitment, value: u64) -> Result<Commitment, secp
 }
 
 /// Signs the message with the provided SecretKey
-#[cfg(test)]
 #[allow(dead_code)]
 pub fn sign(
 	sk: &SecretKey,

--- a/libwallet/src/mwixnet/onion/mod.rs
+++ b/libwallet/src/mwixnet/onion/mod.rs
@@ -14,7 +14,7 @@
 
 //! Onion module definition
 
-mod crypto;
+pub mod crypto;
 pub mod onion;
 pub mod util;
 
@@ -48,7 +48,7 @@ pub struct Hop {
 }
 
 /// Crate a new hop
-#[cfg(test)]
+#[cfg(any(test, feature = "mwixnet-test"))]
 pub fn new_hop(
 	server_key: &SecretKey,
 	hop_excess: &SecretKey,
@@ -119,7 +119,7 @@ pub fn create_onion(
 
 /// Internal tests
 #[allow(missing_docs, dead_code)]
-#[cfg(test)]
+#[cfg(any(test, feature = "mwixnet-test"))]
 pub mod test_util {
 	use super::*;
 	use crypto::dalek::DalekPublicKey;


### PR DESCRIPTION
exposes the existing mwixnet onion apis for use by the external mwixnet implementation.
adds the mwixnet-test feature for downstream tests. no protocol or wallet behavior is changed.
