### PR TITLE
Add multi-OS builds

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,4 @@
+.git
+**/.git
+target
+**/target

--- a/.github/scripts/smoke.sh
+++ b/.github/scripts/smoke.sh
@@ -1,0 +1,41 @@
+#!/bin/sh
+
+set -eu
+
+case "$1" in
+	/*) wallet=$1 ;;
+	*) wallet=$(cd "$(dirname "$1")" && pwd)/$(basename "$1") ;;
+esac
+
+test_dir=$(mktemp -d "${TMPDIR:-/tmp}/grin-wallet-smoke.XXXXXX")
+log=$test_dir/wallet.log
+: >"$log"
+
+cleanup() {
+	status=$?
+	trap - EXIT HUP INT TERM
+	if [ "$status" -ne 0 ]; then
+		cat "$log"
+	fi
+	rm -rf "$test_dir"
+	exit "$status"
+}
+trap cleanup EXIT
+trap 'exit 1' HUP INT TERM
+
+cd "$test_dir"
+# Create a temporary testnet wallet.
+if ! "$wallet" --testnet -p smoke-password init -h >"$test_dir/init.log" 2>&1; then
+	echo "wallet init failed" >"$log"
+	exit 1
+fi
+
+test -s grin-wallet.toml
+test -s wallet_data/wallet.seed
+
+# Check a few basic wallet commands.
+"$wallet" --testnet -p smoke-password account -c smoke >>"$log" 2>&1
+"$wallet" --testnet -p smoke-password account >>"$log" 2>&1
+grep -qE '^ smoke +\| m/1/0( |$)' "$log"
+"$wallet" --testnet -p smoke-password address >>"$log" 2>&1
+grep -q tgrin1 "$log"

--- a/.github/workflows/cd.yaml
+++ b/.github/workflows/cd.yaml
@@ -1,107 +1,406 @@
 name: Continuous Deployment
 
 on:
+  workflow_dispatch:
   push:
+    branches:
+      - master
+      - staging
     tags:
       - "v*.*.*"
 
+permissions:
+  contents: read
+
+env:
+  BUILD_LABEL: &build-label ${{ github.ref_name == 'master' && 'latest' || github.ref_name == 'staging' && 'staging-latest' || github.ref_type == 'tag' && github.ref_name || github.sha }}
+
+concurrency:
+  group: cd-${{ github.ref }}
+  cancel-in-progress: ${{ !startsWith(github.ref, 'refs/tags/') }}
+
 jobs:
-    linux-release:
-        name: Linux Release
-        runs-on: ubuntu-latest
-        steps:
-          - name: Checkout
-            uses: actions/checkout@v6
-            with:
-              submodules: recursive
-          - name: Build
-            run: cargo build --release
-          - name: Archive
-            working-directory: target/release
-            run: tar -czvf grin-wallet-${{  github.ref_name }}-linux-x86_64.tar.gz grin-wallet
-          - name: Create Checksum
-            working-directory: target/release
-            run: openssl sha256 grin-wallet-${{  github.ref_name }}-linux-x86_64.tar.gz > grin-wallet-${{  github.ref_name }}-linux-x86_64-sha256sum.txt
-          - name: Release
-            uses: softprops/action-gh-release@v1
-            with:
-                generate_release_notes: true
-                files: |
-                    target/release/grin-wallet-${{  github.ref_name }}-linux-x86_64.tar.gz
-                    target/release/grin-wallet-${{  github.ref_name }}-linux-x86_64-sha256sum.txt
+  linux-release:
+    name: Linux Release
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v6
+        with:
+          submodules: recursive
 
-    macos-release-x86:
-        name: macOS Release - x86_64
-        runs-on: macos-latest
-        steps:
-          - name: Install Rust Target
-            run: rustup target add x86_64-apple-darwin
-          - name: Checkout
-            uses: actions/checkout@v6
-            with:
-              submodules: recursive
-          - name: Build
-            run: cargo build --release --target x86_64-apple-darwin
-          - name: Archive
-            working-directory: target/x86_64-apple-darwin/release
-            run: tar -czvf grin-wallet-${{  github.ref_name }}-macos-x86_64.tar.gz grin-wallet
-          - name: Create Checksum
-            working-directory: target/x86_64-apple-darwin/release
-            run: openssl sha256 grin-wallet-${{  github.ref_name }}-macos-x86_64.tar.gz > grin-wallet-${{  github.ref_name }}-macos-x86_64-sha256sum.txt
-          - name: Release
-            uses: softprops/action-gh-release@v1
-            with:
-              files: |
-                target/x86_64-apple-darwin/release/grin-wallet-${{  github.ref_name }}-macos-x86_64.tar.gz
-                target/x86_64-apple-darwin/release/grin-wallet-${{  github.ref_name }}-macos-x86_64-sha256sum.txt
+      - name: Build
+        run: cargo build --release --locked
 
-    macos-release-arm64:
-        name: macOS Release - arm64
-        runs-on: macos-latest
-        steps:
-          - name: Install Rust Target
-            run: rustup target add aarch64-apple-darwin
-          - name: Checkout
-            uses: actions/checkout@v6
-            with:
-              submodules: recursive
-          - name: Build
-            run: cargo build --release --target aarch64-apple-darwin
-          - name: Archive
-            working-directory: target/aarch64-apple-darwin/release
-            run: tar -czvf grin-wallet-${{  github.ref_name }}-macos-arm64.tar.gz grin-wallet
-          - name: Create Checksum
-            working-directory: target/aarch64-apple-darwin/release
-            run: openssl sha256 grin-wallet-${{  github.ref_name }}-macos-arm64.tar.gz > grin-wallet-${{  github.ref_name }}-macos-arm64-sha256sum.txt
-          - name: Release
-            uses: softprops/action-gh-release@v1
-            with:
-              files: |
-                target/aarch64-apple-darwin/release/grin-wallet-${{  github.ref_name }}-macos-arm64.tar.gz
-                target/aarch64-apple-darwin/release/grin-wallet-${{  github.ref_name }}-macos-arm64-sha256sum.txt
-    
-    windows-release:
-        name: Windows Release
-        runs-on: windows-latest
-        steps:
-          - name: Checkout
-            uses: actions/checkout@v6
-            with:
-              submodules: recursive
-          - name: Build
-            run: cargo build --release
-          - name: Archive
-            uses: vimtor/action-zip@v1
-            with:
-                files: target/release/grin-wallet.exe
-                dest: target/release/grin-wallet-${{  github.ref_name }}-win-x86_64.zip
-          - name: Create Checksum
-            working-directory: target/release
-            shell: pwsh
-            run: get-filehash -algorithm sha256 grin-wallet-${{  github.ref_name }}-win-x86_64.zip | Format-List |  Out-String | ForEach-Object { $_.Trim() } > grin-wallet-${{  github.ref_name }}-win-x86_64-sha256sum.txt
-          - name: Release
-            uses: softprops/action-gh-release@v1
-            with:
-              files: |
-                target/release/grin-wallet-${{  github.ref_name }}-win-x86_64.zip
-                target/release/grin-wallet-${{  github.ref_name }}-win-x86_64-sha256sum.txt
+      - name: Check binary
+        run: |
+          file target/release/grin-wallet
+          target/release/grin-wallet --version
+
+      - name: Smoke test
+        run: sh .github/scripts/smoke.sh "$PWD/target/release/grin-wallet"
+
+      - name: Archive
+        working-directory: target/release
+        run: tar -czf "grin-wallet-${BUILD_LABEL}-linux-x86_64.tar.gz" grin-wallet
+
+      - name: Create checksum
+        working-directory: target/release
+        run: openssl sha256 "grin-wallet-${BUILD_LABEL}-linux-x86_64.tar.gz" > "grin-wallet-${BUILD_LABEL}-linux-x86_64-sha256sum.txt"
+
+      - name: Upload artifact
+        uses: actions/upload-artifact@v6
+        with:
+          name: linux-x86_64
+          path: |
+            target/release/grin-wallet-${{ env.BUILD_LABEL }}-linux-x86_64.tar.gz
+            target/release/grin-wallet-${{ env.BUILD_LABEL }}-linux-x86_64-sha256sum.txt
+          if-no-files-found: error
+          retention-days: 14
+
+  linux-musl:
+    name: Linux musl ${{ matrix.arch }}
+    runs-on: ${{ matrix.runner }}
+    container:
+      image: ${{ matrix.image }}
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - arch: x86_64
+            runner: ubuntu-24.04
+            target: x86_64-unknown-linux-musl
+            image: messense/rust-musl-cross:x86_64-musl@sha256:ce75e9174325d4fbb3de85c309e2d7ca29f7500169bc4b5d2c611ff7e86d549a
+          - arch: arm64
+            runner: ubuntu-24.04-arm
+            target: aarch64-unknown-linux-musl
+            image: messense/rust-musl-cross:aarch64-musl@sha256:ecae5dd62d1c938c14f8071d36c16fa699860aace03bfb5284fb1216474d2643
+    steps:
+      - uses: actions/checkout@v6
+        with:
+          submodules: recursive
+
+      - name: Build
+        env:
+          OPENSSL_STATIC: "1"
+        run: cargo build --release --locked --target ${{ matrix.target }}
+
+      - name: Check binary
+        run: |
+          binary=target/${{ matrix.target }}/release/grin-wallet
+          file "$binary"
+          if readelf -l "$binary" | grep -q INTERP; then
+            exit 1
+          fi
+          if readelf -d "$binary" | grep -q NEEDED; then
+            exit 1
+          fi
+          "$binary" --version
+
+      - name: Smoke test
+        run: |
+          binary=target/${{ matrix.target }}/release/grin-wallet
+          sh .github/scripts/smoke.sh "$PWD/$binary"
+
+      - name: Archive
+        working-directory: target/${{ matrix.target }}/release
+        run: tar -czf "grin-wallet-${BUILD_LABEL}-linux-${{ matrix.arch }}-musl.tar.gz" grin-wallet
+
+      - name: Create checksum
+        working-directory: target/${{ matrix.target }}/release
+        run: openssl sha256 "grin-wallet-${BUILD_LABEL}-linux-${{ matrix.arch }}-musl.tar.gz" > "grin-wallet-${BUILD_LABEL}-linux-${{ matrix.arch }}-musl-sha256sum.txt"
+
+      - name: Upload artifact
+        uses: actions/upload-artifact@v6
+        with:
+          name: linux-${{ matrix.arch }}-musl
+          path: |
+            target/${{ matrix.target }}/release/grin-wallet-${{ env.BUILD_LABEL }}-linux-${{ matrix.arch }}-musl.tar.gz
+            target/${{ matrix.target }}/release/grin-wallet-${{ env.BUILD_LABEL }}-linux-${{ matrix.arch }}-musl-sha256sum.txt
+          if-no-files-found: error
+          retention-days: 14
+
+  bsd:
+    name: ${{ matrix.name }} x86_64
+    runs-on: ubuntu-24.04
+    timeout-minutes: 120
+    defaults:
+      run:
+        shell: cpa.sh {0}
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - name: OpenBSD
+            os: openbsd
+            version: "7.9"
+            install: sudo pkg_add rust git cmake pkgconf gmake curl
+            build: LZMA_API_STATIC=1 cargo build --release --locked
+          - name: FreeBSD
+            os: freebsd
+            version: "14.4"
+            install: sudo pkg install -y rust git cmake pkgconf gmake curl perl5
+            build: cargo build --release --locked
+    steps:
+      - uses: actions/checkout@v6
+        with:
+          submodules: recursive
+
+      - name: Start ${{ matrix.name }}
+        uses: cross-platform-actions/action@v1.3.0
+        with:
+          operating_system: ${{ matrix.os }}
+          architecture: x86-64
+          version: ${{ matrix.version }}
+          environment_variables: BUILD_LABEL
+          memory: 8G
+          cpu_count: 4
+
+      - name: Install dependencies
+        run: ${{ matrix.install }}
+
+      - name: Build
+        run: ${{ matrix.build }}
+
+      - name: Check binary
+        run: |
+          binary=target/release/grin-wallet
+          file "$binary"
+          if [ "${{ matrix.os }}" = openbsd ] && objdump -p "$binary" | grep -q 'NEEDED.*liblzma'; then
+            echo "liblzma is dynamically linked"
+            exit 1
+          fi
+          "$binary" --version
+
+      - name: Smoke test
+        run: sh .github/scripts/smoke.sh "$PWD/target/release/grin-wallet"
+
+      - name: Archive
+        run: |
+          cd target/release
+          tar -czf "grin-wallet-${BUILD_LABEL}-${{ matrix.os }}-x86_64.tar.gz" grin-wallet
+
+      - name: Create checksum
+        run: |
+          cd target/release
+          openssl sha256 "grin-wallet-${BUILD_LABEL}-${{ matrix.os }}-x86_64.tar.gz" > "grin-wallet-${BUILD_LABEL}-${{ matrix.os }}-x86_64-sha256sum.txt"
+
+      - name: Copy artifacts
+        shell: bash
+        run: |
+          archive="grin-wallet-${BUILD_LABEL}-${{ matrix.os }}-x86_64.tar.gz"
+          checksum="grin-wallet-${BUILD_LABEL}-${{ matrix.os }}-x86_64-sha256sum.txt"
+          remote="runner@cross_platform_actions_host:${GITHUB_WORKSPACE}/target/release"
+          scp "${remote}/${archive}" "${remote}/${checksum}" target/release/
+
+      - name: Upload artifact
+        uses: actions/upload-artifact@v6
+        with:
+          name: ${{ matrix.os }}-x86_64
+          path: |
+            target/release/grin-wallet-${{ env.BUILD_LABEL }}-${{ matrix.os }}-x86_64.tar.gz
+            target/release/grin-wallet-${{ env.BUILD_LABEL }}-${{ matrix.os }}-x86_64-sha256sum.txt
+          if-no-files-found: error
+          retention-days: 14
+
+  macos-release-x86:
+    name: macOS Release - x86_64
+    runs-on: macos-15-intel
+    steps:
+      - name: Install Rust target
+        run: rustup target add x86_64-apple-darwin
+
+      - name: Checkout
+        uses: actions/checkout@v6
+        with:
+          submodules: recursive
+
+      - name: Build
+        run: cargo build --release --locked --target x86_64-apple-darwin
+
+      - name: Check binary
+        run: |
+          file target/x86_64-apple-darwin/release/grin-wallet
+          target/x86_64-apple-darwin/release/grin-wallet --version
+
+      - name: Smoke test
+        run: sh .github/scripts/smoke.sh "$PWD/target/x86_64-apple-darwin/release/grin-wallet"
+
+      - name: Archive
+        working-directory: target/x86_64-apple-darwin/release
+        run: tar -czf "grin-wallet-${BUILD_LABEL}-macos-x86_64.tar.gz" grin-wallet
+
+      - name: Create checksum
+        working-directory: target/x86_64-apple-darwin/release
+        run: openssl sha256 "grin-wallet-${BUILD_LABEL}-macos-x86_64.tar.gz" > "grin-wallet-${BUILD_LABEL}-macos-x86_64-sha256sum.txt"
+
+      - name: Upload artifact
+        uses: actions/upload-artifact@v6
+        with:
+          name: macos-x86_64
+          path: |
+            target/x86_64-apple-darwin/release/grin-wallet-${{ env.BUILD_LABEL }}-macos-x86_64.tar.gz
+            target/x86_64-apple-darwin/release/grin-wallet-${{ env.BUILD_LABEL }}-macos-x86_64-sha256sum.txt
+          if-no-files-found: error
+          retention-days: 14
+
+  macos-release-arm64:
+    name: macOS Release - arm64
+    runs-on: macos-latest
+    steps:
+      - name: Install Rust target
+        run: rustup target add aarch64-apple-darwin
+
+      - name: Checkout
+        uses: actions/checkout@v6
+        with:
+          submodules: recursive
+
+      - name: Build
+        run: cargo build --release --locked --target aarch64-apple-darwin
+
+      - name: Check binary
+        run: |
+          file target/aarch64-apple-darwin/release/grin-wallet
+          target/aarch64-apple-darwin/release/grin-wallet --version
+
+      - name: Smoke test
+        run: sh .github/scripts/smoke.sh "$PWD/target/aarch64-apple-darwin/release/grin-wallet"
+
+      - name: Archive
+        working-directory: target/aarch64-apple-darwin/release
+        run: tar -czf "grin-wallet-${BUILD_LABEL}-macos-arm64.tar.gz" grin-wallet
+
+      - name: Create checksum
+        working-directory: target/aarch64-apple-darwin/release
+        run: openssl sha256 "grin-wallet-${BUILD_LABEL}-macos-arm64.tar.gz" > "grin-wallet-${BUILD_LABEL}-macos-arm64-sha256sum.txt"
+
+      - name: Upload artifact
+        uses: actions/upload-artifact@v6
+        with:
+          name: macos-arm64
+          path: |
+            target/aarch64-apple-darwin/release/grin-wallet-${{ env.BUILD_LABEL }}-macos-arm64.tar.gz
+            target/aarch64-apple-darwin/release/grin-wallet-${{ env.BUILD_LABEL }}-macos-arm64-sha256sum.txt
+          if-no-files-found: error
+          retention-days: 14
+
+  windows-release:
+    name: Windows Release
+    runs-on: windows-2022
+    env:
+      ROARING_ARCH: x86-64-v2
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v6
+        with:
+          submodules: recursive
+
+      - name: Build
+        run: cargo build --release --locked
+
+      - name: Check binary
+        shell: pwsh
+        run: |
+          Get-Item target/release/grin-wallet.exe
+          target/release/grin-wallet.exe --version
+
+      - name: Smoke test
+        shell: bash
+        run: sh .github/scripts/smoke.sh "$PWD/target/release/grin-wallet.exe"
+
+      - name: Archive
+        working-directory: target/release
+        shell: pwsh
+        run: Compress-Archive -Path grin-wallet.exe -DestinationPath "grin-wallet-${env:BUILD_LABEL}-win-x86_64.zip"
+
+      - name: Create checksum
+        working-directory: target/release
+        shell: pwsh
+        run: Get-FileHash -Algorithm SHA256 "grin-wallet-${env:BUILD_LABEL}-win-x86_64.zip" | Format-List | Out-String | ForEach-Object { $_.Trim() } > "grin-wallet-${env:BUILD_LABEL}-win-x86_64-sha256sum.txt"
+
+      - name: Upload artifact
+        uses: actions/upload-artifact@v6
+        with:
+          name: windows-x86_64
+          path: |
+            target/release/grin-wallet-${{ env.BUILD_LABEL }}-win-x86_64.zip
+            target/release/grin-wallet-${{ env.BUILD_LABEL }}-win-x86_64-sha256sum.txt
+          if-no-files-found: error
+          retention-days: 14
+
+  docker:
+    name: Docker
+    uses: ./.github/workflows/publish-ghcr.yaml
+    permissions:
+      contents: read
+      packages: write
+
+  snap:
+    name: Snap
+    uses: ./.github/workflows/snap.yaml
+    secrets: inherit
+    with:
+      build_label: *build-label
+
+  release:
+    name: Publish release
+    if: startsWith(github.ref, 'refs/tags/v')
+    needs:
+      - linux-release
+      - linux-musl
+      - bsd
+      - macos-release-x86
+      - macos-release-arm64
+      - windows-release
+      - docker
+      - snap
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+    steps:
+      - name: Download artifacts
+        uses: actions/download-artifact@v7
+        with:
+          path: release
+          pattern: "!digests-*"
+          merge-multiple: true
+
+      - name: Publish release
+        uses: softprops/action-gh-release@v3
+        with:
+          generate_release_notes: true
+          prerelease: ${{ contains(github.ref_name, '-') }}
+          files: release/*
+
+  telegram-notify:
+    name: Telegram Notification
+    if: always()
+    needs:
+      - linux-release
+      - linux-musl
+      - bsd
+      - macos-release-x86
+      - macos-release-arm64
+      - windows-release
+      - docker
+      - snap
+      - release
+    uses: ./.github/workflows/telegram.yaml
+    secrets: inherit
+    with:
+      title: Grin Wallet CD
+      status: ${{ contains(join(needs.*.result, ','), 'failure') && 'failed' || contains(join(needs.*.result, ','), 'cancelled') && 'cancelled' || 'success' }}
+      details: |
+        <b>Linux:</b> ${{ needs['linux-release'].result }}
+        <b>musl:</b> ${{ needs['linux-musl'].result }}
+        <b>BSD:</b> ${{ needs.bsd.result }}
+        <b>macOS x86:</b> ${{ needs['macos-release-x86'].result }}
+        <b>macOS arm64:</b> ${{ needs['macos-release-arm64'].result }}
+        <b>Windows:</b> ${{ needs['windows-release'].result }}
+        <b>Docker:</b> ${{ needs.docker.result }}
+        <b>Snap:</b> ${{ needs.snap.result }}
+        <b>Release:</b> ${{ needs.release.result }}
+      image_tag: ${{ needs.docker.outputs.image_tag }}
+      artifact_url: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
+      commit_message: ${{ github.event.head_commit.message }}

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -5,16 +5,38 @@ jobs:
   linux-tests:
     name: Linux Tests
     runs-on: ubuntu-latest
-    strategy:
-      matrix:
-        job_args: [api, config, controller, impls, libwallet, .]
     steps:
       - uses: actions/checkout@v6
         with:
           submodules: recursive
-      - name: Test ${{ matrix.job_args }}
-        working-directory: ${{ matrix.job_args }}
-        run: cargo test --release
+      - name: Tests
+        run: cargo test --release --all --locked
+
+  musl-tests:
+    name: Linux musl ${{ matrix.arch }} Tests
+    runs-on: ${{ matrix.runner }}
+    container:
+      image: ${{ matrix.image }}
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - arch: x86_64
+            runner: ubuntu-24.04
+            target: x86_64-unknown-linux-musl
+            image: messense/rust-musl-cross:x86_64-musl@sha256:ce75e9174325d4fbb3de85c309e2d7ca29f7500169bc4b5d2c611ff7e86d549a
+          - arch: arm64
+            runner: ubuntu-24.04-arm
+            target: aarch64-unknown-linux-musl
+            image: messense/rust-musl-cross:aarch64-musl@sha256:ecae5dd62d1c938c14f8071d36c16fa699860aace03bfb5284fb1216474d2643
+    steps:
+      - uses: actions/checkout@v6
+        with:
+          submodules: recursive
+      - name: Tests
+        env:
+          OPENSSL_STATIC: "1"
+        run: cargo test --release --all --locked --target ${{ matrix.target }}
 
   macos-tests:
     name: macOS Tests
@@ -25,15 +47,89 @@ jobs:
         with:
           submodules: recursive
       - name: Tests
-        run: cargo test --release --all
+        run: cargo test --release --all --locked
 
   windows-tests:
     name: Windows Tests
-    runs-on: windows-latest
+    runs-on: windows-2022
+    env:
+      ROARING_ARCH: x86-64-v2
     steps:
       - name: Checkout
         uses: actions/checkout@v6
         with:
           submodules: recursive
       - name: Tests
-        run: cargo test --release --all
+        run: cargo test --release --all --locked
+
+  bsd-tests:
+    name: ${{ matrix.name }} Tests
+    runs-on: ubuntu-24.04
+    timeout-minutes: 120
+    defaults:
+      run:
+        shell: cpa.sh {0} --sync-files runner-to-vm
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - name: OpenBSD
+            os: openbsd
+            version: "7.9"
+            install: sudo pkg_add rust git cmake pkgconf gmake curl
+          - name: FreeBSD
+            os: freebsd
+            version: "14.4"
+            install: sudo pkg install -y rust git cmake pkgconf gmake curl perl5
+    steps:
+      - uses: actions/checkout@v6
+        with:
+          submodules: recursive
+
+      - name: Start ${{ matrix.name }}
+        uses: cross-platform-actions/action@v1.3.0
+        with:
+          operating_system: ${{ matrix.os }}
+          architecture: x86-64
+          version: ${{ matrix.version }}
+          memory: 8G
+          cpu_count: 4
+
+      - name: Install dependencies
+        run: ${{ matrix.install }}
+
+      - name: Raise SysV semaphore limits
+        if: matrix.os == 'openbsd'
+        run: |
+          # LMDB environments created by separate doctest processes accumulate during the run.
+          sudo sysctl kern.seminfo.semmni=256
+          sudo sysctl kern.seminfo.semmns=512
+          sudo sysctl kern.seminfo.semmnu=256
+
+      - name: Build tests
+        if: matrix.os == 'openbsd'
+        run: cargo test --release --all --locked --no-run
+
+      - name: Clear Cargo cache
+        if: matrix.os == 'openbsd'
+        run: rm -rf /home/runner/.cargo/registry/cache
+
+      - name: Tests
+        run: cargo test --release --all --locked
+
+  telegram-notify:
+    name: Telegram Notification
+    needs: [linux-tests, musl-tests, macos-tests, windows-tests, bsd-tests]
+    if: always() && github.event_name == 'push'
+    uses: ./.github/workflows/telegram.yaml
+    secrets: inherit
+    with:
+      title: Grin Wallet CI
+      status: ${{ contains(join(needs.*.result, ','), 'failure') && 'failed' || contains(join(needs.*.result, ','), 'cancelled') && 'cancelled' || 'success' }}
+      details: |
+        <b>Linux:</b> ${{ needs.linux-tests.result }}
+        <b>musl:</b> ${{ needs.musl-tests.result }}
+        <b>macOS:</b> ${{ needs.macos-tests.result }}
+        <b>Windows:</b> ${{ needs.windows-tests.result }}
+        <b>BSD:</b> ${{ needs.bsd-tests.result }}
+      commit_message: ${{ github.event.head_commit.message }}

--- a/.github/workflows/publish-ghcr.yaml
+++ b/.github/workflows/publish-ghcr.yaml
@@ -1,0 +1,150 @@
+name: Build and Push to GHCR
+
+on:
+  workflow_call:
+    outputs:
+      image_tag:
+        description: Published image tag
+        value: ${{ jobs.merge.outputs.image_tag }}
+
+env:
+  GHCR_IMAGE: ghcr.io/${{ github.repository_owner }}/${{ github.event.repository.name }}
+  DOCKER_BUILD_RECORD_UPLOAD: false
+
+permissions:
+  contents: read
+  packages: write
+
+jobs:
+  build:
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - platform: linux/amd64
+            runner: ubuntu-latest
+          - platform: linux/arm64
+            runner: ubuntu-24.04-arm
+    runs-on: ${{ matrix.runner }}
+    name: Build Docker image for ${{ matrix.platform }}
+    steps:
+      - name: Prepare
+        run: |
+          platform=${{ matrix.platform }}
+          echo "PLATFORM_PAIR=${platform//\//-}" >> "$GITHUB_ENV"
+
+      - name: Docker meta
+        id: meta
+        uses: docker/metadata-action@v6
+        with:
+          images: ${{ env.GHCR_IMAGE }}
+
+      - name: Log in to GHCR
+        uses: docker/login-action@v4
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ github.token }}
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v4
+
+      - name: Build and push by digest
+        id: build
+        uses: docker/build-push-action@v7
+        with:
+          build-args: BUILDKIT_CONTEXT_KEEP_GIT_DIR=1
+          provenance: false
+          sbom: false
+          platforms: ${{ matrix.platform }}
+          labels: ${{ steps.meta.outputs.labels }}
+          annotations: ${{ steps.meta.outputs.annotations }}
+          tags: ${{ env.GHCR_IMAGE }}
+          cache-from: type=gha,scope=${{ env.PLATFORM_PAIR }}
+          cache-to: type=gha,mode=max,scope=${{ env.PLATFORM_PAIR }}
+          outputs: type=image,push-by-digest=true,name-canonical=true,push=true
+
+      - name: Export digest
+        run: |
+          mkdir -p ${{ runner.temp }}/digests
+          digest="${{ steps.build.outputs.digest }}"
+          touch "${{ runner.temp }}/digests/${digest#sha256:}"
+
+      - name: Upload digest
+        uses: actions/upload-artifact@v6
+        with:
+          name: digests-${{ env.PLATFORM_PAIR }}
+          path: ${{ runner.temp }}/digests/*
+          if-no-files-found: error
+          retention-days: 1
+
+  merge:
+    name: Merge Docker manifests
+    runs-on: ubuntu-latest
+    needs: build
+    outputs:
+      image_tag: ${{ steps.vars.outputs.tag || steps.vars.outputs.version }}
+    steps:
+      - name: Download digests
+        uses: actions/download-artifact@v7
+        with:
+          path: ${{ runner.temp }}/digests
+          pattern: digests-*
+          merge-multiple: true
+
+      - name: Log in to GHCR
+        uses: docker/login-action@v4
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ github.token }}
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v4
+
+      - name: Checkout
+        uses: actions/checkout@v6
+        with:
+          submodules: recursive
+
+      - name: Generate image tag
+        id: vars
+        run: |
+          version=$(awk -F'"' '/^version/{ print $2; exit; }' Cargo.toml)
+          if [[ "$GITHUB_REF" == refs/tags/v* ]]; then
+            echo "version=${GITHUB_REF_NAME#v}" >> "$GITHUB_OUTPUT"
+            if [[ "$GITHUB_REF_NAME" != *-* ]]; then
+              echo "tag=latest" >> "$GITHUB_OUTPUT"
+            else
+              echo "tag=" >> "$GITHUB_OUTPUT"
+            fi
+          elif [ "$GITHUB_REF_NAME" = master ]; then
+            echo "version=latest" >> "$GITHUB_OUTPUT"
+            echo "tag=" >> "$GITHUB_OUTPUT"
+          elif [ "$GITHUB_REF_NAME" = staging ]; then
+            echo "version=${version}-staging" >> "$GITHUB_OUTPUT"
+            echo "tag=staging" >> "$GITHUB_OUTPUT"
+          else
+            tag=${GITHUB_REF_NAME//\//-}
+            echo "version=${version}-${tag}" >> "$GITHUB_OUTPUT"
+            echo "tag=$tag" >> "$GITHUB_OUTPUT"
+          fi
+
+      - name: Docker meta
+        id: meta
+        uses: docker/metadata-action@v6
+        with:
+          images: ${{ env.GHCR_IMAGE }}
+          tags: |
+            type=raw,value=${{ steps.vars.outputs.version }},enable=true
+            type=raw,value=${{ steps.vars.outputs.tag }},enable=${{ steps.vars.outputs.tag != '' }}
+
+      - name: Create manifest list and push
+        working-directory: ${{ runner.temp }}/digests
+        run: |
+          # shellcheck disable=SC2046
+          docker buildx imagetools create $(jq -cr '.tags | map("-t " + .) | join(" ")' <<< "$DOCKER_METADATA_OUTPUT_JSON") \
+          $(printf '${{ env.GHCR_IMAGE }}@sha256:%s ' *)
+
+      - name: Inspect image
+        run: docker buildx imagetools inspect ${{ env.GHCR_IMAGE }}:${{ steps.vars.outputs.version }}

--- a/.github/workflows/snap.yaml
+++ b/.github/workflows/snap.yaml
@@ -1,0 +1,65 @@
+name: Snap Package
+
+on:
+  workflow_call:
+    inputs:
+      build_label:
+        required: true
+        type: string
+
+permissions:
+  contents: read
+
+env:
+  BUILD_LABEL: ${{ inputs.build_label }}
+
+jobs:
+  build-snap:
+    name: Snap ${{ matrix.arch }}
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - arch: x86_64
+            runner: ubuntu-latest
+          - arch: arm64
+            runner: ubuntu-24.04-arm
+    runs-on: ${{ matrix.runner }}
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v6
+        with:
+          submodules: recursive
+
+      - name: Prepare snapcraft project
+        run: |
+          grade=devel
+          if [ "$GITHUB_REF_NAME" = master ]; then
+            grade=stable
+          elif [[ "$GITHUB_REF" == refs/tags/v* && "$GITHUB_REF_NAME" != *-* ]]; then
+            grade=stable
+          fi
+          mkdir -p snap
+          sed "s/SNAP_GRADE/$grade/" .packaging/snaps/snapcraft.yaml > snap/snapcraft.yaml
+
+      - name: Build snap package
+        uses: snapcore/action-build@v1
+        with:
+          path: .
+
+      - name: Prepare artifact
+        run: |
+          snap=$(find . -maxdepth 1 -name "*.snap" -print -quit)
+          asset=grin-wallet-${BUILD_LABEL}-linux-${{ matrix.arch }}.snap
+          mv "$snap" "$asset"
+          openssl sha256 "$asset" > "${asset}-sha256sum.txt"
+
+      - name: Upload artifact
+        uses: actions/upload-artifact@v6
+        with:
+          name: snap-${{ matrix.arch }}
+          path: |
+            grin-wallet-${{ env.BUILD_LABEL }}-linux-${{ matrix.arch }}.snap
+            grin-wallet-${{ env.BUILD_LABEL }}-linux-${{ matrix.arch }}.snap-sha256sum.txt
+          if-no-files-found: error
+          retention-days: 14

--- a/.github/workflows/telegram.yaml
+++ b/.github/workflows/telegram.yaml
@@ -1,0 +1,178 @@
+name: Telegram Events
+
+on:
+  workflow_call:
+    inputs:
+      title:
+        required: true
+        type: string
+      status:
+        required: true
+        type: string
+      details:
+        required: false
+        type: string
+        default: ""
+      image:
+        required: false
+        type: string
+        default: ""
+      image_tag:
+        required: false
+        type: string
+        default: ""
+      artifact_url:
+        required: false
+        type: string
+        default: ""
+      commit_message:
+        required: false
+        type: string
+        default: ""
+    secrets:
+      TELEGRAM_BOT_TOKEN:
+        required: false
+      TELEGRAM_CHAT_ID:
+        required: false
+      TELEGRAM_MESSAGE_THREAD_ID:
+        required: false
+      GHCR_USERNAME:
+        required: false
+  pull_request_target:
+    types: [opened, reopened, ready_for_review, closed]
+    branches: [master, staging]
+  issues:
+    types: [opened, reopened]
+
+permissions:
+  contents: read
+
+jobs:
+  telegram-notify:
+    name: Telegram Notification
+    runs-on: ubuntu-latest
+    env:
+      TELEGRAM_BOT_TOKEN: ${{ secrets.TELEGRAM_BOT_TOKEN }}
+      TELEGRAM_CHAT_ID: ${{ secrets.TELEGRAM_CHAT_ID }}
+      TELEGRAM_MESSAGE_THREAD_ID: ${{ secrets.TELEGRAM_MESSAGE_THREAD_ID }}
+      GHCR_USERNAME: ${{ secrets.GHCR_USERNAME }}
+    steps:
+      - name: Send Telegram message
+        if: ${{ env.TELEGRAM_BOT_TOKEN != '' && env.TELEGRAM_CHAT_ID != '' }}
+        env:
+          EVENT_NAME: ${{ github.event_name }}
+          ACTION_NAME: ${{ github.event.action }}
+          ACTOR: ${{ github.actor }}
+          REF_NAME: ${{ github.ref_name }}
+          REPOSITORY: ${{ github.repository }}
+          PR_TITLE: ${{ github.event.pull_request.title }}
+          PR_NUMBER: ${{ github.event.pull_request.number }}
+          PR_URL: ${{ github.event.pull_request.html_url }}
+          PR_MERGED: ${{ github.event.pull_request.merged }}
+          ISSUE_TITLE: ${{ github.event.issue.title }}
+          ISSUE_NUMBER: ${{ github.event.issue.number }}
+          ISSUE_URL: ${{ github.event.issue.html_url }}
+          NOTIFY_TITLE: ${{ inputs.title }}
+          NOTIFY_STATUS: ${{ inputs.status }}
+          NOTIFY_DETAILS: ${{ inputs.details }}
+          NOTIFY_IMAGE: ${{ inputs.image }}
+          NOTIFY_IMAGE_TAG: ${{ inputs.image_tag }}
+          NOTIFY_ARTIFACT_URL: ${{ inputs.artifact_url }}
+          NOTIFY_COMMIT_MESSAGE: ${{ inputs.commit_message }}
+          RUN_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
+          COMMIT_URL: ${{ github.server_url }}/${{ github.repository }}/commit/${{ github.sha }}
+        run: |
+          telegram_api_url="https://api.telegram.org/bot${TELEGRAM_BOT_TOKEN}/sendMessage"
+          echo "::add-mask::$TELEGRAM_BOT_TOKEN"
+          echo "::add-mask::$telegram_api_url"
+
+          html_escape() {
+            printf "%s" "$1" | sed \
+              -e "s/&/\&amp;/g" \
+              -e "s/</\&lt;/g" \
+              -e "s/>/\&gt;/g"
+          }
+
+          if [ -n "$NOTIFY_TITLE" ]; then
+            actor=$(html_escape "$ACTOR")
+            commit_message=$(html_escape "$NOTIFY_COMMIT_MESSAGE")
+            ref_name=$(html_escape "$REF_NAME")
+            text=$(printf "<b>%s</b>\n<b>Build %s</b>" "$NOTIFY_TITLE" "$NOTIFY_STATUS")
+
+            if [ -n "$NOTIFY_DETAILS" ]; then
+              text=$(printf "%s\n\n%s" "$text" "$NOTIFY_DETAILS")
+            fi
+
+            text=$(printf "%s\n\n<b>Actor:</b> %s\n<b>Repository:</b> %s\n<b>Branch:</b> %s" \
+              "$text" \
+              "$actor" \
+              "$REPOSITORY" \
+              "$ref_name")
+
+            if [ -n "$NOTIFY_IMAGE" ]; then
+              text=$(printf "%s\n<b>Image:</b> %s" "$text" "$NOTIFY_IMAGE")
+            elif [ -n "$NOTIFY_IMAGE_TAG" ]; then
+              image_owner="${GHCR_USERNAME:-${REPOSITORY%%/*}}"
+              image_name="${REPOSITORY#*/}"
+              text=$(printf "%s\n<b>Image:</b> ghcr.io/%s/%s:%s" "$text" "$image_owner" "$image_name" "$NOTIFY_IMAGE_TAG")
+            fi
+
+            text=$(printf "%s\n<b>Commit:</b> <a href=\"%s\">%s</a>" \
+              "$text" \
+              "$COMMIT_URL" \
+              "${GITHUB_SHA::7}")
+
+            if [ -n "$commit_message" ]; then
+              text=$(printf "%s\n%s" "$text" "$commit_message")
+            fi
+
+            if [ -n "$NOTIFY_ARTIFACT_URL" ]; then
+              text=$(printf "%s\n\n<a href=\"%s\">Download artifacts</a>" "$text" "$NOTIFY_ARTIFACT_URL")
+            else
+              text=$(printf "%s\n\n<a href=\"%s\">View workflow run</a>" "$text" "$RUN_URL")
+            fi
+          elif [ "$EVENT_NAME" = "pull_request_target" ]; then
+            title=$(html_escape "$PR_TITLE")
+            pr_status="$ACTION_NAME"
+            if [ "$ACTION_NAME" = "closed" ] && [ "$PR_MERGED" = "true" ]; then
+              pr_status="merged"
+            fi
+            text=$(printf "<b>Grin Wallet pull request</b>\n<b>Status:</b> %s\n\n<b>Repository:</b> %s\n<b>PR:</b> <a href=\"%s\">#%s %s</a>" \
+              "$pr_status" \
+              "$REPOSITORY" \
+              "$PR_URL" \
+              "$PR_NUMBER" \
+              "$title")
+          else
+            title=$(html_escape "$ISSUE_TITLE")
+            text=$(printf "<b>Grin Wallet issue</b>\n<b>Status:</b> %s\n\n<b>Repository:</b> %s\n<b>Issue:</b> <a href=\"%s\">#%s %s</a>" \
+              "$ACTION_NAME" \
+              "$REPOSITORY" \
+              "$ISSUE_URL" \
+              "$ISSUE_NUMBER" \
+              "$title")
+          fi
+
+          payload=$(jq -n \
+            --arg chat_id "$TELEGRAM_CHAT_ID" \
+            --arg text "$text" \
+            '{chat_id: $chat_id, text: $text, parse_mode: "HTML", disable_web_page_preview: true}')
+
+          if [ -n "$TELEGRAM_MESSAGE_THREAD_ID" ]; then
+            payload=$(jq --argjson message_thread_id "$TELEGRAM_MESSAGE_THREAD_ID" \
+              '. + {message_thread_id: $message_thread_id}' <<< "$payload")
+          fi
+
+          response_file=$(mktemp)
+          http_code=$(curl -sS \
+            -o "$response_file" \
+            -w "%{http_code}" \
+            -H "Content-Type: application/json" \
+            -d "$payload" \
+            "$telegram_api_url")
+
+          if [ "$http_code" -lt 200 ] || [ "$http_code" -ge 300 ]; then
+            description=$(jq -r '.description // "unknown error"' "$response_file")
+            echo "Telegram notification failed with HTTP $http_code: $description"
+            exit 1
+          fi

--- a/.packaging/snaps/snapcraft.yaml
+++ b/.packaging/snaps/snapcraft.yaml
@@ -1,0 +1,41 @@
+name: grin-wallet
+adopt-info: grin-wallet
+summary: Command line wallet for Grin
+description: |
+  https://grin.mw/
+
+confinement: strict
+grade: SNAP_GRADE
+base: core22
+architectures:
+  - build-on: [arm64]
+    build-for: [arm64]
+  - build-on: [amd64]
+    build-for: [amd64]
+
+parts:
+  grin-wallet:
+    plugin: rust
+    source: .
+    override-pull: |
+      craftctl default
+      craftctl set version="$(sed -n 's/^version = "\(.*\)"/\1/p' Cargo.toml | head -n 1)"
+    build-packages:
+      - build-essential
+      - clang
+      - cmake
+      - git
+      - libncurses5-dev
+      - libncursesw5-dev
+      - libssl-dev
+      - llvm
+      - pkg-config
+      - zlib1g-dev
+
+apps:
+  grin-wallet:
+    environment:
+      LC_ALL: C.UTF-8
+      LANG: C.UTF-8
+    command: bin/grin-wallet
+    plugs: [home, network, network-bind]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2222,7 +2222,7 @@ checksum = "9985c9503b412198aa4197559e9a318524ebc4519c229bfa05a535828c950b9d"
 
 [[package]]
 name = "grin_api"
-version = "5.5.1"
+version = "5.5.1-alpha.0"
 dependencies = [
  "bytes 1.12.0",
  "easy-jsonrpc-mw",
@@ -2254,7 +2254,7 @@ dependencies = [
 
 [[package]]
 name = "grin_chain"
-version = "5.5.1"
+version = "5.5.1-alpha.0"
 dependencies = [
  "bit-vec",
  "bitflags 1.3.2",
@@ -2278,7 +2278,7 @@ dependencies = [
 
 [[package]]
 name = "grin_core"
-version = "5.5.1"
+version = "5.5.1-alpha.0"
 dependencies = [
  "blake2-rfc",
  "byteorder",
@@ -2304,7 +2304,7 @@ dependencies = [
 
 [[package]]
 name = "grin_keychain"
-version = "5.5.1"
+version = "5.5.1-alpha.0"
 dependencies = [
  "blake2-rfc",
  "byteorder",
@@ -2325,7 +2325,7 @@ dependencies = [
 
 [[package]]
 name = "grin_p2p"
-version = "5.5.1"
+version = "5.5.1-alpha.0"
 dependencies = [
  "bitflags 1.3.2",
  "built",
@@ -2348,7 +2348,7 @@ dependencies = [
 
 [[package]]
 name = "grin_pool"
-version = "5.5.1"
+version = "5.5.1-alpha.0"
 dependencies = [
  "blake2-rfc",
  "chrono",
@@ -2380,7 +2380,7 @@ dependencies = [
 
 [[package]]
 name = "grin_store"
-version = "5.5.1"
+version = "5.5.1-alpha.0"
 dependencies = [
  "byteorder",
  "chrono",
@@ -2402,7 +2402,7 @@ dependencies = [
 
 [[package]]
 name = "grin_util"
-version = "5.5.1"
+version = "5.5.1-alpha.0"
 dependencies = [
  "anyhow",
  "backtrace",
@@ -3530,8 +3530,7 @@ checksum = "92daf443525c4cce67b150400bc2316076100ce0b3686209eb8cf3c31612e6f0"
 [[package]]
 name = "lmdb-master-sys"
 version = "0.2.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "aaeb9bd22e73bd1babffff614994b341e9b2008de7bb73bf1f7e9154f1978f8b"
+source = "git+https://github.com/wiesche89/heed?rev=4c7252128a58819406f2978adfc8d41365e7f77a#4c7252128a58819406f2978adfc8d41365e7f77a"
 dependencies = [
  "cc",
  "doxygen-rs",
@@ -3636,15 +3635,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "memoffset"
-version = "0.6.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5aa361d4faea93603064a027415f07bd8e1d5c88c9fbf68bf56a285428fd79ce"
-dependencies = [
- "autocfg 1.5.1",
-]
-
-[[package]]
 name = "merlin"
 version = "3.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3740,15 +3730,14 @@ dependencies = [
 
 [[package]]
 name = "nix"
-version = "0.23.2"
+version = "0.25.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8f3790c00a0150112de0f4cd161e3d7fc4b2d8a5542ffc35f099a2562aecb35c"
+checksum = "f346ff70e7dbfd675fe90590b92d59ef2de15a8779ae305ebcbfd3f0caf59be4"
 dependencies = [
+ "autocfg 1.5.1",
  "bitflags 1.3.2",
- "cc",
  "cfg-if 1.0.4",
  "libc",
- "memoffset",
 ]
 
 [[package]]
@@ -5313,9 +5302,9 @@ checksum = "b39cdef0fa800fc44525c84ccb54a029961a8215f9619753635a9c0d2538d46d"
 
 [[package]]
 name = "rustyline"
-version = "9.1.2"
+version = "10.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "db7826789c0e25614b03e5a54a0717a86f9ff6e6e5247f92b369472869320039"
+checksum = "c1e83c32c3f3c33b08496e0d1df9ea8c64d39adb8eb36a1ebb1440c690697aef"
 dependencies = [
  "bitflags 1.3.2",
  "cfg-if 1.0.4",
@@ -5325,10 +5314,9 @@ dependencies = [
  "libc",
  "log",
  "memchr",
- "nix 0.23.2",
+ "nix 0.25.1",
  "radix_trie",
  "scopeguard",
- "smallvec",
  "unicode-segmentation",
  "unicode-width",
  "utf8parse",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -26,7 +26,7 @@ thiserror = "1"
 log = "0.4"
 linefeed = "0.6"
 semver = "1.0.28"
-rustyline = "9"
+rustyline = "10"
 lazy_static = "1"
 
 grin_wallet_api = { path = "./api", version = "5.5.0" }
@@ -52,3 +52,6 @@ url = "2.1"
 serde = "1"
 serde_json = "1"
 easy-jsonrpc-mw = "0.5.4"
+
+[patch.crates-io]
+lmdb-master-sys = { git = "https://github.com/wiesche89/heed", rev = "4c7252128a58819406f2978adfc8d41365e7f77a" }

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,29 @@
+FROM rust:slim-trixie AS builder
+
+RUN apt-get update && apt-get install -y --no-install-recommends \
+    build-essential \
+    clang \
+    cmake \
+    libncursesw5-dev \
+    libssl-dev \
+    pkg-config \
+    zlib1g-dev \
+    && rm -rf /var/lib/apt/lists/*
+
+WORKDIR /usr/src/grin-wallet
+COPY . .
+RUN cargo build --release --locked
+
+FROM debian:trixie-slim
+
+RUN apt-get update && apt-get install -y --no-install-recommends \
+    ca-certificates \
+    && rm -rf /var/lib/apt/lists/*
+
+COPY --from=builder /usr/src/grin-wallet/target/release/grin-wallet /usr/local/bin/grin-wallet
+
+WORKDIR /root/.grin
+VOLUME ["/root/.grin"]
+
+ENTRYPOINT ["grin-wallet"]
+CMD ["--help"]

--- a/src/cli/cli.rs
+++ b/src/cli/cli.rs
@@ -30,7 +30,7 @@ use rustyline::error::ReadlineError;
 use rustyline::highlight::{Highlighter, MatchingBracketHighlighter};
 use rustyline::hint::Hinter;
 use rustyline::validate::Validator;
-use rustyline::{CompletionType, Config, Context, EditMode, Editor, Helper, OutputStreamType};
+use rustyline::{CompletionType, Config, Context, EditMode, Editor, Helper};
 use std::borrow::Cow::{self, Borrowed, Owned};
 use std::sync::mpsc::{channel, Receiver};
 use std::sync::Arc;
@@ -124,10 +124,9 @@ where
 		.history_ignore_space(true)
 		.completion_type(CompletionType::List)
 		.edit_mode(EditMode::Emacs)
-		.output_stream(OutputStreamType::Stdout)
 		.build();
 
-	let mut reader = Editor::with_config(editor);
+	let mut reader = Editor::with_config(editor).map_err(|e| Error::GenericError(e.to_string()))?;
 	reader.set_helper(Some(EditorHelper(
 		FilenameCompleter::new(),
 		MatchingBracketHighlighter::new(),

--- a/tests/owner_v3_init_secure.rs
+++ b/tests/owner_v3_init_secure.rs
@@ -116,7 +116,7 @@ fn owner_v3_init_secure() -> Result<(), grin_wallet_controller::Error> {
 
 	// 5) A normal request, incorrect key
 	let mut bad_key = shared_key.clone();
-	bad_key.0[0] = 0;
+	bad_key.0[0] ^= 1;
 	let req = include_str!("data/v3_reqs/retrieve_info.req.json");
 	let res = send_request_enc::<RetrieveSummaryInfoResp>(
 		&JsonId::StrId(String::from("1")),


### PR DESCRIPTION
**Summary**

Adds CI and release builds for OpenBSD, FreeBSD and static musl.

Each native binary is checked and smoke-tested before packaging. Docker and Snap build in parallel, while GitHub releases are only created for version tags.

Adds Telegram notifications for CI, CD, pull requests and issues.

Fixes #790

**OpenBSD note**

OpenBSD needs a small LMDB fix to prevent stale reads.

The issue is tracked in https://github.com/meilisearch/heed/issues/383 and the upstream fix is in https://github.com/meilisearch/lmdb/pull/5. This PR temporarily uses the patched LMDB revision until the fix is available through heed.