### PR TITLE
support kernel features when creating slates

### DIFF
--- a/libwallet/src/lib.rs
+++ b/libwallet/src/lib.rs
@@ -55,7 +55,7 @@ pub mod slatepack;
 mod types;
 
 pub use crate::error::Error;
-pub use crate::slate::{ParticipantData, Slate, SlateState};
+pub use crate::slate::{KernelFeaturesArgs, ParticipantData, Slate, SlateState};
 pub use crate::slate_versions::v4::sig_is_blank;
 pub use crate::slate_versions::{
 	SlateVersion, VersionedBinSlate, VersionedCoinbase, VersionedSlate, CURRENT_SLATE_VERSION,

--- a/libwallet/src/slate.rs
+++ b/libwallet/src/slate.rs
@@ -986,6 +986,8 @@ pub fn tx_from_slate_v4(slate: &SlateV4) -> Option<Transaction> {
 	let secp = secp.lock();
 	let mut calc_slate = Slate::blank(2, false);
 	calc_slate.fee_fields = slate.fee;
+	calc_slate.kernel_features = slate.feat;
+	calc_slate.kernel_features_args = slate.feat_args.as_ref().map(KernelFeaturesArgs::from);
 	for d in slate.sigs.iter() {
 		calc_slate.participant_data.push(ParticipantData {
 			public_blind_excess: d.xs,
@@ -1001,18 +1003,11 @@ pub fn tx_from_slate_v4(slate: &SlateV4) -> Option<Transaction> {
 		Ok(s) => s,
 		Err(_) => Signature::from_raw_data(&[0; 64]).unwrap(),
 	};
+	let features = calc_slate
+		.kernel_features()
+		.unwrap_or(KernelFeatures::Plain { fee: slate.fee });
 	let kernel = TxKernel {
-		features: match slate.feat {
-			0 => KernelFeatures::Plain { fee: slate.fee },
-			2 => KernelFeatures::HeightLocked {
-				fee: slate.fee,
-				lock_height: match slate.feat_args.as_ref() {
-					Some(a) => a.lock_hgt,
-					None => 0,
-				},
-			},
-			_ => KernelFeatures::Plain { fee: slate.fee },
-		},
+		features,
 		excess,
 		excess_sig,
 	};

--- a/libwallet/src/slate.rs
+++ b/libwallet/src/slate.rs
@@ -276,6 +276,38 @@ impl Slate {
 			kernel_features_args: None,
 		}
 	}
+
+	/// Create a new slate with the provided kernel features.
+	pub fn blank_with_kernel_features(
+		num_participants: u8,
+		is_invoice: bool,
+		kernel_features: KernelFeatures,
+	) -> Result<Slate, Error> {
+		let feature = kernel_features.as_u8();
+		let (fee_fields, kernel_features_args) = match kernel_features {
+			KernelFeatures::Plain { fee } => (fee, None),
+			KernelFeatures::Coinbase => return Err(Error::InvalidKernelFeatures(feature)),
+			KernelFeatures::HeightLocked { fee, lock_height } => {
+				(fee, Some(KernelFeaturesArgs { lock_height }))
+			}
+			KernelFeatures::NoRecentDuplicate {
+				fee,
+				relative_height,
+			} => (
+				fee,
+				Some(KernelFeaturesArgs {
+					lock_height: relative_height.into(),
+				}),
+			),
+		};
+		let mut slate = Slate::blank(num_participants, is_invoice);
+		slate.fee_fields = fee_fields;
+		slate.kernel_features = feature;
+		slate.kernel_features_args = kernel_features_args;
+		slate.update_kernel()?;
+		Ok(slate)
+	}
+
 	/// Removes any signature data that isn't mine, for compacting
 	/// slates for a return journey
 	pub fn remove_other_sigdata<K>(
@@ -972,7 +1004,7 @@ pub fn tx_from_slate_v4(slate: &SlateV4) -> Option<Transaction> {
 	let kernel = TxKernel {
 		features: match slate.feat {
 			0 => KernelFeatures::Plain { fee: slate.fee },
-			1 => KernelFeatures::HeightLocked {
+			2 => KernelFeatures::HeightLocked {
 				fee: slate.fee,
 				lock_height: match slate.feat_args.as_ref() {
 					Some(a) => a.lock_hgt,

--- a/libwallet/src/slate_versions/mod.rs
+++ b/libwallet/src/slate_versions/mod.rs
@@ -77,13 +77,22 @@ impl From<VersionedSlate> for Slate {
 	}
 }
 
-#[derive(Deserialize, Serialize)]
+#[derive(Serialize)]
 #[serde(untagged)]
 /// Binary versions, can only be parsed 1:1 into the appropriate
 /// version, and VersionedSlate can up/downgrade from there
 pub enum VersionedBinSlate {
 	/// Version 4, binary
 	V4(SlateV4Bin),
+}
+
+impl<'de> serde::Deserialize<'de> for VersionedBinSlate {
+	fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
+	where
+		D: serde::Deserializer<'de>,
+	{
+		<SlateV4Bin as serde::Deserialize>::deserialize(deserializer).map(Self::V4)
+	}
 }
 
 impl TryFrom<VersionedSlate> for VersionedBinSlate {

--- a/libwallet/src/slate_versions/v4_bin.rs
+++ b/libwallet/src/slate_versions/v4_bin.rs
@@ -449,8 +449,8 @@ impl Writeable for SlateV4Bin {
 			proof: &v4.proof,
 		}
 		.write(writer)?;
-		// Write lock height for height locked kernels
-		if v4.feat == 2 {
+		// Write the height argument for height locked and NRD kernels
+		if matches!(v4.feat, 2 | 3) {
 			let lock_hgt = match &v4.feat_args {
 				Some(l) => l.lock_hgt,
 				None => 0,
@@ -475,7 +475,7 @@ impl Readable for SlateV4Bin {
 		let sigs = SigsWrap::read(reader)?.0;
 		let opt_structs = SlateOptStructs::read(reader)?;
 
-		let feat_args = if opts.feat == 2 {
+		let feat_args = if matches!(opts.feat, 2 | 3) {
 			Some(KernelFeaturesArgsV4 {
 				lock_hgt: reader.read_u64()?,
 			})

--- a/libwallet/src/slate_versions/v4_bin.rs
+++ b/libwallet/src/slate_versions/v4_bin.rs
@@ -31,6 +31,10 @@ use crate::slate_versions::v4::{
 	VersionCompatInfoV4,
 };
 
+// KernelFeatures constants from grin_core
+const HEIGHT_LOCKED_U8: u8 = 2;
+const NO_RECENT_DUPLICATE_U8: u8 = 3;
+
 impl Writeable for SlateStateV4 {
 	fn write<W: Writer>(&self, writer: &mut W) -> Result<(), grin_ser::Error> {
 		let b = match self {
@@ -450,7 +454,7 @@ impl Writeable for SlateV4Bin {
 		}
 		.write(writer)?;
 		// Write the height argument for height locked and NRD kernels
-		if matches!(v4.feat, 2 | 3) {
+		if matches!(v4.feat, HEIGHT_LOCKED_U8 | NO_RECENT_DUPLICATE_U8) {
 			let lock_hgt = match &v4.feat_args {
 				Some(l) => l.lock_hgt,
 				None => 0,
@@ -475,9 +479,22 @@ impl Readable for SlateV4Bin {
 		let sigs = SigsWrap::read(reader)?.0;
 		let opt_structs = SlateOptStructs::read(reader)?;
 
-		let feat_args = if matches!(opts.feat, 2 | 3) {
+		let feat_args = if matches!(opts.feat, HEIGHT_LOCKED_U8 | NO_RECENT_DUPLICATE_U8) {
 			Some(KernelFeaturesArgsV4 {
-				lock_hgt: reader.read_u64()?,
+				lock_hgt: reader.read_u64().map_err(|err| {
+					if opts.feat == NO_RECENT_DUPLICATE_U8
+						&& matches!(
+							&err,
+							grin_ser::Error::IOErr(_, std::io::ErrorKind::UnexpectedEof)
+						) {
+						grin_ser::Error::IOErr(
+							"NRD Slatepack is missing relative height".into(),
+							std::io::ErrorKind::UnexpectedEof,
+						)
+					} else {
+						err
+					}
+				})?,
 			})
 		} else {
 			None

--- a/libwallet/tests/slate_versioning.rs
+++ b/libwallet/tests/slate_versioning.rs
@@ -15,28 +15,49 @@
 
 use grin_core::core::transaction::{KernelFeatures, NRDRelativeHeight};
 use grin_core::core::FeeFields;
-use grin_wallet_libwallet::{KernelFeaturesArgs, Slate, SlateVersion, VersionedSlate};
+use grin_wallet_libwallet::{Slate, SlateVersion, Slatepacker, SlatepackerArgs, VersionedSlate};
 
 #[test]
-fn height_locked_round_trip() {
-	let lock_height = 500_000;
-	let expected_features = KernelFeatures::HeightLocked {
-		fee: FeeFields::new(0, 42).unwrap(),
-		lock_height,
-	};
-	let slate = Slate::blank_with_kernel_features(2, false, expected_features).unwrap();
+fn kernel_features_round_trip() {
+	let fee = FeeFields::new(0, 42).unwrap();
+	let features = [
+		KernelFeatures::HeightLocked {
+			fee,
+			lock_height: 500_000,
+		},
+		KernelFeatures::NoRecentDuplicate {
+			fee,
+			relative_height: NRDRelativeHeight::new(10).unwrap(),
+		},
+	];
+	let packer = Slatepacker::new(SlatepackerArgs {
+		sender: None,
+		recipients: vec![],
+		dec_key: None,
+	});
 
-	let versioned = VersionedSlate::into_version(slate, SlateVersion::V4).unwrap();
-	let json = serde_json::to_string(&versioned).unwrap();
-	let versioned: VersionedSlate = serde_json::from_str(&json).unwrap();
-	let slate: Slate = versioned.into();
+	for expected_features in features {
+		let slate = Slate::blank_with_kernel_features(2, false, expected_features).unwrap();
+		let expected_args = slate.kernel_features_args.clone();
 
-	assert_eq!(slate.kernel_features, expected_features.as_u8());
-	assert_eq!(
-		slate.kernel_features_args,
-		Some(KernelFeaturesArgs { lock_height })
-	);
-	assert_eq!(slate.tx.unwrap().kernels()[0].features, expected_features);
+		let versioned = VersionedSlate::into_version(slate.clone(), SlateVersion::V4).unwrap();
+		let json = serde_json::to_string(&versioned).unwrap();
+		let versioned: VersionedSlate = serde_json::from_str(&json).unwrap();
+		let json_slate: Slate = versioned.into();
+		assert_eq!(json_slate.kernel_features_args, expected_args);
+		assert_eq!(
+			json_slate.tx.unwrap().kernels()[0].features,
+			expected_features
+		);
+
+		let slatepack = packer.create_slatepack(&slate).unwrap();
+		let slatepack_slate = packer.get_slate(&slatepack).unwrap();
+		assert_eq!(slatepack_slate.kernel_features_args, expected_args);
+		assert_eq!(
+			slatepack_slate.tx.unwrap().kernels()[0].features,
+			expected_features
+		);
+	}
 }
 
 #[test]

--- a/libwallet/tests/slate_versioning.rs
+++ b/libwallet/tests/slate_versioning.rs
@@ -61,6 +61,31 @@ fn kernel_features_round_trip() {
 }
 
 #[test]
+fn nrd_missing_height() {
+	let features = KernelFeatures::NoRecentDuplicate {
+		fee: FeeFields::new(0, 42).unwrap(),
+		relative_height: NRDRelativeHeight::new(10).unwrap(),
+	};
+	let slate = Slate::blank_with_kernel_features(2, false, features).unwrap();
+	let packer = Slatepacker::new(SlatepackerArgs {
+		sender: None,
+		recipients: vec![],
+		dec_key: None,
+	});
+	let mut slatepack = packer.create_slatepack(&slate).unwrap();
+
+	slatepack.payload.truncate(slatepack.payload.len() - 8);
+	let error = packer.get_slate(&slatepack).unwrap_err();
+	match error {
+		grin_wallet_libwallet::Error::SlatepackDeser(message) => assert!(
+			message.contains("NRD Slatepack is missing relative height"),
+			"unexpected error: {message}"
+		),
+		error => panic!("unexpected error: {error:?}"),
+	}
+}
+
+#[test]
 fn kernel_features() {
 	let fee = FeeFields::new(0, 42).unwrap();
 	let features = [

--- a/libwallet/tests/slate_versioning.rs
+++ b/libwallet/tests/slate_versioning.rs
@@ -11,8 +11,60 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-//! core::libtx specific tests
-//use grin_wallet_libwallet::Slate;
+//! Slate versioning tests
+
+use grin_core::core::transaction::{KernelFeatures, NRDRelativeHeight};
+use grin_core::core::FeeFields;
+use grin_wallet_libwallet::{KernelFeaturesArgs, Slate, SlateVersion, VersionedSlate};
+
+#[test]
+fn height_locked_round_trip() {
+	let lock_height = 500_000;
+	let expected_features = KernelFeatures::HeightLocked {
+		fee: FeeFields::new(0, 42).unwrap(),
+		lock_height,
+	};
+	let slate = Slate::blank_with_kernel_features(2, false, expected_features).unwrap();
+
+	let versioned = VersionedSlate::into_version(slate, SlateVersion::V4).unwrap();
+	let json = serde_json::to_string(&versioned).unwrap();
+	let versioned: VersionedSlate = serde_json::from_str(&json).unwrap();
+	let slate: Slate = versioned.into();
+
+	assert_eq!(slate.kernel_features, expected_features.as_u8());
+	assert_eq!(
+		slate.kernel_features_args,
+		Some(KernelFeaturesArgs { lock_height })
+	);
+	assert_eq!(slate.tx.unwrap().kernels()[0].features, expected_features);
+}
+
+#[test]
+fn kernel_features() {
+	let fee = FeeFields::new(0, 42).unwrap();
+	let features = [
+		KernelFeatures::Plain { fee },
+		KernelFeatures::HeightLocked {
+			fee,
+			lock_height: 500_000,
+		},
+		KernelFeatures::NoRecentDuplicate {
+			fee,
+			relative_height: NRDRelativeHeight::new(10).unwrap(),
+		},
+	];
+
+	for expected_features in features {
+		let slate = Slate::blank_with_kernel_features(2, false, expected_features).unwrap();
+		assert_eq!(slate.kernel_features, expected_features.as_u8());
+		assert_eq!(slate.tx.unwrap().kernels()[0].features, expected_features);
+	}
+
+	assert!(matches!(
+		Slate::blank_with_kernel_features(2, false, KernelFeatures::Coinbase),
+		Err(grin_wallet_libwallet::Error::InvalidKernelFeatures(1))
+	));
+}
 
 // test all slate conversions
 /* TODO: Turn back on upon release of new slate version


### PR DESCRIPTION
Adds typed kernel feature support for new slates and fixes height locked V4 reconstruction.
Includes coverage for kernel creation and roundtrips.
Also preserves NRD kernel features through V4 Slatepack roundtrips

Fixes #564 
Fixes #393 
Replace: #565