### PR TITLE
unpack plain slatepacks without password

### DIFF
--- a/controller/src/command.rs
+++ b/controller/src/command.rs
@@ -24,7 +24,7 @@ use crate::impls::SlateGetter as _;
 use crate::keychain;
 use crate::libwallet::api_impl::types::update_tx_slate_state;
 use crate::libwallet::{
-	self, InitTxArgs, IssueInvoiceTxArgs, NodeClient, PaymentProof, Slate, SlateState,
+	self, InitTxArgs, IssueInvoiceTxArgs, NodeClient, PaymentProof, Slate, SlateState, Slatepack,
 	SlatepackAddress, Slatepacker, SlatepackerArgs, WalletLCProvider,
 };
 use crate::util::secp::key::SecretKey;
@@ -764,32 +764,34 @@ where
 	Ok(())
 }
 
+pub fn read_slatepack(args: ReceiveArgs) -> Result<Slatepack, Error> {
+	let packer = Slatepacker::new(SlatepackerArgs {
+		sender: None,
+		recipients: vec![],
+		dec_key: None,
+	});
+	let slatepack = match args.input_file {
+		Some(f) => PathToSlatepack::new(f.into(), &packer, true).get_slatepack(false)?,
+		None => match args.input_slatepack_message {
+			Some(message) => packer.deser_slatepack(message.as_bytes(), false)?,
+			None => {
+				return Err(Error::ArgumentError("Invalid Slatepack Input".into()).into());
+			}
+		},
+	};
+	Ok(slatepack)
+}
+
 pub fn unpack<L, C, K>(
 	owner_api: &mut Owner<L, C, K>,
 	keychain_mask: Option<&SecretKey>,
-	args: ReceiveArgs,
+	mut slatepack: Slatepack,
 ) -> Result<(), Error>
 where
 	L: WalletLCProvider<'static, C, K> + 'static,
 	C: NodeClient + 'static,
 	K: keychain::Keychain + 'static,
 {
-	let mut slatepack = match args.input_file {
-		Some(f) => {
-			let packer = Slatepacker::new(SlatepackerArgs {
-				sender: None,
-				recipients: vec![],
-				dec_key: None,
-			});
-			PathToSlatepack::new(f.into(), &packer, true).get_slatepack(false)?
-		}
-		None => match args.input_slatepack_message {
-			Some(mes) => owner_api.decode_slatepack_message(keychain_mask, mes, vec![])?,
-			None => {
-				return Err(Error::ArgumentError("Invalid Slatepack Input".into()).into());
-			}
-		},
-	};
 	println!();
 	println!("SLATEPACK CONTENTS");
 	println!("------------------");

--- a/src/cmd/wallet_args.rs
+++ b/src/cmd/wallet_args.rs
@@ -1058,12 +1058,26 @@ where
 	// local wallet proxy, etc.)
 	wallet_inst_cb(wallet.clone());
 
+	let unpack_slatepack = match wallet_args.subcommand() {
+		("unpack", Some(args)) => {
+			let args = arg_parse!(parse_unpack_args(args));
+			Some(command::read_slatepack(args)?)
+		}
+		_ => None,
+	};
+
 	// don't open wallet for certain lifecycle commands
 	let mut open_wallet = true;
 	match wallet_args.subcommand() {
 		("init", Some(_)) => open_wallet = false,
 		("recover", _) => open_wallet = false,
 		("cli", _) => open_wallet = false,
+		("unpack", _) => {
+			open_wallet = unpack_slatepack
+				.as_ref()
+				.map(|slatepack| slatepack.mode == 1)
+				.unwrap_or(false);
+		}
 		("owner_api", _) => {
 			// If wallet exists and password is present then open it. Otherwise, that's fine too.
 			let mut wallet_lock = wallet.lock();
@@ -1091,6 +1105,11 @@ where
 		}
 		false => None,
 	};
+	if let Some(slatepack) = unpack_slatepack {
+		let mut owner_api = Owner::new(wallet, None, config.config_file_path);
+		command::unpack(&mut owner_api, keychain_mask.as_ref(), slatepack)?;
+		return Ok("unpack".into());
+	}
 
 	let res = match wallet_args.subcommand() {
 		("cli", Some(_)) => command_loop(
@@ -1231,7 +1250,8 @@ where
 		}
 		("unpack", Some(args)) => {
 			let a = arg_parse!(parse_unpack_args(&args));
-			command::unpack(owner_api, km, a)
+			let slatepack = command::read_slatepack(a)?;
+			command::unpack(owner_api, km, slatepack)
 		}
 		("finalize", Some(args)) => {
 			let a = arg_parse!(parse_finalize_args(&args));


### PR DESCRIPTION
Allows unencrypted Slatepacks to be unpacked without a wallet password. Encrypted Slatepacks still require the wallet to be opened.

Closes #469