### PR TITLE
reject wrong slate states in receive and finalize

### DIFF
--- a/controller/tests/invoice.rs
+++ b/controller/tests/invoice.rs
@@ -124,6 +124,27 @@ fn invoice_tx_impl(test_dir: &'static str) -> Result<(), libwallet::Error> {
 	)?;
 	assert_eq!(slate.state, SlateState::Invoice1);
 
+	let receive_result = wallet::controller::foreign_single_use(
+		wallet1.clone(),
+		PathBuf::from(test_dir),
+		mask1_i.clone(),
+		|api| api.receive_tx(&slate, None, None).map(|_| ()),
+	);
+	assert_eq!(
+		receive_result,
+		Err(libwallet::Error::InvoiceSlateRequiresPay)
+	);
+	wallet::controller::owner_single_use(
+		wallet1.clone(),
+		mask1,
+		PathBuf::from(test_dir),
+		|api, m| {
+			let (_, txs) = api.retrieve_txs(m, false, None, Some(slate.id), None)?;
+			assert!(txs.is_empty());
+			Ok(())
+		},
+	)?;
+
 	wallet::controller::owner_single_use(
 		wallet1.clone(),
 		mask1,

--- a/libwallet/src/api_impl/foreign.rs
+++ b/libwallet/src/api_impl/foreign.rs
@@ -66,6 +66,9 @@ where
 	K: Keychain,
 {
 	let mut ret_slate = slate.clone();
+	if ret_slate.state == SlateState::Invoice1 {
+		return Err(Error::InvoiceSlateRequiresPay);
+	}
 	check_ttl(w, &ret_slate)?;
 	let parent_key_id = match dest_acct_name {
 		Some(d) => {

--- a/libwallet/src/error.rs
+++ b/libwallet/src/error.rs
@@ -217,6 +217,10 @@ pub enum Error {
 	#[error("Invalid slate state")]
 	SlateState,
 
+	/// Invoice passed to receive
+	#[error("Use the 'pay' command to process invoice slates")]
+	InvoiceSlateRequiresPay,
+
 	/// Can't serialize slate pack
 	#[error("Can't Serialize slatepack")]
 	SlatepackSer,


### PR DESCRIPTION
Rejects slates passed to "receive_tx" that are not in state S1. The "receive" and "finalize" commands tell the user which command to use instead, e.g. "pay" for invoice slates.

This prevents receive from converting an invoice slate to S2 and creating an incorrect received transaction and output.

Fixes #439