### PR TITLE
reject invalid invoice locking

### DIFF
--- a/controller/tests/invoice.rs
+++ b/controller/tests/invoice.rs
@@ -146,6 +146,22 @@ fn invoice_tx_impl(test_dir: &'static str) -> Result<(), libwallet::Error> {
 	)?;
 	assert_eq!(slate.state, SlateState::Invoice2);
 
+	wallet::controller::owner_single_use(
+		wallet2.clone(),
+		mask2,
+		PathBuf::from(test_dir),
+		|api, m| {
+			assert_eq!(
+				api.tx_lock_outputs(m, &slate),
+				Err(libwallet::Error::SlateState)
+			);
+			let (_, txs) = api.retrieve_txs(m, false, None, None, None)?;
+			assert_eq!(txs.len(), 1);
+			assert_eq!(txs[0].tx_type, libwallet::TxLogEntryType::TxReceived);
+			Ok(())
+		},
+	)?;
+
 	// wallet 2 finalizes and posts
 	wallet::controller::foreign_single_use(
 		wallet2.clone(),

--- a/libwallet/src/api_impl/owner.rs
+++ b/libwallet/src/api_impl/owner.rs
@@ -826,6 +826,9 @@ where
 	K: Keychain,
 {
 	let context = w.get_private_context(keychain_mask, slate.id.as_bytes())?;
+	if slate.state == SlateState::Invoice2 && context.input_ids.is_empty() {
+		return Err(Error::SlateState);
+	}
 	let mut excess_override = None;
 
 	let mut sl = slate.clone();


### PR DESCRIPTION
Reject tx_lock_outputs when the invoice issuer did not contribute any inputs.
This api misuse previously resulted in both TxReceived and TxSent entries for the same slate, as seen in issue: #637

Fixes #791