### PR TITLE
Make updater apis public

### DIFF
--- a/controller/tests/accounts.rs
+++ b/controller/tests/accounts.rs
@@ -256,6 +256,15 @@ fn accounts_test_impl(test_dir: &'static str) -> Result<(), libwallet::Error> {
 		},
 	)?;
 
+	// Use the requested account's stored height
+	{
+		wallet_inst!(wallet1, w);
+		assert_eq!(w.parent_key_id(), ExtKeychain::derive_key_id(2, 1, 0, 0, 0));
+		let account2 = ExtKeychain::derive_key_id(2, 2, 0, 0, 0);
+		let account2_info = libwallet::retrieve_info(w, &account2, 1)?;
+		assert_eq!(account2_info.last_confirmed_height, 12);
+	}
+
 	// other account should be untouched
 	{
 		wallet_inst!(wallet1, w);

--- a/libwallet/src/api_impl/foreign.rs
+++ b/libwallet/src/api_impl/foreign.rs
@@ -94,7 +94,7 @@ where
 
 	ret_slate.tx = Some(Slate::empty_transaction());
 
-	let height = w.last_confirmed_height(Some(&parent_key_id))?;
+	let height = w.last_confirmed_height_for_parent(&parent_key_id)?;
 	let keychain = w.keychain(keychain_mask)?;
 
 	let context = tx::add_output_to_slate(

--- a/libwallet/src/api_impl/foreign.rs
+++ b/libwallet/src/api_impl/foreign.rs
@@ -94,7 +94,7 @@ where
 
 	ret_slate.tx = Some(Slate::empty_transaction());
 
-	let height = w.last_confirmed_height()?;
+	let height = w.last_confirmed_height(Some(&parent_key_id))?;
 	let keychain = w.keychain(keychain_mask)?;
 
 	let context = tx::add_output_to_slate(

--- a/libwallet/src/api_impl/owner.rs
+++ b/libwallet/src/api_impl/owner.rs
@@ -322,7 +322,7 @@ where
 
 	let parent_key_id = w.parent_key_id();
 	let wallet_info = updater::retrieve_info(w, &parent_key_id, minimum_confirmations)?;
-	let current_height = w.last_confirmed_height()?;
+	let current_height = w.last_confirmed_height(Some(&parent_key_id))?;
 	let max_outputs = 500;
 	let change_outputs = 1;
 	let (amount, fee, input_count) = match selection::select_coins_and_fee(

--- a/libwallet/src/api_impl/owner.rs
+++ b/libwallet/src/api_impl/owner.rs
@@ -1177,7 +1177,7 @@ where
 	K: Keychain,
 {
 	// Refuse if TTL is expired
-	let last_confirmed_height = w.last_confirmed_height()?;
+	let last_confirmed_height = w.last_confirmed_height(None)?;
 	if slate.ttl_cutoff_height != 0 {
 		if last_confirmed_height >= slate.ttl_cutoff_height {
 			return Err(Error::TransactionExpired);

--- a/libwallet/src/api_impl/owner.rs
+++ b/libwallet/src/api_impl/owner.rs
@@ -322,7 +322,7 @@ where
 
 	let parent_key_id = w.parent_key_id();
 	let wallet_info = updater::retrieve_info(w, &parent_key_id, minimum_confirmations)?;
-	let current_height = w.last_confirmed_height(Some(&parent_key_id))?;
+	let current_height = w.last_confirmed_height_for_parent(&parent_key_id)?;
 	let max_outputs = 500;
 	let change_outputs = 1;
 	let (amount, fee, input_count) = match selection::select_coins_and_fee(
@@ -1240,7 +1240,7 @@ where
 	K: Keychain,
 {
 	// Refuse if TTL is expired
-	let last_confirmed_height = w.last_confirmed_height(None)?;
+	let last_confirmed_height = w.last_confirmed_height()?;
 	if slate.ttl_cutoff_height != 0 {
 		if last_confirmed_height >= slate.ttl_cutoff_height {
 			return Err(Error::TransactionExpired);

--- a/libwallet/src/backend.rs
+++ b/libwallet/src/backend.rs
@@ -482,13 +482,21 @@ where
 		Ok(Identifier::from_path(&return_path))
 	}
 
-	/// Last verified height of outputs directly descending from the given parent key.
-	pub fn last_confirmed_height(&mut self) -> Result<u64, Error> {
+	/// Last verified height of outputs directly descending from the given parent key,
+	/// will use current parent key if not provided.
+	pub fn last_confirmed_height(
+		&mut self,
+		parent_key_id: Option<&Identifier>,
+	) -> Result<u64, Error> {
 		let batch = self.db.batch()?;
+		let parent_key_id = match parent_key_id {
+			Some(id) => id,
+			None => &self.parent_key_id,
+		};
 		let last_confirmed_height = batch
 			.get_ser(
 				Some(CONFIRMED_HEIGHT_PREFIX),
-				&self.parent_key_id.to_bytes(),
+				&parent_key_id.to_bytes(),
 				None,
 			)?
 			.unwrap_or_else(|| 0);

--- a/libwallet/src/backend.rs
+++ b/libwallet/src/backend.rs
@@ -482,17 +482,18 @@ where
 		Ok(Identifier::from_path(&return_path))
 	}
 
-	/// Last verified height of outputs directly descending from the given parent key,
-	/// will use current parent key if not provided.
-	pub fn last_confirmed_height(
+	/// Last verified height of outputs directly descending from the current parent key.
+	pub fn last_confirmed_height(&mut self) -> Result<u64, Error> {
+		let parent_key_id = self.parent_key_id.clone();
+		self.last_confirmed_height_for_parent(&parent_key_id)
+	}
+
+	/// Last verified height of outputs directly descending from the given parent key.
+	pub(crate) fn last_confirmed_height_for_parent(
 		&mut self,
-		parent_key_id: Option<&Identifier>,
+		parent_key_id: &Identifier,
 	) -> Result<u64, Error> {
 		let batch = self.db.batch()?;
-		let parent_key_id = match parent_key_id {
-			Some(id) => id,
-			None => &self.parent_key_id,
-		};
 		let last_confirmed_height = batch
 			.get_ser(
 				Some(CONFIRMED_HEIGHT_PREFIX),

--- a/libwallet/src/internal/updater.rs
+++ b/libwallet/src/internal/updater.rs
@@ -402,6 +402,7 @@ where
 
 /// Refreshes the outputs in a wallet with the latest information
 /// from a node
+/// Also removes stale unconfirmed coinbase outputs across all accounts
 pub fn refresh_outputs<C, K>(
 	wallet: &mut WalletBackend<C, K>,
 	keychain_mask: Option<&SecretKey>,

--- a/libwallet/src/internal/updater.rs
+++ b/libwallet/src/internal/updater.rs
@@ -420,7 +420,7 @@ where
 /// Build a local map of wallet outputs keyed by commit
 /// and a list of outputs we want to query the node for.
 /// If `update_all` equals `false` we will select outputs
-/// that are actually involved in an outstanding transaction.
+/// that are actually involved in existing transactions for account.
 /// Returns mapping of output commit to tuple of derived key for output,
 /// PMMR index, tx entry log identifier and check if output is unspent
 pub fn map_wallet_outputs<C, K>(
@@ -526,7 +526,7 @@ where
 	// api output (if it exists) and refresh it in-place in the wallet.
 	// Note: minimizing the time we spend holding the wallet lock.
 	{
-		let last_confirmed_height = wallet.last_confirmed_height()?;
+		let last_confirmed_height = wallet.last_confirmed_height(Some(parent_key_id))?;
 		// If the server height is less than our confirmed height, don't apply
 		// these changes as the chain is syncing, incorrect or forking
 		if height < last_confirmed_height {
@@ -803,7 +803,7 @@ where
 	C: NodeClient,
 	K: Keychain,
 {
-	let current_height = wallet.last_confirmed_height()?;
+	let current_height = wallet.last_confirmed_height(Some(parent_key_id))?;
 	let outputs = wallet
 		.iter()?
 		.filter(|out| out.root_key_id == *parent_key_id);

--- a/libwallet/src/internal/updater.rs
+++ b/libwallet/src/internal/updater.rs
@@ -91,7 +91,7 @@ where
 }
 
 /// Apply advanced filtering to resultset from retrieve_txs below
-pub fn apply_advanced_tx_list_filtering<C, K>(
+fn apply_advanced_tx_list_filtering<C, K>(
 	wallet: &mut WalletBackend<C, K>,
 	parent_key_id: Option<&Identifier>,
 	query_args: &RetrieveTxQueryArgs,
@@ -417,8 +417,12 @@ where
 	Ok(())
 }
 
-/// build a local map of wallet outputs keyed by commit
-/// and a list of outputs we want to query the node for
+/// Build a local map of wallet outputs keyed by commit
+/// and a list of outputs we want to query the node for.
+/// If `update_all` equals `false` we will select outputs
+/// that are actually involved in an outstanding transaction.
+/// Returns mapping of output commit to tuple of derived key for output,
+/// PMMR index, tx entry log identifier and check if output is unspent
 pub fn map_wallet_outputs<C, K>(
 	wallet: &mut WalletBackend<C, K>,
 	keychain_mask: Option<&SecretKey>,
@@ -469,7 +473,7 @@ where
 }
 
 /// Cancel transaction and associated outputs
-pub fn cancel_tx_and_outputs<C, K>(
+fn cancel_tx_and_outputs<C, K>(
 	wallet: &mut WalletBackend<C, K>,
 	keychain_mask: Option<&SecretKey>,
 	mut tx: TxLogEntry,

--- a/libwallet/src/internal/updater.rs
+++ b/libwallet/src/internal/updater.rs
@@ -417,10 +417,10 @@ where
 	Ok(())
 }
 
-/// Build a local map of wallet outputs keyed by commit
-/// and a list of outputs we want to query the node for.
-/// If `update_all` equals `false` we will select outputs
-/// that are actually involved in existing transactions for account.
+/// Build a local map of wallet outputs keyed by commit.
+/// The map keys identify outputs to query from the node.
+/// If `update_all` is `false`, select outputs involved in outstanding
+/// transactions for the account and outputs without a transaction log entry.
 /// Returns mapping of output commit to tuple of derived key for output,
 /// PMMR index, tx entry log identifier and check if output is unspent
 pub fn map_wallet_outputs<C, K>(

--- a/libwallet/src/internal/updater.rs
+++ b/libwallet/src/internal/updater.rs
@@ -526,7 +526,7 @@ where
 	// api output (if it exists) and refresh it in-place in the wallet.
 	// Note: minimizing the time we spend holding the wallet lock.
 	{
-		let last_confirmed_height = wallet.last_confirmed_height(Some(parent_key_id))?;
+		let last_confirmed_height = wallet.last_confirmed_height_for_parent(parent_key_id)?;
 		// If the server height is less than our confirmed height, don't apply
 		// these changes as the chain is syncing, incorrect or forking
 		if height < last_confirmed_height {
@@ -803,7 +803,7 @@ where
 	C: NodeClient,
 	K: Keychain,
 {
-	let current_height = wallet.last_confirmed_height(Some(parent_key_id))?;
+	let current_height = wallet.last_confirmed_height_for_parent(parent_key_id)?;
 	let outputs = wallet
 		.iter()?
 		.filter(|out| out.root_key_id == *parent_key_id);

--- a/libwallet/src/internal/updater.rs
+++ b/libwallet/src/internal/updater.rs
@@ -473,7 +473,7 @@ where
 }
 
 /// Cancel transaction and associated outputs
-fn cancel_tx_and_outputs<C, K>(
+pub fn cancel_tx_and_outputs<C, K>(
 	wallet: &mut WalletBackend<C, K>,
 	keychain_mask: Option<&SecretKey>,
 	mut tx: TxLogEntry,

--- a/libwallet/src/internal/updater.rs
+++ b/libwallet/src/internal/updater.rs
@@ -505,7 +505,7 @@ where
 }
 
 /// Apply refreshed API output data to the wallet
-pub fn apply_api_outputs<C, K>(
+fn apply_api_outputs<C, K>(
 	wallet: &mut WalletBackend<C, K>,
 	keychain_mask: Option<&SecretKey>,
 	wallet_outputs: &HashMap<pedersen::Commitment, (Identifier, Option<u64>, Option<u32>, bool)>,
@@ -876,7 +876,7 @@ where
 
 //TODO: Split up the output creation and the wallet insertion
 /// Build a coinbase output and the corresponding kernel
-pub fn receive_coinbase<C, K>(
+fn receive_coinbase<C, K>(
 	wallet: &mut WalletBackend<C, K>,
 	keychain_mask: Option<&SecretKey>,
 	block_fees: &BlockFees,

--- a/libwallet/src/lib.rs
+++ b/libwallet/src/lib.rs
@@ -73,8 +73,7 @@ pub use api_impl::types::{
 pub use backend::{WalletBackend, WalletBatch};
 pub use internal::scan::scan;
 pub use internal::updater::{
-	apply_advanced_tx_list_filtering, cancel_tx_and_outputs, map_wallet_outputs, refresh_outputs,
-	retrieve_info, retrieve_outputs, retrieve_txs,
+	map_wallet_outputs, refresh_outputs, retrieve_info, retrieve_outputs, retrieve_txs,
 };
 pub use slate_versions::ser as dalek_ser;
 pub use types::{

--- a/libwallet/src/lib.rs
+++ b/libwallet/src/lib.rs
@@ -72,6 +72,7 @@ pub use api_impl::types::{
 };
 pub use backend::{WalletBackend, WalletBatch};
 pub use internal::scan::scan;
+pub use internal::updater;
 pub use slate_versions::ser as dalek_ser;
 pub use types::{
 	AcctPathMapping, BlockIdentifier, CbData, Context, NodeClient, NodeVersionInfo, OutputData,

--- a/libwallet/src/lib.rs
+++ b/libwallet/src/lib.rs
@@ -72,7 +72,10 @@ pub use api_impl::types::{
 };
 pub use backend::{WalletBackend, WalletBatch};
 pub use internal::scan::scan;
-pub use internal::updater;
+pub use internal::updater::{
+	apply_advanced_tx_list_filtering, cancel_tx_and_outputs, map_wallet_outputs, refresh_outputs,
+	retrieve_info, retrieve_outputs, retrieve_txs,
+};
 pub use slate_versions::ser as dalek_ser;
 pub use types::{
 	AcctPathMapping, BlockIdentifier, CbData, Context, NodeClient, NodeVersionInfo, OutputData,


### PR DESCRIPTION
Make `updater` APIs public at `grin_wallet_libwallet` for better integration and outputs control, for example we need to calculate balances for all accounts (accounts API can be extented for this).

- fix: provide parent key to get last confirmed height for right account