### PR TITLE
centralize grin workspace dependencies

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,6 +19,14 @@ path = "src/bin/grin-wallet.rs"
 members = ["api", "config", "controller", "impls", "libwallet", "util"]
 exclude = ["integration"]
 
+[workspace.dependencies]
+grin_api = { path = "grin/api" }
+grin_chain = { path = "grin/chain" }
+grin_core = { path = "grin/core" }
+grin_keychain = { path = "grin/keychain" }
+grin_store = { path = "grin/store" }
+grin_util = { path = "grin/util" }
+
 [dependencies]
 clap = { version = "2.33", features = ["yaml"] }
 rpassword = "7.5.4"
@@ -37,10 +45,10 @@ grin_wallet_config = { path = "./config", version = "5.5.0" }
 
 ##### Grin Imports
 
-grin_core = { path = "grin/core"}
-grin_keychain = { path = "grin/keychain"}
-grin_util = { path = "grin/util"}
-grin_api = { path = "grin/api"}
+grin_core = { workspace = true }
+grin_keychain = { workspace = true }
+grin_util = { workspace = true }
+grin_api = { workspace = true }
 
 ###### 
 

--- a/api/Cargo.toml
+++ b/api/Cargo.toml
@@ -29,9 +29,9 @@ grin_wallet_util = { path = "../util", version = "5.5.0" }
 
 ##### Grin Imports
 
-grin_core = { path = "../grin/core"}
-grin_keychain = { path = "../grin/keychain"}
-grin_util = { path = "../grin/util"}
+grin_core = { workspace = true }
+grin_keychain = { workspace = true }
+grin_util = { workspace = true }
 
 #####
 

--- a/config/Cargo.toml
+++ b/config/Cargo.toml
@@ -20,8 +20,8 @@ lazy_static = "1"
 
 ##### Grin Imports
 
-grin_core = { path = "../grin/core"}
-grin_util = { path = "../grin/util"}
+grin_core = { workspace = true }
+grin_util = { workspace = true }
 
 #####
 

--- a/controller/Cargo.toml
+++ b/controller/Cargo.toml
@@ -33,11 +33,11 @@ grin_wallet_config = { path = "../config", version = "5.5.0" }
 
 ##### Grin Imports
 
-grin_core = { path = "../grin/core"}
-grin_keychain = { path = "../grin/keychain"}
-grin_util = { path = "../grin/util"}
-grin_api = { path = "../grin/api"}
-grin_chain = { path = "../grin/chain"}
+grin_core = { workspace = true }
+grin_keychain = { workspace = true }
+grin_util = { workspace = true }
+grin_api = { workspace = true }
+grin_chain = { workspace = true }
 
 #####
 

--- a/impls/Cargo.toml
+++ b/impls/Cargo.toml
@@ -53,10 +53,10 @@ grin_wallet_libwallet = { path = "../libwallet", version = "5.5.0" }
 
 ##### Grin Imports
 
-grin_core = { path = "../grin/core"}
-grin_keychain = { path = "../grin/keychain"}
-grin_chain = { path = "../grin/chain"}
-grin_util = { path = "../grin/util"}
-grin_api = { path = "../grin/api"}
+grin_core = { workspace = true }
+grin_keychain = { workspace = true }
+grin_chain = { workspace = true }
+grin_util = { workspace = true }
+grin_api = { workspace = true }
 
 #####

--- a/libwallet/Cargo.toml
+++ b/libwallet/Cargo.toml
@@ -47,9 +47,9 @@ grin_wallet_config = { path = "../config", version = "5.5.0" }
 
 ##### Grin Imports
 
-grin_core = { path = "../grin/core"}
-grin_keychain = { path = "../grin/keychain"}
-grin_util = { path = "../grin/util"}
-grin_store = { path = "../grin/store"}
+grin_core = { workspace = true }
+grin_keychain = { workspace = true }
+grin_util = { workspace = true }
+grin_store = { workspace = true }
 
 #####

--- a/util/Cargo.toml
+++ b/util/Cargo.toml
@@ -19,6 +19,6 @@ thiserror = "1"
 
 ##### Grin Imports
 
-grin_util = { path = "../grin/util"}
+grin_util = { workspace = true }
 
 ######


### PR DESCRIPTION
**summary**

centralizes all grin dependencies in the root Cargo.toml using [workspace.dependencies].
this removes duplicated dependency definitions across the wallet crates and makes future path, branch, or version updates possible in one place.

addresses Issue : #662 
